### PR TITLE
chore(nats): upgrade nats-box docker image to v0.19.2

### DIFF
--- a/internal/resources/brokerconsumers/controller.go
+++ b/internal/resources/brokerconsumers/controller.go
@@ -183,7 +183,7 @@ func createServiceNatsConsumer(ctx core.Context, stack *v1beta1.Stack, consumer 
 			--defaults
 	}`
 
-	natsBoxImage, err := registries.GetNatsBoxImage(ctx, stack, "0.14.1")
+	natsBoxImage, err := registries.GetNatsBoxImage(ctx, stack, "0.19.2")
 	if err != nil {
 		return err
 	}
@@ -236,7 +236,7 @@ func createStackNatsConsumer(ctx core.Context, stack *v1beta1.Stack, consumer *v
 		--defaults $filters
 	`
 
-	natsBoxImage, err := registries.GetNatsBoxImage(ctx, stack, "0.14.1")
+	natsBoxImage, err := registries.GetNatsBoxImage(ctx, stack, "0.19.2")
 	if err != nil {
 		return err
 	}

--- a/internal/resources/brokers/reconcile.go
+++ b/internal/resources/brokers/reconcile.go
@@ -115,7 +115,7 @@ func detectBrokerModeByCheckingExistentStreams(ctx core.Context, stack *v1beta1.
 	[[ -z "$v" ]] || exit 12;
 `
 
-	natsBoxImage, err := registries.GetNatsBoxImage(ctx, stack, "0.14.1")
+	natsBoxImage, err := registries.GetNatsBoxImage(ctx, stack, "0.19.2")
 	if err != nil {
 		return false, err
 	}
@@ -194,7 +194,7 @@ func deleteBroker(ctx core.Context, broker *v1beta1.Broker) error {
 		return err
 	}
 
-	natsBoxImage, err := registries.GetNatsBoxImage(ctx, stack, "0.14.1")
+	natsBoxImage, err := registries.GetNatsBoxImage(ctx, stack, "0.19.2")
 	if err != nil {
 		return err
 	}
@@ -231,7 +231,7 @@ func createOneStreamByStack(ctx core.Context, stack *v1beta1.Stack, broker *v1be
 			$STREAM
 	} || true`
 
-	natsBoxImage, err := registries.GetNatsBoxImage(ctx, stack, "0.14.1")
+	natsBoxImage, err := registries.GetNatsBoxImage(ctx, stack, "0.19.2")
 	if err != nil {
 		return err
 	}
@@ -292,7 +292,7 @@ func createNatsTopic(ctx core.Context, stack *v1beta1.Stack, broker *v1beta1.Bro
 			$STREAM
 	fi`
 
-	natsBoxImage, err := registries.GetNatsBoxImage(ctx, stack, "0.14.1")
+	natsBoxImage, err := registries.GetNatsBoxImage(ctx, stack, "0.19.2")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Upgraded the nats-box Docker image to v0.19.2 used by broker reconcile and consumer controllers for NATS CLI commands.

- **Dependencies**
  - nats-box: 0.14.1 → 0.19.2

<sup>Written for commit 2234b8c81982d9141f92ccb1d549da6c2c722474. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

