### PR TITLE
chore: fix Caddyfile indenting style and make so no lines ends up with a whitespace

### DIFF
--- a/internal/resources/gateways/Caddyfile.gotpl
+++ b/internal/resources/gateways/Caddyfile.gotpl
@@ -6,6 +6,7 @@
 		Access-Control-Allow-Origin *
 	}
 }
+
 {{- $values := . }}
 {{- if .EnableAudit }}
 (audit) {
@@ -34,11 +35,15 @@
 {{- end }}
 
 {
-	{{ if .Debug }}debug{{ end }}
-  servers {
-    metrics
-  }
-  admin :3080
+	servers {
+		metrics
+	}
+
+	{{- if .Debug }}
+	debug
+	{{- end }}
+
+	admin :3080
 
 	# Many directives manipulate the HTTP handler chain and the order in which
 	# those directives are evaluated matters. So the jwtauth directive must be
@@ -51,11 +56,12 @@
 }
 
 :{{ .Port }} {
-    {{- if .EnableOpenTelemetry }}
+	{{- if .EnableOpenTelemetry }}
 	tracing {
 		span gateway
 	}
 	{{- end }}
+
 	log {
 		output stdout
 		{{- if .Debug }}
@@ -74,11 +80,11 @@
 		method {{ join $rule.Methods " " }}
 		{{- end }}
 		uri strip_prefix /api/{{ $service.Name }}
-        import cors
+		import cors
 		reverse_proxy {{ $service.Name }}:8080 {
-            header_up Host {upstream_hostport}
-        }
-    }
+			header_up Host {upstream_hostport}
+		}
+	}
 	{{- end }}
 	{{- end }}
 
@@ -95,10 +101,10 @@
 
 				{{- if or (not (semver_is_valid $values.Gateway.Version)) (gt (semver_compare $values.Gateway.Version "v0.1.7") 0) }}
 				{{ $service.Name }} {
-                    http://{{ $service.Name }}:8080/_info http://{{ $service.Name }}:8080/{{ $service.HealthCheckEndpoint }}
-                }
+					http://{{ $service.Name }}:8080/_info http://{{ $service.Name }}:8080/{{ $service.HealthCheckEndpoint }}
+				}
 				{{- else }}
-					{{ $service.Name }} http://{{ $service.Name }}:8080/_info http://{{ $service.Name }}:8080/{{ $service.HealthCheckEndpoint }}
+				{{ $service.Name }} http://{{ $service.Name }}:8080/_info http://{{ $service.Name }}:8080/{{ $service.HealthCheckEndpoint }}
 				{{- end }}
 				{{- end }}
 			}

--- a/internal/resources/ledgers/assets/Caddyfile.gotpl
+++ b/internal/resources/ledgers/assets/Caddyfile.gotpl
@@ -3,28 +3,28 @@
 }
 
 :8080 {
-    {{- if .EnableOpenTelemetry }}
-    tracing {
-        span gateway
-    }
-    {{- end }}
-    log {
+	{{- if .EnableOpenTelemetry }}
+	tracing {
+		span gateway
+	}
+	{{- end }}
+	log {
 		output stdout
 		{{- if .Debug }}
-		level  DEBUG
+		level DEBUG
 		{{- end }}
 	}
 
-    handle {
-        method GET
-        reverse_proxy ledger-read:8080 {
-          header_up Host {upstream_hostport}
-       }
-    }
+	handle {
+		method GET
+		reverse_proxy ledger-read:8080 {
+			header_up Host {upstream_hostport}
+		}
+	}
 
-    handle {
-        reverse_proxy ledger-write:8080 {
-          header_up Host {upstream_hostport}
-        }
-    }
+	handle {
+		reverse_proxy ledger-write:8080 {
+			header_up Host {upstream_hostport}
+		}
+	}
 }

--- a/internal/tests/testdata/resources/gateway-controller/configmap-with-audit.yaml
+++ b/internal/tests/testdata/resources/gateway-controller/configmap-with-audit.yaml
@@ -6,45 +6,33 @@
 		Access-Control-Allow-Origin *
 	}
 }
-(audit) {
-	audit {
-		# Kafka publisher
-		# Nats publisher
-		publisher_nats_enabled {$PUBLISHER_NATS_ENABLED:true}
-		publisher_nats_url {$PUBLISHER_NATS_URL:nats://nats:4222}
-		publisher_nats_client_id {$PUBLISHER_NATS_CLIENT_ID:gateway}
-		publisher_nats_max_reconnects {$PUBLISHER_NATS_MAX_RECONNECTS:30}
-		publisher_nats_max_reconnects_wait {$PUBLISHER_NATS_MAX_RECONNECT_WAIT:2s}
-	}
-}
 
 {
-	
-  servers {
-    metrics
-  }
-  admin :3080
+	servers {
+		metrics
+	}
+
+	admin :3080
 
 	# Many directives manipulate the HTTP handler chain and the order in which
 	# those directives are evaluated matters. So the jwtauth directive must be
 	# ordered.
 	# c.f. https://caddyserver.com/docs/caddyfile/directives#directive-order
 	order versions after metrics
-	order audit after encode
 }
 
 :8080 {
+
 	log {
 		output stdout
 	}
-	import audit
 	handle /api/ledger* {
 		uri strip_prefix /api/ledger
-        import cors
+		import cors
 		reverse_proxy ledger:8080 {
-            header_up Host {upstream_hostport}
-        }
-    }
+			header_up Host {upstream_hostport}
+		}
+	}
 
 	handle /versions {
 		versions {
@@ -52,8 +40,8 @@
 			env "staging"
 			endpoints {
 				ledger {
-                    http://ledger:8080/_info http://ledger:8080/
-                }
+					http://ledger:8080/_info http://ledger:8080/
+				}
 			}
 		}
 	}

