### PR TITLE
fix(gateway): fix Caddyfile audit config and metrics deprecation

### DIFF
--- a/internal/resources/gateways/Caddyfile.gotpl
+++ b/internal/resources/gateways/Caddyfile.gotpl
@@ -12,7 +12,10 @@
 {{- if .EnableAudit }}
 (audit) {
 	audit {
+		{{- /* topic_name option is only available in Gateway >= v2.2.0 */}}
+		{{- if or (not (semver_is_valid $values.Gateway.Version)) (ge (semver_compare $values.Gateway.Version "v2.2.0") 0) }}
 		topic_name {$TOPIC_NAME}
+		{{- end }}
 		auto_provision false
 		auth_enabled {$AUTH_ENABLED:false}
 		auth_url {$AUTH_URL:http://auth:8080}
@@ -44,8 +47,10 @@
 {{- end }}
 
 {
+	# Global metrics endpoint (moved from servers block - deprecated location)
+	metrics
+
 	servers {
-		metrics
 		{{- if and .TrustedProxies (gt (len .TrustedProxies) 0) }}
 		trusted_proxies {{ .TrustedProxies }}
 		{{- end }}

--- a/internal/tests/testdata/resources/gateway-controller/configmap-with-audit.yaml
+++ b/internal/tests/testdata/resources/gateway-controller/configmap-with-audit.yaml
@@ -9,8 +9,10 @@
 }
 
 {
+	# Global metrics endpoint (moved from servers block - deprecated location)
+	metrics
+
 	servers {
-		metrics
 	}
 
 	admin :3080

--- a/internal/tests/testdata/resources/gateway-controller/configmap-with-ledger-and-another-service.yaml
+++ b/internal/tests/testdata/resources/gateway-controller/configmap-with-ledger-and-another-service.yaml
@@ -9,8 +9,10 @@
 }
 
 {
+	# Global metrics endpoint (moved from servers block - deprecated location)
+	metrics
+
 	servers {
-		metrics
 	}
 
 	admin :3080

--- a/internal/tests/testdata/resources/gateway-controller/configmap-with-ledger-only.yaml
+++ b/internal/tests/testdata/resources/gateway-controller/configmap-with-ledger-only.yaml
@@ -9,8 +9,10 @@
 }
 
 {
+	# Global metrics endpoint (moved from servers block - deprecated location)
+	metrics
+
 	servers {
-		metrics
 	}
 
 	admin :3080

--- a/internal/tests/testdata/resources/gateway-controller/configmap-with-opentelemetry.yaml
+++ b/internal/tests/testdata/resources/gateway-controller/configmap-with-opentelemetry.yaml
@@ -9,8 +9,10 @@
 }
 
 {
+	# Global metrics endpoint (moved from servers block - deprecated location)
+	metrics
+
 	servers {
-		metrics
 	}
 
 	admin :3080


### PR DESCRIPTION
## Summary

- Make `topic_name` option conditional for Gateway >= v2.2.0 (older versions don't support this option and generate topic automatically via `$STACK-audit`)
- Move `metrics` directive from `servers` block to global level (servers.metrics is deprecated and will be removed in the next major Caddy version)

## Context

| Problem | Minimum Gateway Version | Solution |
|---------|------------------------|----------|
| `topic_name` unrecognized | v2.2.0 | Make option conditional based on version |
| `metrics` deprecated | N/A | Move to global Caddyfile level |

## Changes

- `internal/resources/gateways/Caddyfile.gotpl`: Added version check for `topic_name` and moved `metrics` to global level
- Updated golden test files to reflect the new Caddyfile structure

## Test plan

- [ ] Verify Gateway < v2.2.0 starts without `topic_name` error
- [ ] Verify Gateway >= v2.2.0 works with `topic_name` option
- [ ] Verify metrics deprecation warning is resolved
- [ ] CI tests pass