### PR TITLE
fix(orchestrations): add brokers.Watch to trigger reconciliation on broker changes

### DIFF
--- a/internal/resources/orchestrations/init.go
+++ b/internal/resources/orchestrations/init.go
@@ -24,6 +24,7 @@ import (
 	"github.com/formancehq/operator/api/formance.com/v1beta1"
 	. "github.com/formancehq/operator/internal/core"
 	"github.com/formancehq/operator/internal/resources/brokerconsumers"
+	"github.com/formancehq/operator/internal/resources/brokers"
 	"github.com/formancehq/operator/internal/resources/brokertopics"
 	"github.com/formancehq/operator/internal/resources/databases"
 	"github.com/formancehq/operator/internal/resources/gatewayhttpapis"
@@ -102,6 +103,7 @@ func init() {
 			WithWatchDependency[*v1beta1.Orchestration](&v1beta1.Wallets{}),
 			brokertopics.Watch[*v1beta1.Orchestration]("orchestration"),
 			databases.Watch[*v1beta1.Orchestration](),
+			brokers.Watch[*v1beta1.Orchestration](),
 		),
 	)
 }


### PR DESCRIPTION
## Summary

- Add `brokers.Watch[*v1beta1.Orchestration]()` to the Orchestrations controller to fix a bug where Orchestration wasn't being reconciled when `broker.dsn` setting was added after the resource was created

This is a follow-up to #378 which fixed the same issue for Webhooks.

## Problem

When Orchestration is created **before** the `broker.dsn` setting exists:
1. The BrokerConsumer is created but not ready (no broker configured)
2. The reconciler returns with "waiting for consumers to be ready" without creating the deployment
3. Later, when `broker.dsn` is added, the Broker becomes ready
4. BrokerConsumer becomes ready
5. **But Orchestration was not being notified** of this change, so the deployment was never created
6. Restarting the operator was required to fix the issue

## Why the existing watch wasn't sufficient

Orchestration had `brokertopics.Watch[*v1beta1.Orchestration]("orchestration")` which only triggers when the "orchestration" BrokerTopic changes. However, the "orchestration" BrokerTopic is only created when **another consumer** wants to consume from Orchestration. If Orchestration is the first/only module, no one creates that topic.

## Solution

Add `brokers.Watch[*v1beta1.Orchestration]()` to directly watch for Broker status changes, ensuring Orchestration is reconciled when the Broker becomes ready.

This follows the same pattern used by:
- `Webhooks` (fixed in #378)
- `BrokerConsumer` 
- `BrokerTopic`
- `Benthos`

## Test plan

- [x] All existing tests pass
- [ ] Manual testing: Create Orchestration before broker.dsn, then add broker.dsn - Orchestration should automatically reconcile and create its deployment