### PR TITLE
chore: bump operator Helm chart version to 2.17.0

### DIFF
--- a/helm/operator/Chart.yaml
+++ b/helm/operator/Chart.yaml
@@ -12,12 +12,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: "2.16.0"
+version: "2.17.0"
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v2.16.0"
+appVersion: "v2.17.0"
 dependencies:
 - name: operator-crds
   version: "2.X"


### PR DESCRIPTION
## Summary
- Update operator Helm chart version from 2.16.0 to 2.17.0
- Update appVersion from v2.16.0 to v2.17.0

## Test plan
- [ ] Verify the Helm chart can be packaged successfully
- [ ] Verify the chart can be deployed to a test cluster
- [ ] Verify the operator starts correctly with the new version