### PR TITLE
fix: Ownership of scopes and clients object

### DIFF
--- a/apis/components/auth/v1beta1/ownership.go
+++ b/apis/components/auth/v1beta1/ownership.go
@@ -1,0 +1,21 @@
+package v1beta1
+
+import (
+	"fmt"
+	"reflect"
+
+	. "github.com/numary/formance-operator/internal/collectionutil"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func authServerChanges(previous, actual client.Object, reference string) bool {
+	expectedOwnerRef := fmt.Sprintf("%s-%s", actual.GetNamespace(), reference)
+	ownerFromSource := First(previous.GetOwnerReferences(), func(ref metav1.OwnerReference) bool {
+		return ref.Name == expectedOwnerRef
+	})
+	ownerFromActual := First(actual.GetOwnerReferences(), func(ref metav1.OwnerReference) bool {
+		return ref.Name == expectedOwnerRef
+	})
+	return !reflect.DeepEqual(ownerFromSource, ownerFromActual)
+}

--- a/apis/components/benthos/v1beta1/server_types.go
+++ b/apis/components/benthos/v1beta1/server_types.go
@@ -35,6 +35,14 @@ type ServerStatus struct {
 	PodIP  string `json:"podIP,omitempty"`
 }
 
+func (in *ServerStatus) IsDirty(t Object) bool {
+	if in.Status.IsDirty(t) {
+		return true
+	}
+	server := t.(*Server)
+	return in.PodIP != server.Status.PodIP
+}
+
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
 
@@ -47,12 +55,12 @@ type Server struct {
 	Status ServerStatus `json:"status,omitempty"`
 }
 
+func (in *Server) GetStatus() Dirty {
+	return &in.Status
+}
+
 func (in *Server) IsDirty(t Object) bool {
-	if in.Status.IsDirty(t) {
-		return true
-	}
-	server := t.(*Server)
-	return in.Status.PodIP != server.Status.PodIP
+	return false
 }
 
 func (in *Server) GetConditions() *Conditions {

--- a/apis/components/benthos/v1beta1/stream_types.go
+++ b/apis/components/benthos/v1beta1/stream_types.go
@@ -45,8 +45,12 @@ type Stream struct {
 	Status Status     `json:"status,omitempty"`
 }
 
+func (in *Stream) GetStatus() Dirty {
+	return &in.Status
+}
+
 func (in *Stream) IsDirty(t Object) bool {
-	return in.Status.IsDirty(t)
+	return false
 }
 
 func (in *Stream) GetConditions() *Conditions {

--- a/apis/components/v1beta1/auth_types.go
+++ b/apis/components/v1beta1/auth_types.go
@@ -62,8 +62,12 @@ type Auth struct {
 	Status Status   `json:"status,omitempty"`
 }
 
+func (a *Auth) GetStatus() Dirty {
+	return &a.Status
+}
+
 func (a *Auth) IsDirty(t Object) bool {
-	return a.Status.IsDirty(t)
+	return false
 }
 
 func (a *Auth) GetConditions() *Conditions {

--- a/apis/components/v1beta1/control_types.go
+++ b/apis/components/v1beta1/control_types.go
@@ -44,8 +44,12 @@ type Control struct {
 	Status Status      `json:"status,omitempty"`
 }
 
+func (in *Control) GetStatus() Dirty {
+	return &in.Status
+}
+
 func (in *Control) IsDirty(t Object) bool {
-	return in.Status.IsDirty(t)
+	return false
 }
 
 func (in *Control) GetConditions() *Conditions {

--- a/apis/components/v1beta1/ledger_types.go
+++ b/apis/components/v1beta1/ledger_types.go
@@ -75,8 +75,12 @@ type Ledger struct {
 	Status Status     `json:"status,omitempty"`
 }
 
+func (a *Ledger) GetStatus() Dirty {
+	return &a.Status
+}
+
 func (a *Ledger) IsDirty(t Object) bool {
-	return a.Status.IsDirty(t)
+	return false
 }
 
 func (a *Ledger) GetConditions() *Conditions {

--- a/apis/components/v1beta1/payments_types.go
+++ b/apis/components/v1beta1/payments_types.go
@@ -80,12 +80,16 @@ type Payments struct {
 	Status Status       `json:"status,omitempty"`
 }
 
+func (in *Payments) GetStatus() Dirty {
+	return &in.Status
+}
+
 func (in *Payments) GetConditions() *Conditions {
 	return &in.Status.Conditions
 }
 
 func (in *Payments) IsDirty(t Object) bool {
-	return in.Status.IsDirty(t)
+	return false
 }
 
 //+kubebuilder:object:root=true

--- a/apis/components/v1beta1/search_types.go
+++ b/apis/components/v1beta1/search_types.go
@@ -77,8 +77,12 @@ type Search struct {
 	Status Status     `json:"status,omitempty"`
 }
 
+func (in *Search) GetStatus() Dirty {
+	return &in.Status
+}
+
 func (in *Search) IsDirty(t Object) bool {
-	return in.Status.IsDirty(t)
+	return false
 }
 
 func (in *Search) GetConditions() *Conditions {

--- a/apis/components/v1beta1/searchingester_types.go
+++ b/apis/components/v1beta1/searchingester_types.go
@@ -47,8 +47,12 @@ type SearchIngester struct {
 	Status Status             `json:"status,omitempty"`
 }
 
+func (in *SearchIngester) GetStatus() Dirty {
+	return &in.Status
+}
+
 func (in *SearchIngester) IsDirty(t Object) bool {
-	return in.Status.IsDirty(t)
+	return false
 }
 
 func (in *SearchIngester) GetConditions() *Conditions {

--- a/apis/sharedtypes/object.go
+++ b/apis/sharedtypes/object.go
@@ -5,8 +5,14 @@ import (
 )
 
 // +kubebuilder:object:generate=false
+type Dirty interface {
+	IsDirty(t Object) bool
+}
+
+// +kubebuilder:object:generate=false
 type Object interface {
 	client.Object
+	Dirty
+	GetStatus() Dirty
 	GetConditions() *Conditions
-	IsDirty(t Object) bool
 }

--- a/apis/stack/v1beta1/stack_types.go
+++ b/apis/stack/v1beta1/stack_types.go
@@ -92,9 +92,12 @@ func (in *Stack) GetScheme() string {
 	}
 	return "https"
 }
+func (in *Stack) GetStatus() Dirty {
+	return &in.Status
+}
 
 func (in *Stack) IsDirty(t Object) bool {
-	return in.Status.IsDirty(t)
+	return false
 }
 
 func (in *Stack) GetConditions() *Conditions {

--- a/controllers/components/auth/clients/client_mutator.go
+++ b/controllers/components/auth/clients/client_mutator.go
@@ -56,6 +56,10 @@ func (r Mutator) Mutate(ctx context.Context, actualK8SClient *authcomponentsv1be
 		return Requeue(), err
 	}
 
+	if err := pkgInternal.DefineOwner(ctx, r.client, r.scheme, actualK8SClient, actualK8SClient.Spec.AuthServerReference); err != nil {
+		return Requeue(), err
+	}
+
 	var (
 		actualAuthServerClient           *authclient.Client
 		err                              error

--- a/controllers/components/auth/internal/ownership.go
+++ b/controllers/components/auth/internal/ownership.go
@@ -1,0 +1,37 @@
+package internal
+
+import (
+	"context"
+
+	"github.com/numary/formance-operator/apis/components/v1beta1"
+	pkgError "github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/pointer"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+func DefineOwner(ctx context.Context, client client.Client, scheme *runtime.Scheme, ob client.Object, reference string) error {
+	auth := &v1beta1.Auth{}
+	if err := client.Get(ctx, types.NamespacedName{
+		Namespace: ob.GetNamespace(),
+		Name:      ob.GetNamespace() + "-" + reference,
+	}, auth); err != nil {
+		return pkgError.Wrap(err, "Retrieving Auth object")
+	}
+
+	if err := controllerutil.SetOwnerReference(auth, ob, scheme); err != nil {
+		return pkgError.Wrap(err, "Setting owner reference to Auth object")
+	}
+
+	references := ob.GetOwnerReferences()
+	for ind, ref := range references {
+		if ref.UID == auth.UID {
+			ref.BlockOwnerDeletion = pointer.Bool(true)
+			references[ind] = ref
+		}
+	}
+	ob.SetOwnerReferences(references)
+	return nil
+}

--- a/controllers/components/auth/scopes/scope_mutator.go
+++ b/controllers/components/auth/scopes/scope_mutator.go
@@ -53,6 +53,10 @@ func (s Mutator) Mutate(ctx context.Context, actualK8SScope *authcomponentsv1bet
 
 	SetProgressing(actualK8SScope)
 
+	if err := pkgInternal.DefineOwner(ctx, s.client, s.scheme, actualK8SScope, actualK8SScope.Spec.AuthServerReference); err != nil {
+		return Requeue(), err
+	}
+
 	var (
 		err                             error
 		actualAuthServerScope           *authclient.Scope

--- a/controllers/components/auth/scopes/scope_mutator_test.go
+++ b/controllers/components/auth/scopes/scope_mutator_test.go
@@ -1,15 +1,19 @@
 package scopes
 
 import (
+	"fmt"
+
 	"github.com/google/uuid"
 	"github.com/numary/auth/authclient"
 	. "github.com/numary/formance-operator/apis/components/auth/v1beta1"
+	"github.com/numary/formance-operator/apis/components/v1beta1"
 	. "github.com/numary/formance-operator/apis/sharedtypes"
 	pkgInternal "github.com/numary/formance-operator/controllers/components/auth/internal"
 	. "github.com/numary/formance-operator/internal/testing"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
 	kClient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -25,8 +29,42 @@ var _ = Describe("Scope reconciler", func() {
 
 	WithMutator(mutator, func() {
 		WithNewNamespace(func() {
+			var (
+				auth                *v1beta1.Auth
+				authServerReference string
+			)
+			BeforeEach(func() {
+				authServerReference = uuid.NewString()
+				auth = &v1beta1.Auth{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: fmt.Sprintf("%s-%s", ActualNamespace().Name, authServerReference),
+					},
+					Spec: v1beta1.AuthSpec{
+						Postgres: v1beta1.PostgresConfigCreateDatabase{
+							PostgresConfigWithDatabase: PostgresConfigWithDatabase{
+								PostgresConfig: PostgresConfig{
+									Port:     8080,
+									Host:     "foo",
+									Username: "xxx",
+									Password: "xxx",
+								},
+								Database: "xxx",
+							},
+						},
+						BaseURL:    "http://localhost:8080",
+						SigningKey: "XXX",
+						DelegatedOIDCServer: v1beta1.DelegatedOIDCServerConfiguration{
+							Issuer:       "http://issuer",
+							ClientID:     "xxx",
+							ClientSecret: "xxx",
+						},
+					},
+				}
+				Expect(Create(auth)).To(BeNil())
+				Eventually(Exists(auth)).Should(BeTrue())
+			})
 			newScope := func(transient ...string) *Scope {
-				return NewScope(uuid.NewString(), uuid.NewString(), transient...)
+				return NewScope(uuid.NewString(), uuid.NewString(), authServerReference, transient...)
 			}
 			When("Creating a new scope object", func() {
 				var firstScope *Scope
@@ -46,6 +84,15 @@ var _ = Describe("Scope reconciler", func() {
 					Expect(firstScope.Status.AuthServerID).NotTo(BeNil())
 					Expect(api.Scope(firstScope.Status.AuthServerID)).NotTo(BeNil())
 					Expect(api.Scope(firstScope.Status.AuthServerID).Label).To(Equal(firstScope.Spec.Label))
+				})
+				It("Should apply correct ownership", func() {
+					Expect(firstScope.GetOwnerReferences()).To(Equal([]metav1.OwnerReference{{
+						APIVersion:         "components.formance.com/v1beta1",
+						Kind:               "Auth",
+						Name:               auth.Name,
+						UID:                auth.UID,
+						BlockOwnerDeletion: pointer.Bool(true),
+					}}))
 				})
 				Context("Then updating with a new label", func() {
 					BeforeEach(func() {
@@ -106,6 +153,5 @@ var _ = Describe("Scope reconciler", func() {
 				})
 			})
 		})
-
 	})
 })

--- a/example.yaml
+++ b/example.yaml
@@ -94,20 +94,23 @@ spec:
           password: admin
     control:
       image: ghcr.io/numary/control:cdbeb8e9bd10d388674da80622a113519f1147ce
-#      ingress:
-#        host: localhost
-#        annotations:
-#          # Force disable global middlewares
-#          traefik.ingress.kubernetes.io/router.middlewares: ""
-
 ---
 apiVersion: auth.components.formance.com/v1beta1
-kind: Client
+kind: Scope
 metadata:
-  name: postman
+  name: scope1
   namespace: stack1
 spec:
-  public: true
+  label: scope1
   authServerReference: auth
-  redirectUris:
-  - https://oauth.pstmn.io/v1/callback
+#---
+#apiVersion: auth.components.formance.com/v1beta1
+#kind: Client
+#metadata:
+#  name: postman
+#  namespace: stack1
+#spec:
+#  public: true
+#  authServerReference: auth
+#  redirectUris:
+#  - https://oauth.pstmn.io/v1/callback

--- a/internal/reconciler.go
+++ b/internal/reconciler.go
@@ -64,10 +64,18 @@ func (r *Reconciler[T]) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 	}
 
 	if updated.IsDirty(actual) {
-		log.FromContext(ctx).Info("Object dirty, updating status")
-		if patchErr := r.Status().Update(ctx, updated); patchErr != nil {
-			log.FromContext(ctx).Error(patchErr, "Updating status")
+		log.FromContext(ctx).Info("Object dirty, updating it")
+		if patchErr := r.Update(ctx, updated); patchErr != nil {
+			log.FromContext(ctx).Error(patchErr, "Updating object")
 			return ctrl.Result{}, patchErr
+		}
+	} else {
+		if updated.GetStatus().IsDirty(actual) {
+			log.FromContext(ctx).Info("Object dirty, updating status")
+			if patchErr := r.Status().Update(ctx, updated); patchErr != nil {
+				log.FromContext(ctx).Error(patchErr, "Updating status")
+				return ctrl.Result{}, patchErr
+			}
 		}
 	}
 

--- a/internal/testing/assertions.go
+++ b/internal/testing/assertions.go
@@ -46,6 +46,14 @@ func NotFound(object client.Object) func() bool {
 
 func Exists(object client.Object) func() bool {
 	return func() bool {
-		return k8sClient.Get(ctx, client.ObjectKeyFromObject(object), object) == nil
+		err := k8sClient.Get(ctx, client.ObjectKeyFromObject(object), object)
+		switch {
+		case errors.IsNotFound(err):
+			return false
+		case err == nil:
+			return true
+		default:
+			panic(err)
+		}
 	}
 }

--- a/internal/testing/env.go
+++ b/internal/testing/env.go
@@ -88,6 +88,10 @@ func GetScheme() *runtime.Scheme {
 	return scheme.Scheme
 }
 
+func ActualNamespace() *corev1.Namespace {
+	return ns
+}
+
 var _ = SynchronizedAfterSuite(func() {
 	cancel()
 	Expect(testEnv.Stop()).To(BeNil())
@@ -144,6 +148,7 @@ func WithNewNamespace(fn func()) {
 	AfterEach(func() {
 		Expect(k8sClient.Delete(ctx, ns))
 		k8sClient = oldClient
+		ns = nil
 	})
 	fn()
 }


### PR DESCRIPTION
Ownership is defined on those object to the Auth server on which they are applied.
This allow to block the Auth object deletion until Scope and Client objects are properly removed.
