### PR TITLE
fix(tests): reset settings slice in application test to prevent flakiness

### DIFF
--- a/internal/tests/application_test.go
+++ b/internal/tests/application_test.go
@@ -22,10 +22,10 @@ var _ = Context("When creating a Application", func() {
 			ObjectMeta: RandObjectMeta(),
 			Spec:       v1beta1.StackSpec{},
 		}
-		settings = append(settings,
+		settings = []*v1beta1.Settings{
 			coresettings.New(uuid.NewString(), "postgres.*.uri", "postgresql://localhost", stack.Name),
 			coresettings.New(uuid.NewString(), "deployments.*.spec.template.annotations", "annotations=annotations", stack.Name),
-		)
+		}
 		ledger = &v1beta1.Ledger{
 			ObjectMeta: RandObjectMeta(),
 			Spec: v1beta1.LedgerSpec{


### PR DESCRIPTION
The settings slice was appended to in BeforeEach instead of being reset, causing stale objects with metadata from previous tests to accumulate. This made the NODE_IP test fail when it ran after the annotations test.