### PR TITLE
fix: otel resource attributes env var

### DIFF
--- a/internal/resources/auths/deployment.go
+++ b/internal/resources/auths/deployment.go
@@ -36,7 +36,7 @@ func createDeployment(ctx Context, stack *v1beta1.Stack, auth *v1beta1.Auth, dat
 	}
 
 	env := make([]corev1.EnvVar, 0)
-	otlpEnv, err := settings.GetOTELEnvVars(ctx, stack.Name, LowerCamelCaseKind(ctx, auth))
+	otlpEnv, err := settings.GetOTELEnvVars(ctx, stack.Name, LowerCamelCaseKind(ctx, auth), " ")
 	if err != nil {
 		return err
 	}

--- a/internal/resources/benthos/controller.go
+++ b/internal/resources/benthos/controller.go
@@ -130,7 +130,7 @@ func createDeployment(ctx Context, stack *v1beta1.Stack, b *v1beta1.Benthos) err
 		}
 	}
 
-	otelEnvVars, err := settings.GetOTELEnvVars(ctx, stack.Name, "benthos")
+	otelEnvVars, err := settings.GetOTELEnvVars(ctx, stack.Name, "benthos", " ")
 	if err != nil {
 		return err
 	}

--- a/internal/resources/caddy/caddy.go
+++ b/internal/resources/caddy/caddy.go
@@ -21,7 +21,7 @@ import (
 func DeploymentTemplate(ctx core.Context, stack *v1beta1.Stack, owner v1beta1.Object, caddyfile *v1.ConfigMap, image string, env []v1.EnvVar) (*appsv1.Deployment, error) {
 	t := &appsv1.Deployment{}
 
-	otlpEnv, err := settings.GetOTELEnvVars(ctx, stack.Name, core.LowerCamelCaseKind(ctx, owner))
+	otlpEnv, err := settings.GetOTELEnvVars(ctx, stack.Name, core.LowerCamelCaseKind(ctx, owner), ",")
 	if err != nil {
 		return nil, err
 	}
@@ -34,7 +34,6 @@ func DeploymentTemplate(ctx core.Context, stack *v1beta1.Stack, owner v1beta1.Ob
 				if envVar.Value == "true" {
 					scheme = "http"
 				}
-				break
 			}
 		}
 		env = append(env, core.Env("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", fmt.Sprintf("%s://$(OTEL_TRACES_EXPORTER_OTLP_ENDPOINT)", scheme)))

--- a/internal/resources/ledgers/deployments.go
+++ b/internal/resources/ledgers/deployments.go
@@ -378,7 +378,7 @@ func setCommonContainerConfiguration(ctx core.Context, stack *v1beta1.Stack, led
 		prefix = "NUMARY_"
 	}
 	env := make([]corev1.EnvVar, 0)
-	otlpEnv, err := settings.GetOTELEnvVarsWithPrefix(ctx, stack.Name, core.LowerCamelCaseKind(ctx, ledger), prefix)
+	otlpEnv, err := settings.GetOTELEnvVarsWithPrefix(ctx, stack.Name, core.LowerCamelCaseKind(ctx, ledger), prefix, "")
 	if err != nil {
 		return err
 	}

--- a/internal/resources/orchestrations/deployments.go
+++ b/internal/resources/orchestrations/deployments.go
@@ -50,7 +50,7 @@ func createDeployment(ctx Context, stack *v1beta1.Stack, orchestration *v1beta1.
 	consumer *v1beta1.BrokerConsumer, image string) error {
 
 	env := make([]corev1.EnvVar, 0)
-	otlpEnv, err := settings.GetOTELEnvVars(ctx, stack.Name, LowerCamelCaseKind(ctx, orchestration))
+	otlpEnv, err := settings.GetOTELEnvVars(ctx, stack.Name, LowerCamelCaseKind(ctx, orchestration), " ")
 	if err != nil {
 		return err
 	}

--- a/internal/resources/payments/deployments.go
+++ b/internal/resources/payments/deployments.go
@@ -100,7 +100,7 @@ func temporalEnvVars(ctx core.Context, stack *v1beta1.Stack, payments *v1beta1.P
 
 func commonEnvVars(ctx core.Context, stack *v1beta1.Stack, payments *v1beta1.Payments, database *v1beta1.Database) ([]v1.EnvVar, error) {
 	env := make([]v1.EnvVar, 0)
-	otlpEnv, err := settings.GetOTELEnvVars(ctx, stack.Name, core.LowerCamelCaseKind(ctx, payments))
+	otlpEnv, err := settings.GetOTELEnvVars(ctx, stack.Name, core.LowerCamelCaseKind(ctx, payments), " ")
 	if err != nil {
 		return nil, err
 	}

--- a/internal/resources/reconciliations/deployments.go
+++ b/internal/resources/reconciliations/deployments.go
@@ -17,7 +17,7 @@ import (
 func createDeployment(ctx core.Context, stack *v1beta1.Stack, reconciliation *v1beta1.Reconciliation,
 	database *v1beta1.Database, authClient *v1beta1.AuthClient, image string) error {
 	env := make([]v1.EnvVar, 0)
-	otlpEnv, err := settings.GetOTELEnvVars(ctx, stack.Name, core.LowerCamelCaseKind(ctx, reconciliation))
+	otlpEnv, err := settings.GetOTELEnvVars(ctx, stack.Name, core.LowerCamelCaseKind(ctx, reconciliation), " ")
 	if err != nil {
 		return err
 	}

--- a/internal/resources/searches/init.go
+++ b/internal/resources/searches/init.go
@@ -70,7 +70,7 @@ func Reconcile(ctx Context, stack *v1beta1.Stack, search *v1beta1.Search, versio
 		env = append(env, Env("AWS_IAM_ENABLED", "true"))
 	}
 
-	otlpEnv, err := settings.GetOTELEnvVars(ctx, stack.Name, LowerCamelCaseKind(ctx, search))
+	otlpEnv, err := settings.GetOTELEnvVars(ctx, stack.Name, LowerCamelCaseKind(ctx, search), " ")
 	if err != nil {
 		return err
 	}

--- a/internal/resources/settings/opentelemetry.go
+++ b/internal/resources/settings/opentelemetry.go
@@ -15,18 +15,18 @@ const (
 	MonitoringTypeMetrics MonitoringType = "METRICS"
 )
 
-func GetOTELEnvVars(ctx core.Context, stack, serviceName string) ([]v1.EnvVar, error) {
-	return GetOTELEnvVarsWithPrefix(ctx, stack, serviceName, "")
+func GetOTELEnvVars(ctx core.Context, stack, serviceName string, sliceStringSeparator string) ([]v1.EnvVar, error) {
+	return GetOTELEnvVarsWithPrefix(ctx, stack, serviceName, "", sliceStringSeparator)
 }
 
-func GetOTELEnvVarsWithPrefix(ctx core.Context, stack, serviceName, prefix string) ([]v1.EnvVar, error) {
+func GetOTELEnvVarsWithPrefix(ctx core.Context, stack, serviceName, prefix, sliceStringSeparator string) ([]v1.EnvVar, error) {
 
-	traces, err := otelEnvVars(ctx, stack, MonitoringTypeTraces, serviceName, prefix)
+	traces, err := otelEnvVars(ctx, stack, MonitoringTypeTraces, serviceName, prefix, sliceStringSeparator)
 	if err != nil {
 		return nil, err
 	}
 
-	metrics, err := otelEnvVars(ctx, stack, MonitoringTypeMetrics, serviceName, prefix)
+	metrics, err := otelEnvVars(ctx, stack, MonitoringTypeMetrics, serviceName, prefix, sliceStringSeparator)
 	if err != nil {
 		return nil, err
 	}
@@ -47,7 +47,7 @@ func HasOpenTelemetryTracesEnabled(ctx core.Context, stack string) (bool, error)
 	return true, nil
 }
 
-func otelEnvVars(ctx core.Context, stack string, monitoringType MonitoringType, serviceName, prefix string) ([]v1.EnvVar, error) {
+func otelEnvVars(ctx core.Context, stack string, monitoringType MonitoringType, serviceName, prefix, sliceStringSeparator string) ([]v1.EnvVar, error) {
 
 	otlp, err := GetURL(ctx, stack, "opentelemetry", strings.ToLower(string(monitoringType)), "dsn")
 	if err != nil {
@@ -93,7 +93,7 @@ func otelEnvVars(ctx core.Context, stack string, monitoringType MonitoringType, 
 
 	resourceAttributesStr := ""
 	for k, v := range resourceAttributes {
-		resourceAttributesStr = fmt.Sprintf("%s%s=%s,", resourceAttributesStr, k, v)
+		resourceAttributesStr = fmt.Sprintf("%s%s=%s%s", resourceAttributesStr, k, v, sliceStringSeparator)
 	}
 	if len(resourceAttributesStr) > 0 {
 		resourceAttributesStr = resourceAttributesStr[:len(resourceAttributesStr)-1]

--- a/internal/resources/stargates/deployment.go
+++ b/internal/resources/stargates/deployment.go
@@ -16,7 +16,7 @@ func createDeployment(ctx core.Context, stack *v1beta1.Stack, stargate *v1beta1.
 
 	env := make([]v1.EnvVar, 0)
 
-	otlpEnv, err := settings.GetOTELEnvVars(ctx, stack.Name, core.LowerCamelCaseKind(ctx, stargate))
+	otlpEnv, err := settings.GetOTELEnvVars(ctx, stack.Name, core.LowerCamelCaseKind(ctx, stargate), " ")
 	if err != nil {
 		return err
 	}

--- a/internal/resources/wallets/deployment.go
+++ b/internal/resources/wallets/deployment.go
@@ -17,7 +17,7 @@ import (
 func createDeployment(ctx core.Context, stack *v1beta1.Stack, wallets *v1beta1.Wallets,
 	authClient *v1beta1.AuthClient, version string) error {
 	env := make([]v1.EnvVar, 0)
-	otlpEnv, err := settings.GetOTELEnvVars(ctx, stack.Name, core.LowerCamelCaseKind(ctx, wallets))
+	otlpEnv, err := settings.GetOTELEnvVars(ctx, stack.Name, core.LowerCamelCaseKind(ctx, wallets), " ")
 	if err != nil {
 		return err
 	}

--- a/internal/resources/webhooks/deployment.go
+++ b/internal/resources/webhooks/deployment.go
@@ -32,7 +32,7 @@ func deploymentEnvVars(ctx core.Context, stack *v1beta1.Stack, webhooks *v1beta1
 	}
 
 	env := make([]v1.EnvVar, 0)
-	otlpEnv, err := settings.GetOTELEnvVars(ctx, stack.Name, core.LowerCamelCaseKind(ctx, webhooks))
+	otlpEnv, err := settings.GetOTELEnvVars(ctx, stack.Name, core.LowerCamelCaseKind(ctx, webhooks), " ")
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Keep "," separator for gateway.
Keep " " for services.
