### PR TITLE
feat(temporal): init search attributes when wanted

### DIFF
--- a/internal/resources/orchestrations/deployments.go
+++ b/internal/resources/orchestrations/deployments.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/formancehq/operator/internal/core"
 	"github.com/formancehq/operator/internal/resources/brokers"
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -133,6 +134,10 @@ func createDeployment(ctx Context, stack *v1beta1.Stack, orchestration *v1beta1.
 			EnvFromSecret("TEMPORAL_SSL_CLIENT_KEY", secret, "tls.key"),
 			EnvFromSecret("TEMPORAL_SSL_CLIENT_CERT", secret, "tls.crt"),
 		)
+	}
+
+	if initSearchAttributes := temporalURI.Query().Get("initSearchAttributes"); initSearchAttributes == "true" {
+		env = append(env, core.Env("TEMPORAL_INIT_SEARCH_ATTRIBUTES", "true"))
 	}
 
 	broker := &v1beta1.Broker{}

--- a/internal/resources/payments/deployments.go
+++ b/internal/resources/payments/deployments.go
@@ -96,6 +96,10 @@ func temporalEnvVars(ctx core.Context, stack *v1beta1.Stack, payments *v1beta1.P
 		)
 	}
 
+	if initSearchAttributes := temporalURI.Query().Get("initSearchAttributes"); initSearchAttributes == "true" {
+		env = append(env, core.Env("TEMPORAL_INIT_SEARCH_ATTRIBUTES", "true"))
+	}
+
 	temporalMaxConcurrentWorkflowTaskPollers, err := settings.GetIntOrDefault(ctx, stack.Name, 4, "payments", "worker", "temporal-max-concurrent-workflow-task-pollers")
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Thanks to a query param of the temporal URL, we will be able to init or not the temporal search attributes