### PR TITLE
feat: spec search optional config

### DIFF
--- a/apis/stack/v1beta1/search_types.go
+++ b/apis/stack/v1beta1/search_types.go
@@ -10,10 +10,13 @@ import (
 // +kubebuilder:object:generate=true
 type SearchSpec struct {
 	ImageHolder `json:",inline"`
+
 	// +optional
 	Scaling ScalingSpec `json:"scaling,omitempty"`
 
+	// *optional
 	ElasticSearchConfig *v1beta1.ElasticSearchConfig `json:"elasticSearch"`
+
 	//+optional
 	Ingress *IngressConfig `json:"ingress"`
 }

--- a/config/crd/bases/stack.formance.com_configurations.yaml
+++ b/config/crd/bases/stack.formance.com_configurations.yaml
@@ -1856,6 +1856,7 @@ spec:
                   search:
                     properties:
                       elasticSearch:
+                        description: '*optional'
                         properties:
                           basicAuth:
                             properties:

--- a/config/crd/bases/stack.formance.com_stacks.yaml
+++ b/config/crd/bases/stack.formance.com_stacks.yaml
@@ -1879,6 +1879,7 @@ spec:
                   search:
                     properties:
                       elasticSearch:
+                        description: '*optional'
                         properties:
                           basicAuth:
                             properties:


### PR DESCRIPTION
- fix(search): missing some field to index
- feat(apis/stack): make elasticSearch config optional (has to be defined in global config)