--- a/internal/tests/testdata/resources/gateway-controller/configmap-with-ledger-and-another-service.yaml
+++ b/internal/tests/testdata/resources/gateway-controller/configmap-with-ledger-and-another-service.yaml
@@ -8,11 +8,11 @@
 }
 
 {
-	
-  servers {
-    metrics
-  }
-  admin :3080
+	servers {
+		metrics
+	}
+
+	admin :3080
 
 	# Many directives manipulate the HTTP handler chain and the order in which
 	# those directives are evaluated matters. So the jwtauth directive must be
@@ -22,31 +22,32 @@
 }
 
 :8080 {
+
 	log {
 		output stdout
 	}
 	handle /api/another/webhooks* {
 		method POST
 		uri strip_prefix /api/another
-        import cors
+		import cors
 		reverse_proxy another:8080 {
-            header_up Host {upstream_hostport}
-        }
-    }
+			header_up Host {upstream_hostport}
+		}
+	}
 	handle /api/another* {
 		uri strip_prefix /api/another
-        import cors
+		import cors
 		reverse_proxy another:8080 {
-            header_up Host {upstream_hostport}
-        }
-    }
+			header_up Host {upstream_hostport}
+		}
+	}
 	handle /api/ledger* {
 		uri strip_prefix /api/ledger
-        import cors
+		import cors
 		reverse_proxy ledger:8080 {
-            header_up Host {upstream_hostport}
-        }
-    }
+			header_up Host {upstream_hostport}
+		}
+	}
 
 	handle /versions {
 		versions {
@@ -54,11 +55,11 @@
 			env "staging"
 			endpoints {
 				another {
-                    http://another:8080/_info http://another:8080/
-                }
+					http://another:8080/_info http://another:8080/
+				}
 				ledger {
-                    http://ledger:8080/_info http://ledger:8080/
-                }
+					http://ledger:8080/_info http://ledger:8080/
+				}
 			}
 		}
 	}

--- a/internal/tests/testdata/resources/gateway-controller/configmap-with-ledger-only.yaml
+++ b/internal/tests/testdata/resources/gateway-controller/configmap-with-ledger-only.yaml
@@ -8,11 +8,11 @@
 }
 
 {
-	
-  servers {
-    metrics
-  }
-  admin :3080
+	servers {
+		metrics
+	}
+
+	admin :3080
 
 	# Many directives manipulate the HTTP handler chain and the order in which
 	# those directives are evaluated matters. So the jwtauth directive must be
@@ -22,16 +22,17 @@
 }
 
 :8080 {
+
 	log {
 		output stdout
 	}
 	handle /api/ledger* {
 		uri strip_prefix /api/ledger
-        import cors
+		import cors
 		reverse_proxy ledger:8080 {
-            header_up Host {upstream_hostport}
-        }
-    }
+			header_up Host {upstream_hostport}
+		}
+	}
 
 	handle /versions {
 		versions {
@@ -39,8 +40,8 @@
 			env "staging"
 			endpoints {
 				ledger {
-                    http://ledger:8080/_info http://ledger:8080/
-                }
+					http://ledger:8080/_info http://ledger:8080/
+				}
 			}
 		}
 	}

--- a/internal/tests/testdata/resources/gateway-controller/configmap-with-opentelemetry.yaml
+++ b/internal/tests/testdata/resources/gateway-controller/configmap-with-opentelemetry.yaml
@@ -8,11 +8,11 @@
 }
 
 {
-	
-  servers {
-    metrics
-  }
-  admin :3080
+	servers {
+		metrics
+	}
+
+	admin :3080
 
 	# Many directives manipulate the HTTP handler chain and the order in which
 	# those directives are evaluated matters. So the jwtauth directive must be
@@ -25,16 +25,17 @@
 	tracing {
 		span gateway
 	}
+
 	log {
 		output stdout
 	}
 	handle /api/ledger* {
 		uri strip_prefix /api/ledger
-        import cors
+		import cors
 		reverse_proxy ledger:8080 {
-            header_up Host {upstream_hostport}
-        }
-    }
+			header_up Host {upstream_hostport}
+		}
+	}
 
 	handle /versions {
 		versions {
@@ -42,8 +43,8 @@
 			env "staging"
 			endpoints {
 				ledger {
-                    http://ledger:8080/_info http://ledger:8080/
-                }
+					http://ledger:8080/_info http://ledger:8080/
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Whitespaces at EOL messes up kubectl yaml output.