### PR TITLE
chore(release): v3.9.0

### DIFF
--- a/helm/crds/Chart.yaml
+++ b/helm/crds/Chart.yaml
@@ -12,9 +12,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: "3.8.0"
+version: "3.9.0"
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: v3.8.0
+appVersion: v3.9.0

--- a/helm/operator/Chart.lock
+++ b/helm/operator/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: operator-crds
   repository: file://../crds
-  version: 3.8.0
-digest: sha256:580f97026a858af94473d18ae7037785828fd41ad002e373f05a35ee9d7c4a31
-generated: "2026-02-26T14:30:57.237157+01:00"
+  version: 3.9.0
+digest: sha256:cab8a96173b733f60c6776e75b69b1ec54e2fb0652ef4f96a889c8f41506af1f
+generated: "2026-03-10T09:40:10.545125+01:00"

--- a/helm/operator/Chart.yaml
+++ b/helm/operator/Chart.yaml
@@ -12,12 +12,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: "3.8.0"
+version: "3.9.0"
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v3.8.0"
+appVersion: "v3.9.0"
 dependencies:
 - name: operator-crds
   version: "3.X"


### PR DESCRIPTION
## Summary
- Bump Helm chart versions (operator + CRDs) to 3.9.0

### Changes included in v3.9.0 (since v3.8.0)
- **feat(databases):** pass through arbitrary PostgreSQL query params (#415)
- **fix(core):** prevent panic on nil spec in unstructured type assertions (#416)

## Test plan
- [ ] CI passes
- [ ] Helm lint and template validation passed via `just pre-commit`