### PR TITLE
fix: add defer directive to prevent duplicate CORS headers

### DIFF
--- a/internal/resources/gateways/Caddyfile.gotpl
+++ b/internal/resources/gateways/Caddyfile.gotpl
@@ -1,5 +1,6 @@
 (cors) {
 	header {
+		defer
 		Access-Control-Allow-Methods "GET,OPTIONS,PUT,POST,DELETE,HEAD,PATCH"
 		Access-Control-Allow-Headers content-type
 		Access-Control-Max-Age 100

--- a/internal/tests/testdata/resources/gateway-controller/configmap-with-audit.yaml
+++ b/internal/tests/testdata/resources/gateway-controller/configmap-with-audit.yaml
@@ -1,5 +1,6 @@
 (cors) {
 	header {
+		defer
 		Access-Control-Allow-Methods "GET,OPTIONS,PUT,POST,DELETE,HEAD,PATCH"
 		Access-Control-Allow-Headers content-type
 		Access-Control-Max-Age 100

--- a/internal/tests/testdata/resources/gateway-controller/configmap-with-ledger-and-another-service.yaml
+++ b/internal/tests/testdata/resources/gateway-controller/configmap-with-ledger-and-another-service.yaml
@@ -1,5 +1,6 @@
 (cors) {
 	header {
+		defer
 		Access-Control-Allow-Methods "GET,OPTIONS,PUT,POST,DELETE,HEAD,PATCH"
 		Access-Control-Allow-Headers content-type
 		Access-Control-Max-Age 100

--- a/internal/tests/testdata/resources/gateway-controller/configmap-with-ledger-only.yaml
+++ b/internal/tests/testdata/resources/gateway-controller/configmap-with-ledger-only.yaml
@@ -1,5 +1,6 @@
 (cors) {
 	header {
+		defer
 		Access-Control-Allow-Methods "GET,OPTIONS,PUT,POST,DELETE,HEAD,PATCH"
 		Access-Control-Allow-Headers content-type
 		Access-Control-Max-Age 100

--- a/internal/tests/testdata/resources/gateway-controller/configmap-with-opentelemetry.yaml
+++ b/internal/tests/testdata/resources/gateway-controller/configmap-with-opentelemetry.yaml
@@ -1,5 +1,6 @@
 (cors) {
 	header {
+		defer
 		Access-Control-Allow-Methods "GET,OPTIONS,PUT,POST,DELETE,HEAD,PATCH"
 		Access-Control-Allow-Headers content-type
 		Access-Control-Max-Age 100


### PR DESCRIPTION
## Summary

This PR fixes an issue where the Gateway was returning duplicate `Access-Control-Allow-Origin` headers when clients sent requests with the `Origin` header.

**Problem:**
- When a client sends a request with the `Origin` header, Caddy can automatically add a CORS header
- Our explicit CORS configuration also adds the same header
- Result: Two `Access-Control-Allow-Origin` headers in the response, which causes CORS failures

**Solution:**
- Added the `defer` directive to the CORS header block in the Caddyfile template
- This ensures CORS headers are added after response processing by other handlers
- Prevents header duplication

**Changes:**
- Updated `Caddyfile.gotpl` template with `defer` directive
- Updated all gateway controller test golden files to match

## Test Plan

- [x] All existing tests pass (83/84 - 1 unrelated failure)
- [x] Gateway controller tests validated with updated golden files
- [ ] Manual testing: Deploy a stack with gateway and verify single `Access-Control-Allow-Origin` header in responses when `Origin` header is sent