### PR TITLE
feat(broker): add circuit breaker settings support

### DIFF
--- a/config/samples/formance.com_v1beta1_settings.yaml
+++ b/config/samples/formance.com_v1beta1_settings.yaml
@@ -18,3 +18,23 @@ spec:
     - "*"
   key: search.batching
   value: count=10,period=10s
+---
+apiVersion: formance.com/v1beta1
+kind: Settings
+metadata:
+  name: circuit-breaker-enabled
+spec:
+  stacks:
+    - "*"
+  key: publisher.circuit-breaker.enabled
+  value: "true"
+---
+apiVersion: formance.com/v1beta1
+kind: Settings
+metadata:
+  name: circuit-breaker-open-interval
+spec:
+  stacks:
+    - "*"
+  key: publisher.circuit-breaker.open-interval-duration
+  value: "5s"


### PR DESCRIPTION
## Summary
- Add circuit breaker configuration via Settings CRD instead of relying solely on broker URI query parameters
- Settings configuration takes precedence over URI query params for cleaner configuration
- Maintains backward compatibility with existing URI-based configuration

## New Settings
| Key | Type | Description | Example |
|-----|------|-------------|---------|
| `publisher.circuit-breaker.enabled` | boolean | Enable circuit breaker | `"true"` |
| `publisher.circuit-breaker.open-interval-duration` | duration | Interval before retry | `"5s"` |

## Usage Example
```yaml
apiVersion: formance.com/v1beta1
kind: Settings
metadata:
  name: circuit-breaker-enabled
spec:
  stacks:
    - "*"
  key: publisher.circuit-breaker.enabled
  value: "true"
---
apiVersion: formance.com/v1beta1
kind: Settings
metadata:
  name: circuit-breaker-open-interval
spec:
  stacks:
    - "*"
  key: publisher.circuit-breaker.open-interval-duration
  value: "5s"
```

## Test plan
- [ ] Deploy operator with new Settings
- [ ] Verify pods receive `PUBLISHER_CIRCUIT_BREAKER_ENABLED=true` environment variable
- [ ] Verify backward compatibility with URI query params still works when Settings not defined