### PR TITLE
fix(broker): add WithWatchSettings to trigger reconciliation on settings changes

### DIFF
--- a/internal/resources/brokers/init.go
+++ b/internal/resources/brokers/init.go
@@ -16,6 +16,7 @@ func init() {
 		core.WithResourceReconciler(Reconcile,
 			core.WithFinalizer[*v1beta1.Broker]("clear", deleteBroker),
 			core.WithOwn[*v1beta1.Broker](&v1.Job{}),
+			core.WithWatchSettings[*v1beta1.Broker](),
 		),
 	)
 }


### PR DESCRIPTION
## Summary
- Fix Broker not being re-reconciled when `broker.dsn` setting changes
- This caused `broker.Status.URI` to retain stale values, preventing circuit breaker and other query params from being propagated

## Problem
When modifying the `broker.dsn` setting (e.g., adding `?circuitBreakerEnabled=true`):

| Module | Source of URI | Result |
|--------|---------------|--------|
| Webhooks | `settings.RequireURL()` directly | ✅ Works |
| Ledger, Payments, Gateway, Orchestrations | `broker.Status.URI` | ❌ Stale value |

The Broker was missing `WithWatchSettings`, so it wasn't re-reconciled when settings changed.

## Fix
Add `core.WithWatchSettings[*v1beta1.Broker]()` to the Broker controller registration.

## Test plan
- [ ] Deploy operator with this fix
- [ ] Create a broker.dsn setting without circuitBreakerEnabled
- [ ] Verify Ledger/Payments pods don't have PUBLISHER_CIRCUIT_BREAKER_ENABLED
- [ ] Update broker.dsn to add ?circuitBreakerEnabled=true
- [ ] Verify Broker is re-reconciled and Ledger/Payments pods now have PUBLISHER_CIRCUIT_BREAKER_ENABLED=true