### PR TITLE
feat(reconciliation): split worker into ingestion and matching workers

### DIFF
--- a/internal/resources/brokerconsumers/controller.go
+++ b/internal/resources/brokerconsumers/controller.go
@@ -254,7 +254,7 @@ func createStackNatsConsumer(ctx core.Context, stack *v1beta1.Stack, consumer *v
 			core.Env("NATS_URI", fmt.Sprintf("nats://%s", broker.Status.URI.Host)),
 			core.Env("STREAM", stack.Name),
 			core.Env("NAME", consumerName),
-			core.Env("DELIVER", consumer.Spec.QueriedBy),
+			core.Env("DELIVER", consumerName),
 			core.Env("SUBJECTS", strings.Join(
 				collectionutils.Map(consumer.Spec.Services, func(from string) string {
 					return fmt.Sprintf("%s.%s", stack.Name, from)

--- a/internal/resources/reconciliations/deployments.go
+++ b/internal/resources/reconciliations/deployments.go
@@ -1,6 +1,9 @@
 package reconciliations
 
 import (
+	"fmt"
+
+	"github.com/pkg/errors"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -10,35 +13,54 @@ import (
 	"github.com/formancehq/operator/internal/resources/applications"
 	"github.com/formancehq/operator/internal/resources/authclients"
 	"github.com/formancehq/operator/internal/resources/auths"
+	"github.com/formancehq/operator/internal/resources/brokers"
 	"github.com/formancehq/operator/internal/resources/databases"
 	"github.com/formancehq/operator/internal/resources/gateways"
 	"github.com/formancehq/operator/internal/resources/registries"
 	"github.com/formancehq/operator/internal/resources/settings"
 )
 
-func createDeployment(
+const (
+	DeploymentTypeAPI              = "api"
+	DeploymentTypeWorkerIngestion  = "worker-ingestion"
+	DeploymentTypeWorkerMatching   = "worker-matching"
+)
+
+func commonEnvVars(
 	ctx core.Context,
 	stack *v1beta1.Stack,
 	reconciliation *v1beta1.Reconciliation,
 	database *v1beta1.Database,
 	authClient *v1beta1.AuthClient,
-	imageConfiguration *registries.ImageConfiguration,
-) error {
+) ([]v1.EnvVar, error) {
+	brokerURI, err := settings.RequireURL(ctx, stack.Name, "broker", "dsn")
+	if err != nil {
+		return nil, err
+	}
+	if brokerURI == nil {
+		return nil, errors.New("missing broker configuration")
+	}
+
 	env := make([]v1.EnvVar, 0)
 	otlpEnv, err := settings.GetOTELEnvVars(ctx, stack.Name, core.LowerCamelCaseKind(ctx, reconciliation), " ")
 	if err != nil {
-		return err
+		return nil, err
 	}
 	env = append(env, otlpEnv...)
 
 	gatewayEnv, err := gateways.EnvVarsIfEnabled(ctx, stack.Name)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	postgresEnvVar, err := databases.GetPostgresEnvVars(ctx, stack, database)
 	if err != nil {
-		return err
+		return nil, err
+	}
+
+	brokerEnvVar, err := brokers.GetBrokerEnvVars(ctx, brokerURI, stack.Name, "reconciliation")
+	if err != nil {
+		return nil, err
 	}
 
 	env = append(env, gatewayEnv...)
@@ -46,12 +68,102 @@ func createDeployment(
 	env = append(env, postgresEnvVar...)
 	env = append(env, core.Env("POSTGRES_DATABASE_NAME", "$(POSTGRES_DATABASE)"))
 	env = append(env, authclients.GetEnvVars(authClient)...)
+	env = append(env, brokerEnvVar...)
 
 	authEnvVars, err := auths.ProtectedEnvVars(ctx, stack, "reconciliation", reconciliation.Spec.Auth)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	env = append(env, authEnvVars...)
+
+	return env, nil
+}
+
+func createDeployments(
+	ctx core.Context,
+	stack *v1beta1.Stack,
+	reconciliation *v1beta1.Reconciliation,
+	database *v1beta1.Database,
+	authClient *v1beta1.AuthClient,
+	ingestionConsumer *v1beta1.BrokerConsumer,
+	matchingConsumer *v1beta1.BrokerConsumer,
+	imageConfiguration *registries.ImageConfiguration,
+) error {
+	// Deploy workers first, then API
+	// This ensures workers are ready to process events before API starts accepting requests
+	if err := createDeployment(ctx, stack, reconciliation, database, authClient, ingestionConsumer, imageConfiguration, DeploymentTypeWorkerIngestion); err != nil {
+		return err
+	}
+
+	if err := createDeployment(ctx, stack, reconciliation, database, authClient, matchingConsumer, imageConfiguration, DeploymentTypeWorkerMatching); err != nil {
+		return err
+	}
+
+	if err := createDeployment(ctx, stack, reconciliation, database, authClient, nil, imageConfiguration, DeploymentTypeAPI); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func createDeployment(
+	ctx core.Context,
+	stack *v1beta1.Stack,
+	reconciliation *v1beta1.Reconciliation,
+	database *v1beta1.Database,
+	authClient *v1beta1.AuthClient,
+	consumer *v1beta1.BrokerConsumer,
+	imageConfiguration *registries.ImageConfiguration,
+	deploymentType string,
+) error {
+	var (
+		containerName string
+		metaName      string
+		args          []string
+	)
+
+	switch deploymentType {
+	case DeploymentTypeWorkerIngestion:
+		containerName = "reconciliation-worker-ingestion"
+		metaName = "reconciliation-worker-ingestion"
+		args = []string{"worker", "ingestion"}
+	case DeploymentTypeWorkerMatching:
+		containerName = "reconciliation-worker-matching"
+		metaName = "reconciliation-worker-matching"
+		args = []string{"worker", "matching"}
+	case DeploymentTypeAPI:
+		containerName = "reconciliation"
+		metaName = "reconciliation"
+		args = []string{"serve"}
+	default:
+		return errors.Errorf("unknown deployment type: %s", deploymentType)
+	}
+
+	env, err := commonEnvVars(ctx, stack, reconciliation, database, authClient)
+	if err != nil {
+		return err
+	}
+
+	// Add Elasticsearch env vars for both API and Worker
+	esEnvVars, err := settings.GetElasticsearchEnvVars(ctx, stack.Name)
+	if err != nil {
+		return err
+	}
+	env = append(env, esEnvVars...)
+
+	// Workers: inject KAFKA_TOPICS from their respective consumer
+	if (deploymentType == DeploymentTypeWorkerIngestion || deploymentType == DeploymentTypeWorkerMatching) && consumer != nil {
+		topics, err := brokers.GetTopicsEnvVars(ctx, stack, "KAFKA_TOPICS", consumer.Spec.Services...)
+		if err != nil {
+			return err
+		}
+		env = append(env, topics...)
+	}
+
+	// Ingestion worker: publish to {stack}.reconciliation
+	if deploymentType == DeploymentTypeWorkerIngestion {
+		env = append(env, core.Env("PUBLISHER_TOPIC_MAPPING", fmt.Sprintf("*:%s.reconciliation", stack.Name)))
+	}
 
 	serviceAccountName, err := settings.GetAWSServiceAccount(ctx, stack.Name)
 	if err != nil {
@@ -61,7 +173,7 @@ func createDeployment(
 	return applications.
 		New(reconciliation, &appsv1.Deployment{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: "reconciliation",
+				Name: metaName,
 			},
 			Spec: appsv1.DeploymentSpec{
 				Template: v1.PodTemplateSpec{
@@ -69,9 +181,10 @@ func createDeployment(
 						ImagePullSecrets:   imageConfiguration.PullSecrets,
 						ServiceAccountName: serviceAccountName,
 						Containers: []v1.Container{{
-							Name:           "reconciliation",
+							Name:           containerName,
 							Env:            env,
 							Image:          imageConfiguration.GetFullImageName(),
+							Args:           args,
 							Ports:          []v1.ContainerPort{applications.StandardHTTPPort()},
 							LivenessProbe:  applications.DefaultLiveness("http"),
 							ReadinessProbe: applications.DefaultReadiness("http"),
@@ -83,3 +196,4 @@ func createDeployment(
 		IsEE().
 		Install(ctx)
 }
+

--- a/internal/resources/settings/elasticsearch.go
+++ b/internal/resources/settings/elasticsearch.go
@@ -1,0 +1,56 @@
+package settings
+
+import (
+	v1 "k8s.io/api/core/v1"
+
+	"github.com/formancehq/operator/api/formance.com/v1beta1"
+	"github.com/formancehq/operator/internal/core"
+)
+
+// GetElasticsearchEnvVars returns environment variables for Elasticsearch configuration.
+// Returns an error if elasticsearch.dsn is not configured (required setting).
+func GetElasticsearchEnvVars(ctx core.Context, stackName string) ([]v1.EnvVar, error) {
+	esURL, err := RequireURL(ctx, stackName, "elasticsearch", "dsn")
+	if err != nil {
+		return nil, err
+	}
+
+	env := []v1.EnvVar{
+		core.Env("ELASTICSEARCH_URL", esURL.WithoutQuery().String()),
+	}
+
+	// Username/Password from query params (optional)
+	if username := esURL.Query().Get("username"); username != "" {
+		env = append(env, core.Env("ELASTICSEARCH_USERNAME", username))
+	}
+
+	if password := esURL.Query().Get("password"); password != "" {
+		env = append(env, core.Env("ELASTICSEARCH_PASSWORD", password))
+	}
+
+	// ILM Configuration with defaults
+	env = append(env, core.Env("ELASTICSEARCH_ILM_ENABLED",
+		getQueryParamOrDefault(esURL, "ilmEnabled", "true")))
+
+	env = append(env, core.Env("ELASTICSEARCH_ILM_HOT_PHASE_DAYS",
+		getQueryParamOrDefault(esURL, "ilmHotPhaseDays", "90")))
+
+	env = append(env, core.Env("ELASTICSEARCH_ILM_WARM_PHASE_ROLLOVER_DAYS",
+		getQueryParamOrDefault(esURL, "ilmWarmPhaseRolloverDays", "365")))
+
+	env = append(env, core.Env("ELASTICSEARCH_ILM_DELETE_PHASE_ENABLED",
+		getQueryParamOrDefault(esURL, "ilmDeletePhaseEnabled", "false")))
+
+	env = append(env, core.Env("ELASTICSEARCH_ILM_DELETE_PHASE_DAYS",
+		getQueryParamOrDefault(esURL, "ilmDeletePhaseDays", "0")))
+
+	return env, nil
+}
+
+// getQueryParamOrDefault extracts a query parameter from the URI or returns the default value.
+func getQueryParamOrDefault(uri *v1beta1.URI, key, defaultValue string) string {
+	if value := uri.Query().Get(key); value != "" {
+		return value
+	}
+	return defaultValue
+}

--- a/internal/tests/reconciliation_controller_test.go
+++ b/internal/tests/reconciliation_controller_test.go
@@ -1,0 +1,220 @@
+package tests_test
+
+import (
+	"fmt"
+
+	"github.com/google/uuid"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+
+	v1beta1 "github.com/formancehq/operator/api/formance.com/v1beta1"
+	core "github.com/formancehq/operator/internal/core"
+	"github.com/formancehq/operator/internal/resources/settings"
+	. "github.com/formancehq/operator/internal/tests/internal"
+)
+
+var _ = Describe("ReconciliationController", func() {
+	Context("When creating a Reconciliation object", func() {
+		var (
+			stack                 *v1beta1.Stack
+			gateway               *v1beta1.Gateway
+			auth                  *v1beta1.Auth
+			ledger                *v1beta1.Ledger
+			payments              *v1beta1.Payments
+			reconciliation        *v1beta1.Reconciliation
+			databaseSettings      *v1beta1.Settings
+			brokerDSNSettings     *v1beta1.Settings
+			elasticsearchSettings *v1beta1.Settings
+		)
+		BeforeEach(func() {
+			stack = &v1beta1.Stack{
+				ObjectMeta: RandObjectMeta(),
+				Spec:       v1beta1.StackSpec{},
+			}
+			databaseSettings = settings.New(uuid.NewString(), "postgres.*.uri", "postgresql://localhost", stack.Name)
+			brokerDSNSettings = settings.New(uuid.NewString(), "broker.dsn", "nats://localhost:1234", stack.Name)
+			elasticsearchSettings = settings.New(uuid.NewString(), "elasticsearch.dsn", "https://elasticsearch:9200?username=elastic&password=changeme&ilmEnabled=true&ilmHotPhaseDays=30", stack.Name)
+			gateway = &v1beta1.Gateway{
+				ObjectMeta: RandObjectMeta(),
+				Spec: v1beta1.GatewaySpec{
+					StackDependency: v1beta1.StackDependency{
+						Stack: stack.Name,
+					},
+					Ingress: &v1beta1.GatewayIngress{},
+				},
+			}
+			auth = &v1beta1.Auth{
+				ObjectMeta: RandObjectMeta(),
+				Spec: v1beta1.AuthSpec{
+					StackDependency: v1beta1.StackDependency{
+						Stack: stack.Name,
+					},
+				},
+			}
+			ledger = &v1beta1.Ledger{
+				ObjectMeta: RandObjectMeta(),
+				Spec: v1beta1.LedgerSpec{
+					StackDependency: v1beta1.StackDependency{
+						Stack: stack.Name,
+					},
+				},
+			}
+			payments = &v1beta1.Payments{
+				ObjectMeta: RandObjectMeta(),
+				Spec: v1beta1.PaymentsSpec{
+					StackDependency: v1beta1.StackDependency{
+						Stack: stack.Name,
+					},
+				},
+			}
+			reconciliation = &v1beta1.Reconciliation{
+				ObjectMeta: RandObjectMeta(),
+				Spec: v1beta1.ReconciliationSpec{
+					StackDependency: v1beta1.StackDependency{
+						Stack: stack.Name,
+					},
+				},
+			}
+		})
+		JustBeforeEach(func() {
+			Expect(Create(stack)).To(Succeed())
+			Expect(Create(databaseSettings)).To(Succeed())
+			Expect(Create(brokerDSNSettings)).To(BeNil())
+			Expect(Create(elasticsearchSettings)).To(Succeed())
+			Expect(Create(gateway)).To(Succeed())
+			Expect(Create(auth)).To(Succeed())
+			Expect(Create(ledger)).To(Succeed())
+			Expect(Create(payments)).To(Succeed())
+			Expect(Create(reconciliation)).To(Succeed())
+		})
+		AfterEach(func() {
+			Expect(Delete(stack)).To(Succeed())
+			Expect(Delete(databaseSettings)).To(Succeed())
+			Expect(Delete(brokerDSNSettings)).To(Succeed())
+			Expect(Delete(elasticsearchSettings)).To(Succeed())
+		})
+		It("Should create appropriate components", func() {
+			By("Should set the status to ready", func() {
+				Eventually(func(g Gomega) bool {
+					g.Expect(LoadResource("", reconciliation.Name, reconciliation)).To(Succeed())
+					return reconciliation.Status.Ready
+				}).Should(BeTrue())
+			})
+			By("Should add an owner reference on the stack", func() {
+				Eventually(func(g Gomega) bool {
+					g.Expect(LoadResource("", reconciliation.Name, reconciliation)).To(Succeed())
+					reference, err := core.HasOwnerReference(TestContext(), stack, reconciliation)
+					g.Expect(err).To(BeNil())
+					return reference
+				}).Should(BeTrue())
+			})
+			By("Should create an API deployment", func() {
+				deployment := &appsv1.Deployment{}
+				Eventually(func() error {
+					return LoadResource(stack.Name, "reconciliation", deployment)
+				}).Should(Succeed())
+				Expect(deployment).To(BeControlledBy(reconciliation))
+				Expect(deployment.Spec.Template.Spec.Containers[0].Name).To(Equal("reconciliation"))
+				Expect(deployment.Spec.Template.Spec.Containers[0].Args).To(Equal([]string{"serve"}))
+			})
+			By("Should create a worker deployment", func() {
+				deployment := &appsv1.Deployment{}
+				Eventually(func() error {
+					return LoadResource(stack.Name, "reconciliation-worker", deployment)
+				}).Should(Succeed())
+				Expect(deployment).To(BeControlledBy(reconciliation))
+				Expect(deployment.Spec.Template.Spec.Containers[0].Name).To(Equal("reconciliation-worker"))
+				Expect(deployment.Spec.Template.Spec.Containers[0].Args).To(Equal([]string{"worker"}))
+			})
+			By("API deployment should have broker environment variables", func() {
+				deployment := &appsv1.Deployment{}
+				Eventually(func() error {
+					return LoadResource(stack.Name, "reconciliation", deployment)
+				}).Should(Succeed())
+				Expect(deployment.Spec.Template.Spec.Containers[0].Env).To(ContainElements(
+					core.Env("BROKER", "nats"),
+					core.Env("PUBLISHER_NATS_ENABLED", "true"),
+				))
+			})
+			By("Worker deployment should have broker environment variables", func() {
+				deployment := &appsv1.Deployment{}
+				Eventually(func() error {
+					return LoadResource(stack.Name, "reconciliation-worker", deployment)
+				}).Should(Succeed())
+				Expect(deployment.Spec.Template.Spec.Containers[0].Env).To(ContainElements(
+					core.Env("BROKER", "nats"),
+					core.Env("PUBLISHER_NATS_ENABLED", "true"),
+				))
+			})
+			By("Worker deployment should have topics environment variable", func() {
+				deployment := &appsv1.Deployment{}
+				Eventually(func() error {
+					return LoadResource(stack.Name, "reconciliation-worker", deployment)
+				}).Should(Succeed())
+				Expect(deployment.Spec.Template.Spec.Containers[0].Env).To(ContainElement(
+					core.Env("KAFKA_TOPICS", fmt.Sprintf("%s.ledger %s.payments", stack.Name, stack.Name)),
+				))
+			})
+			By("API deployment should NOT have topics environment variable", func() {
+				deployment := &appsv1.Deployment{}
+				Eventually(func() error {
+					return LoadResource(stack.Name, "reconciliation", deployment)
+				}).Should(Succeed())
+				for _, envVar := range deployment.Spec.Template.Spec.Containers[0].Env {
+					Expect(envVar.Name).NotTo(Equal("KAFKA_TOPICS"))
+				}
+			})
+			By("Should create a new GatewayHTTPAPI object", func() {
+				httpService := &v1beta1.GatewayHTTPAPI{}
+				Eventually(func() error {
+					return LoadResource("", core.GetObjectName(stack.Name, "reconciliation"), httpService)
+				}).Should(Succeed())
+			})
+			By("Should create a new AuthClient object", func() {
+				authClient := &v1beta1.AuthClient{}
+				Eventually(func() error {
+					return LoadResource("", core.GetObjectName(stack.Name, "reconciliation"), authClient)
+				}).Should(Succeed())
+			})
+			By("Should create a new BrokerConsumer object", func() {
+				consumer := &v1beta1.BrokerConsumer{}
+				Eventually(func() error {
+					return LoadResource("", reconciliation.Name+"-reconciliation", consumer)
+				}).Should(Succeed())
+			})
+			By("BrokerConsumer should have correct services", func() {
+				consumer := &v1beta1.BrokerConsumer{}
+				Eventually(func(g Gomega) []string {
+					g.Expect(LoadResource("", reconciliation.Name+"-reconciliation", consumer)).To(Succeed())
+					return consumer.Spec.Services
+				}).Should(ContainElements("ledger", "payments"))
+			})
+			By("Worker deployment should have Elasticsearch environment variables", func() {
+				deployment := &appsv1.Deployment{}
+				Eventually(func() error {
+					return LoadResource(stack.Name, "reconciliation-worker", deployment)
+				}).Should(Succeed())
+				Expect(deployment.Spec.Template.Spec.Containers[0].Env).To(ContainElements(
+					core.Env("ELASTICSEARCH_URL", "https://elasticsearch:9200"),
+					core.Env("ELASTICSEARCH_USERNAME", "elastic"),
+					core.Env("ELASTICSEARCH_PASSWORD", "changeme"),
+					core.Env("ELASTICSEARCH_ILM_ENABLED", "true"),
+					core.Env("ELASTICSEARCH_ILM_HOT_PHASE_DAYS", "30"),
+					core.Env("ELASTICSEARCH_ILM_WARM_PHASE_ROLLOVER_DAYS", "365"),
+					core.Env("ELASTICSEARCH_ILM_DELETE_PHASE_ENABLED", "false"),
+					core.Env("ELASTICSEARCH_ILM_DELETE_PHASE_DAYS", "0"),
+				))
+			})
+			By("API deployment should NOT have Elasticsearch environment variables", func() {
+				deployment := &appsv1.Deployment{}
+				Eventually(func() error {
+					return LoadResource(stack.Name, "reconciliation", deployment)
+				}).Should(Succeed())
+				for _, envVar := range deployment.Spec.Template.Spec.Containers[0].Env {
+					Expect(envVar.Name).NotTo(Equal("ELASTICSEARCH_URL"))
+				}
+			})
+		})
+	})
+})


### PR DESCRIPTION
## Summary
- Split the single reconciliation worker into two dedicated workers: **ingestion** (`worker ingestion`) and **matching** (`worker matching`)
- Ingestion worker consumes `ledger`/`payments` broker topics and publishes to `{stack}.reconciliation`
- Matching worker consumes from the `reconciliation` topic via its own BrokerConsumer with a distinct NATS deliver queue group
- Clean up legacy single worker BrokerConsumer and Deployment on reconciliation
- Fix duplicate `POD_NAME` env var when both OTEL traces and metrics are enabled
- Add Elasticsearch env vars support for reconciliation deployments

## Test plan
- [ ] Verify ingestion worker deployment has `KAFKA_TOPICS` for ledger/payments and `PUBLISHER_TOPIC_MAPPING` for reconciliation
- [ ] Verify matching worker deployment has `KAFKA_TOPICS` for reconciliation only
- [ ] Verify NATS deliver queue groups are distinct (`reconciliation_ingestion` / `reconciliation_matching`)
- [ ] Verify legacy `reconciliation-worker` deployment and old BrokerConsumer are cleaned up
- [ ] Verify `POD_NAME` env var appears only once per pod