### PR TITLE
fix(core): replace "latest" version fallback with explicit error

### DIFF
--- a/api/formance.com/v1beta1/stack_types.go
+++ b/api/formance.com/v1beta1/stack_types.go
@@ -74,7 +74,7 @@ type StackStatus struct {
 //
 // The `version` field will have priority over `versionFromFile`.
 //
-// If `versions` and `versionsFromFile` are not specified, "latest" will be used.
+// If `versions` and `versionsFromFile` are not specified, modules will fail to reconcile with an explicit error.
 type Stack struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -96,9 +96,6 @@ func (in *Stack) SetError(s string) {
 }
 
 func (in *Stack) GetVersion() string {
-	if in.Spec.Version == "" {
-		return "latest"
-	}
 	return in.Spec.Version
 }
 

--- a/config/crd/bases/formance.com_stacks.yaml
+++ b/config/crd/bases/formance.com_stacks.yaml
@@ -59,7 +59,7 @@ spec:
 
           The `version` field will have priority over `versionFromFile`.
 
-          If `versions` and `versionsFromFile` are not specified, "latest" will be used.
+          If `versions` and `versionsFromFile` are not specified, modules will fail to reconcile with an explicit error.
         properties:
           apiVersion:
             description: |-

--- a/docs/09-Configuration reference/02-Custom Resource Definitions.md
+++ b/docs/09-Configuration reference/02-Custom Resource Definitions.md
@@ -60,7 +60,7 @@ It can be specified using either the field `.spec.version` or the `.spec.version
 
 The `version` field will have priority over `versionFromFile`.
 
-If `versions` and `versionsFromFile` are not specified, "latest" will be used.
+If `versions` and `versionsFromFile` are not specified, modules will fail to reconcile with an explicit error.
 
 
 

--- a/helm/crds/templates/crds/apiextensions.k8s.io_v1_customresourcedefinition_stacks.formance.com.yaml
+++ b/helm/crds/templates/crds/apiextensions.k8s.io_v1_customresourcedefinition_stacks.formance.com.yaml
@@ -62,7 +62,7 @@ spec:
 
           The `version` field will have priority over `versionFromFile`.
 
-          If `versions` and `versionsFromFile` are not specified, "latest" will be used.
+          If `versions` and `versionsFromFile` are not specified, modules will fail to reconcile with an explicit error.
         properties:
           apiVersion:
             description: |-

--- a/internal/core/version.go
+++ b/internal/core/version.go
@@ -1,6 +1,8 @@
 package core
 
 import (
+	"errors"
+	"fmt"
 	"strings"
 
 	"golang.org/x/mod/semver"
@@ -10,7 +12,17 @@ import (
 	"github.com/formancehq/operator/v3/api/formance.com/v1beta1"
 )
 
+// ErrNoVersionFound is returned when no version can be resolved for a module
+// through any of the configured sources (module, stack, or versionsFromFile).
+var ErrNoVersionFound = errors.New("no version found")
+
 func GetModuleVersion(ctx Context, stack *v1beta1.Stack, module v1beta1.Module) (string, error) {
+	kinds, _, err := ctx.GetScheme().ObjectKinds(module)
+	if err != nil {
+		return "", fmt.Errorf("resolving module kind: %w", err)
+	}
+	kind := strings.ToLower(kinds[0].Kind)
+
 	if module.GetVersion() != "" {
 		return module.GetVersion(), nil
 	}
@@ -26,20 +38,15 @@ func GetModuleVersion(ctx Context, stack *v1beta1.Stack, module v1beta1.Module) 
 			return "", err
 		}
 		if err == nil {
-			kinds, _, err := ctx.GetScheme().ObjectKinds(module)
-			if err != nil {
-				return "", err
-			}
-			kind := strings.ToLower(kinds[0].Kind)
-
 			version, ok := versions.Spec[kind]
 			if ok && version != "" {
 				return version, nil
 			}
 		}
+		return "", fmt.Errorf("%w for module %s on stack %s: module not found in Versions resource %s", ErrNoVersionFound, kind, stack.Name, stack.Spec.VersionsFromFile)
 	}
 
-	return "latest", nil
+	return "", fmt.Errorf("%w for module %s on stack %s: stack must define spec.version, spec.versionsFromFile, or the module must define its own version", ErrNoVersionFound, kind, stack.Name)
 }
 
 func IsGreaterOrEqual(version string, than string) bool {

--- a/internal/resources/payments/finalizer.go
+++ b/internal/resources/payments/finalizer.go
@@ -1,6 +1,8 @@
 package payments
 
 import (
+	"errors"
+
 	"golang.org/x/mod/semver"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -22,6 +24,10 @@ func Clean(ctx core.Context, t *v1beta1.Payments) error {
 
 	version, err := core.GetModuleVersion(ctx, stack, t)
 	if err != nil {
+		if errors.Is(err, core.ErrNoVersionFound) {
+			log.FromContext(ctx).Info("No version configured, skipping version-gated finalizer logic")
+			return nil
+		}
 		return err
 	}
 	if semver.IsValid(version) && semver.Compare(version, "v3.0.0-beta.1") < 0 {

--- a/internal/tests/application_test.go
+++ b/internal/tests/application_test.go
@@ -20,7 +20,7 @@ var _ = Context("When creating a Application", func() {
 	BeforeEach(func() {
 		stack = &v1beta1.Stack{
 			ObjectMeta: RandObjectMeta(),
-			Spec:       v1beta1.StackSpec{},
+			Spec:       v1beta1.StackSpec{Version: "v1.0.0"},
 		}
 		settings = []*v1beta1.Settings{
 			coresettings.New(uuid.NewString(), "postgres.*.uri", "postgresql://localhost", stack.Name),

--- a/internal/tests/application_test.go
+++ b/internal/tests/application_test.go
@@ -20,7 +20,7 @@ var _ = Context("When creating a Application", func() {
 	BeforeEach(func() {
 		stack = &v1beta1.Stack{
 			ObjectMeta: RandObjectMeta(),
-			Spec:       v1beta1.StackSpec{Version: "v1.0.0"},
+			Spec:       v1beta1.StackSpec{Version: "v99.0.0"},
 		}
 		settings = []*v1beta1.Settings{
 			coresettings.New(uuid.NewString(), "postgres.*.uri", "postgresql://localhost", stack.Name),

--- a/internal/tests/auth_controller_test.go
+++ b/internal/tests/auth_controller_test.go
@@ -31,7 +31,7 @@ var _ = Describe("AuthController", func() {
 		BeforeEach(func() {
 			stack = &v1beta1.Stack{
 				ObjectMeta: RandObjectMeta(),
-				Spec:       v1beta1.StackSpec{},
+				Spec:       v1beta1.StackSpec{Version: "v1.0.0"},
 			}
 			databaseSettings = settings.New(uuid.NewString(), "postgres.*.uri", "postgresql://localhost", stack.Name)
 			pdbSettings = settings.New(uuid.NewString(), "deployments.*.pod-disruption-budget", "minAvailable=1", stack.Name)

--- a/internal/tests/auth_controller_test.go
+++ b/internal/tests/auth_controller_test.go
@@ -31,7 +31,7 @@ var _ = Describe("AuthController", func() {
 		BeforeEach(func() {
 			stack = &v1beta1.Stack{
 				ObjectMeta: RandObjectMeta(),
-				Spec:       v1beta1.StackSpec{Version: "v1.0.0"},
+				Spec:       v1beta1.StackSpec{Version: "v99.0.0"},
 			}
 			databaseSettings = settings.New(uuid.NewString(), "postgres.*.uri", "postgresql://localhost", stack.Name)
 			pdbSettings = settings.New(uuid.NewString(), "deployments.*.pod-disruption-budget", "minAvailable=1", stack.Name)

--- a/internal/tests/auth_scopes_settings_test.go
+++ b/internal/tests/auth_scopes_settings_test.go
@@ -26,7 +26,7 @@ var _ = Describe("AuthScopesSettings", func() {
 		BeforeEach(func() {
 			stack = &v1beta1.Stack{
 				ObjectMeta: RandObjectMeta(),
-				Spec:       v1beta1.StackSpec{Version: "v1.0.0"},
+				Spec:       v1beta1.StackSpec{Version: "v99.0.0"},
 			}
 			databaseSettings = settings.New(uuid.NewString(), "postgres.*.uri", "postgresql://localhost", stack.Name)
 			auth = &v1beta1.Auth{

--- a/internal/tests/auth_scopes_settings_test.go
+++ b/internal/tests/auth_scopes_settings_test.go
@@ -26,7 +26,7 @@ var _ = Describe("AuthScopesSettings", func() {
 		BeforeEach(func() {
 			stack = &v1beta1.Stack{
 				ObjectMeta: RandObjectMeta(),
-				Spec:       v1beta1.StackSpec{},
+				Spec:       v1beta1.StackSpec{Version: "v1.0.0"},
 			}
 			databaseSettings = settings.New(uuid.NewString(), "postgres.*.uri", "postgresql://localhost", stack.Name)
 			auth = &v1beta1.Auth{

--- a/internal/tests/authclient_controller_test.go
+++ b/internal/tests/authclient_controller_test.go
@@ -21,7 +21,7 @@ var _ = Describe("AuthClientController", func() {
 		BeforeEach(func() {
 			stack = &v1beta1.Stack{
 				ObjectMeta: RandObjectMeta(),
-				Spec:       v1beta1.StackSpec{Version: "v1.0.0"},
+				Spec:       v1beta1.StackSpec{Version: "v99.0.0"},
 			}
 			authClient = &v1beta1.AuthClient{
 				ObjectMeta: RandObjectMeta(),

--- a/internal/tests/authclient_controller_test.go
+++ b/internal/tests/authclient_controller_test.go
@@ -21,7 +21,7 @@ var _ = Describe("AuthClientController", func() {
 		BeforeEach(func() {
 			stack = &v1beta1.Stack{
 				ObjectMeta: RandObjectMeta(),
-				Spec:       v1beta1.StackSpec{},
+				Spec:       v1beta1.StackSpec{Version: "v1.0.0"},
 			}
 			authClient = &v1beta1.AuthClient{
 				ObjectMeta: RandObjectMeta(),

--- a/internal/tests/benthos_controller_test.go
+++ b/internal/tests/benthos_controller_test.go
@@ -26,7 +26,7 @@ var _ = Describe("BenthosController", func() {
 		BeforeEach(func() {
 			stack = &v1beta1.Stack{
 				ObjectMeta: RandObjectMeta(),
-				Spec:       v1beta1.StackSpec{Version: "v1.0.0"},
+				Spec:       v1beta1.StackSpec{Version: "v99.0.0"},
 			}
 			broker = &v1beta1.Broker{
 				ObjectMeta: v1.ObjectMeta{

--- a/internal/tests/benthos_controller_test.go
+++ b/internal/tests/benthos_controller_test.go
@@ -26,7 +26,7 @@ var _ = Describe("BenthosController", func() {
 		BeforeEach(func() {
 			stack = &v1beta1.Stack{
 				ObjectMeta: RandObjectMeta(),
-				Spec:       v1beta1.StackSpec{},
+				Spec:       v1beta1.StackSpec{Version: "v1.0.0"},
 			}
 			broker = &v1beta1.Broker{
 				ObjectMeta: v1.ObjectMeta{

--- a/internal/tests/benthosstream_controller_test.go
+++ b/internal/tests/benthosstream_controller_test.go
@@ -19,7 +19,7 @@ var _ = Describe("StreamController", func() {
 		BeforeEach(func() {
 			stack = &v1beta1.Stack{
 				ObjectMeta: RandObjectMeta(),
-				Spec:       v1beta1.StackSpec{Version: "v1.0.0"},
+				Spec:       v1beta1.StackSpec{Version: "v99.0.0"},
 			}
 			Expect(Create(stack)).To(BeNil())
 			stream = &v1beta1.BenthosStream{

--- a/internal/tests/benthosstream_controller_test.go
+++ b/internal/tests/benthosstream_controller_test.go
@@ -19,7 +19,7 @@ var _ = Describe("StreamController", func() {
 		BeforeEach(func() {
 			stack = &v1beta1.Stack{
 				ObjectMeta: RandObjectMeta(),
-				Spec:       v1beta1.StackSpec{},
+				Spec:       v1beta1.StackSpec{Version: "v1.0.0"},
 			}
 			Expect(Create(stack)).To(BeNil())
 			stream = &v1beta1.BenthosStream{

--- a/internal/tests/brokerconsumer_controller_test.go
+++ b/internal/tests/brokerconsumer_controller_test.go
@@ -22,7 +22,7 @@ var _ = Describe("BrokerConsumer", func() {
 		BeforeEach(func() {
 			stack = &v1beta1.Stack{
 				ObjectMeta: RandObjectMeta(),
-				Spec:       v1beta1.StackSpec{Version: "v1.0.0"},
+				Spec:       v1beta1.StackSpec{Version: "v99.0.0"},
 			}
 			Expect(Create(stack)).To(BeNil())
 			brokerNatsDSNSettings = settings.New(uuid.NewString(), "broker.dsn", "nats://localhost:1234", stack.Name)

--- a/internal/tests/brokerconsumer_controller_test.go
+++ b/internal/tests/brokerconsumer_controller_test.go
@@ -22,7 +22,7 @@ var _ = Describe("BrokerConsumer", func() {
 		BeforeEach(func() {
 			stack = &v1beta1.Stack{
 				ObjectMeta: RandObjectMeta(),
-				Spec:       v1beta1.StackSpec{},
+				Spec:       v1beta1.StackSpec{Version: "v1.0.0"},
 			}
 			Expect(Create(stack)).To(BeNil())
 			brokerNatsDSNSettings = settings.New(uuid.NewString(), "broker.dsn", "nats://localhost:1234", stack.Name)

--- a/internal/tests/brokertopic_controller_test.go
+++ b/internal/tests/brokertopic_controller_test.go
@@ -26,7 +26,7 @@ var _ = Describe("BrokerTopicController", func() {
 				ObjectMeta: v1.ObjectMeta{
 					Name: uuid.NewString(),
 				},
-				Spec: v1beta1.StackSpec{Version: "v1.0.0"},
+				Spec: v1beta1.StackSpec{Version: "v99.0.0"},
 			}
 			Expect(Create(stack)).To(BeNil())
 			brokerDSNSettings = settings.New(uuid.NewString(), "broker.dsn", "nats://localhost:1234", stack.Name)

--- a/internal/tests/brokertopic_controller_test.go
+++ b/internal/tests/brokertopic_controller_test.go
@@ -26,7 +26,7 @@ var _ = Describe("BrokerTopicController", func() {
 				ObjectMeta: v1.ObjectMeta{
 					Name: uuid.NewString(),
 				},
-				Spec: v1beta1.StackSpec{},
+				Spec: v1beta1.StackSpec{Version: "v1.0.0"},
 			}
 			Expect(Create(stack)).To(BeNil())
 			brokerDSNSettings = settings.New(uuid.NewString(), "broker.dsn", "nats://localhost:1234", stack.Name)

--- a/internal/tests/database_controller_test.go
+++ b/internal/tests/database_controller_test.go
@@ -27,7 +27,7 @@ var _ = Describe("DatabaseController", func() {
 		BeforeEach(func() {
 			stack = &v1beta1.Stack{
 				ObjectMeta: RandObjectMeta(),
-				Spec:       v1beta1.StackSpec{Version: "v1.0.0"},
+				Spec:       v1beta1.StackSpec{Version: "v99.0.0"},
 			}
 			databaseSettings = settings.New(uuid.NewString(), "postgres.*.uri", "postgresql://localhost", stack.Name)
 			database = &v1beta1.Database{

--- a/internal/tests/database_controller_test.go
+++ b/internal/tests/database_controller_test.go
@@ -27,7 +27,7 @@ var _ = Describe("DatabaseController", func() {
 		BeforeEach(func() {
 			stack = &v1beta1.Stack{
 				ObjectMeta: RandObjectMeta(),
-				Spec:       v1beta1.StackSpec{},
+				Spec:       v1beta1.StackSpec{Version: "v1.0.0"},
 			}
 			databaseSettings = settings.New(uuid.NewString(), "postgres.*.uri", "postgresql://localhost", stack.Name)
 			database = &v1beta1.Database{

--- a/internal/tests/gateway_controller_test.go
+++ b/internal/tests/gateway_controller_test.go
@@ -30,7 +30,7 @@ var _ = Describe("GatewayController", func() {
 		BeforeEach(func() {
 			stack = &v1beta1.Stack{
 				ObjectMeta: RandObjectMeta(),
-				Spec:       v1beta1.StackSpec{Version: "v1.0.0"},
+				Spec:       v1beta1.StackSpec{Version: "v99.0.0"},
 			}
 			gateway = &v1beta1.Gateway{
 				ObjectMeta: RandObjectMeta(),

--- a/internal/tests/gateway_controller_test.go
+++ b/internal/tests/gateway_controller_test.go
@@ -30,7 +30,7 @@ var _ = Describe("GatewayController", func() {
 		BeforeEach(func() {
 			stack = &v1beta1.Stack{
 				ObjectMeta: RandObjectMeta(),
-				Spec:       v1beta1.StackSpec{},
+				Spec:       v1beta1.StackSpec{Version: "v1.0.0"},
 			}
 			gateway = &v1beta1.Gateway{
 				ObjectMeta: RandObjectMeta(),

--- a/internal/tests/gatewayhttpapi_controller_test.go
+++ b/internal/tests/gatewayhttpapi_controller_test.go
@@ -22,7 +22,7 @@ var _ = Describe("GatewayHTTPAPI", func() {
 
 			stack = &v1beta1.Stack{
 				ObjectMeta: RandObjectMeta(),
-				Spec:       v1beta1.StackSpec{Version: "v1.0.0"},
+				Spec:       v1beta1.StackSpec{Version: "v99.0.0"},
 			}
 			httpAPI = &v1beta1.GatewayHTTPAPI{
 				ObjectMeta: RandObjectMeta(),

--- a/internal/tests/gatewayhttpapi_controller_test.go
+++ b/internal/tests/gatewayhttpapi_controller_test.go
@@ -22,7 +22,7 @@ var _ = Describe("GatewayHTTPAPI", func() {
 
 			stack = &v1beta1.Stack{
 				ObjectMeta: RandObjectMeta(),
-				Spec:       v1beta1.StackSpec{},
+				Spec:       v1beta1.StackSpec{Version: "v1.0.0"},
 			}
 			httpAPI = &v1beta1.GatewayHTTPAPI{
 				ObjectMeta: RandObjectMeta(),

--- a/internal/tests/jobs_controller_test.go
+++ b/internal/tests/jobs_controller_test.go
@@ -41,7 +41,7 @@ var _ = Describe("Job", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Name: uuid.NewString()[:8],
 			},
-			Spec: v1beta1.StackSpec{Version: "v1.0.0"},
+			Spec: v1beta1.StackSpec{Version: "v99.0.0"},
 		}
 		runAS = &runAs{
 			user:  rand.IntN(65534),

--- a/internal/tests/jobs_controller_test.go
+++ b/internal/tests/jobs_controller_test.go
@@ -41,6 +41,7 @@ var _ = Describe("Job", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Name: uuid.NewString()[:8],
 			},
+			Spec: v1beta1.StackSpec{Version: "v1.0.0"},
 		}
 		runAS = &runAs{
 			user:  rand.IntN(65534),

--- a/internal/tests/ledger_controller_test.go
+++ b/internal/tests/ledger_controller_test.go
@@ -25,7 +25,7 @@ var _ = Describe("LedgerController", func() {
 		BeforeEach(func() {
 			stack = &v1beta1.Stack{
 				ObjectMeta: RandObjectMeta(),
-				Spec:       v1beta1.StackSpec{},
+				Spec:       v1beta1.StackSpec{Version: "v1.0.0"},
 			}
 			databaseSettings = settings.New(uuid.NewString(), "postgres.*.uri", "postgresql://localhost", stack.Name)
 			ledger = &v1beta1.Ledger{

--- a/internal/tests/ledger_controller_test.go
+++ b/internal/tests/ledger_controller_test.go
@@ -25,7 +25,7 @@ var _ = Describe("LedgerController", func() {
 		BeforeEach(func() {
 			stack = &v1beta1.Stack{
 				ObjectMeta: RandObjectMeta(),
-				Spec:       v1beta1.StackSpec{Version: "v1.0.0"},
+				Spec:       v1beta1.StackSpec{Version: "v99.0.0"},
 			}
 			databaseSettings = settings.New(uuid.NewString(), "postgres.*.uri", "postgresql://localhost", stack.Name)
 			ledger = &v1beta1.Ledger{

--- a/internal/tests/networkpolicy_controller_test.go
+++ b/internal/tests/networkpolicy_controller_test.go
@@ -20,7 +20,7 @@ var _ = Describe("NetworkPolicyController", func() {
 		BeforeEach(func() {
 			stack = &v1beta1.Stack{
 				ObjectMeta: RandObjectMeta(),
-				Spec:       v1beta1.StackSpec{Version: "v1.0.0"},
+				Spec:       v1beta1.StackSpec{Version: "v99.0.0"},
 			}
 		})
 		JustBeforeEach(func() {

--- a/internal/tests/networkpolicy_controller_test.go
+++ b/internal/tests/networkpolicy_controller_test.go
@@ -20,7 +20,7 @@ var _ = Describe("NetworkPolicyController", func() {
 		BeforeEach(func() {
 			stack = &v1beta1.Stack{
 				ObjectMeta: RandObjectMeta(),
-				Spec:       v1beta1.StackSpec{},
+				Spec:       v1beta1.StackSpec{Version: "v1.0.0"},
 			}
 		})
 		JustBeforeEach(func() {

--- a/internal/tests/orchestration_controller_test.go
+++ b/internal/tests/orchestration_controller_test.go
@@ -29,7 +29,7 @@ var _ = Describe("OrchestrationController", func() {
 		BeforeEach(func() {
 			stack = &v1beta1.Stack{
 				ObjectMeta: RandObjectMeta(),
-				Spec:       v1beta1.StackSpec{Version: "v1.0.0"},
+				Spec:       v1beta1.StackSpec{Version: "v99.0.0"},
 			}
 			databaseSettings = settings.New(uuid.NewString(), "postgres.*.uri", "postgresql://localhost", stack.Name)
 			brokerDSNSettings = settings.New(uuid.NewString(), "broker.dsn", "nats://localhost:1234", stack.Name)

--- a/internal/tests/orchestration_controller_test.go
+++ b/internal/tests/orchestration_controller_test.go
@@ -29,7 +29,7 @@ var _ = Describe("OrchestrationController", func() {
 		BeforeEach(func() {
 			stack = &v1beta1.Stack{
 				ObjectMeta: RandObjectMeta(),
-				Spec:       v1beta1.StackSpec{},
+				Spec:       v1beta1.StackSpec{Version: "v1.0.0"},
 			}
 			databaseSettings = settings.New(uuid.NewString(), "postgres.*.uri", "postgresql://localhost", stack.Name)
 			brokerDSNSettings = settings.New(uuid.NewString(), "broker.dsn", "nats://localhost:1234", stack.Name)

--- a/internal/tests/payments_controller_test.go
+++ b/internal/tests/payments_controller_test.go
@@ -23,7 +23,7 @@ var _ = Describe("PaymentsController", func() {
 		BeforeEach(func() {
 			stack = &v1beta1.Stack{
 				ObjectMeta: RandObjectMeta(),
-				Spec:       v1beta1.StackSpec{},
+				Spec:       v1beta1.StackSpec{Version: "v1.0.0"},
 			}
 			payments = &v1beta1.Payments{
 				ObjectMeta: RandObjectMeta(),

--- a/internal/tests/payments_controller_test.go
+++ b/internal/tests/payments_controller_test.go
@@ -23,7 +23,7 @@ var _ = Describe("PaymentsController", func() {
 		BeforeEach(func() {
 			stack = &v1beta1.Stack{
 				ObjectMeta: RandObjectMeta(),
-				Spec:       v1beta1.StackSpec{Version: "v1.0.0"},
+				Spec:       v1beta1.StackSpec{Version: "v99.0.0"},
 			}
 			payments = &v1beta1.Payments{
 				ObjectMeta: RandObjectMeta(),

--- a/internal/tests/registries_test.go
+++ b/internal/tests/registries_test.go
@@ -22,6 +22,7 @@ var _ = Describe("Registries", func() {
 	BeforeEach(func() {
 		stack = &v1beta1.Stack{
 			ObjectMeta: RandObjectMeta(),
+			Spec:       v1beta1.StackSpec{Version: "v1.0.0"},
 		}
 		databaseSettings = settings.New(uuid.NewString(), "postgres.*.uri", "postgresql://localhost", stack.Name)
 		ledger = &v1beta1.Ledger{

--- a/internal/tests/registries_test.go
+++ b/internal/tests/registries_test.go
@@ -22,7 +22,7 @@ var _ = Describe("Registries", func() {
 	BeforeEach(func() {
 		stack = &v1beta1.Stack{
 			ObjectMeta: RandObjectMeta(),
-			Spec:       v1beta1.StackSpec{Version: "v1.0.0"},
+			Spec:       v1beta1.StackSpec{Version: "v99.0.0"},
 		}
 		databaseSettings = settings.New(uuid.NewString(), "postgres.*.uri", "postgresql://localhost", stack.Name)
 		ledger = &v1beta1.Ledger{

--- a/internal/tests/resourcereferences_controller_test.go
+++ b/internal/tests/resourcereferences_controller_test.go
@@ -18,6 +18,7 @@ var _ = Describe("ResourceReferenceController", func() {
 	BeforeEach(func() {
 		stack = &v1beta1.Stack{
 			ObjectMeta: RandObjectMeta(),
+			Spec:       v1beta1.StackSpec{Version: "v1.0.0"},
 		}
 		Expect(Create(stack)).To(Succeed())
 	})

--- a/internal/tests/resourcereferences_controller_test.go
+++ b/internal/tests/resourcereferences_controller_test.go
@@ -18,7 +18,7 @@ var _ = Describe("ResourceReferenceController", func() {
 	BeforeEach(func() {
 		stack = &v1beta1.Stack{
 			ObjectMeta: RandObjectMeta(),
-			Spec:       v1beta1.StackSpec{Version: "v1.0.0"},
+			Spec:       v1beta1.StackSpec{Version: "v99.0.0"},
 		}
 		Expect(Create(stack)).To(Succeed())
 	})

--- a/internal/tests/settings_controller_test.go
+++ b/internal/tests/settings_controller_test.go
@@ -19,6 +19,7 @@ var _ = Describe("SettingsController", func() {
 		BeforeEach(func() {
 			stack = &v1beta1.Stack{
 				ObjectMeta: RandObjectMeta(),
+				Spec:       v1beta1.StackSpec{Version: "v1.0.0"},
 			}
 			setting = &v1beta1.Settings{
 				ObjectMeta: RandObjectMeta(),
@@ -67,6 +68,7 @@ var _ = Describe("SettingsController", func() {
 
 			stack = &v1beta1.Stack{
 				ObjectMeta: RandObjectMeta(),
+				Spec:       v1beta1.StackSpec{Version: "v1.0.0"},
 			}
 
 		})
@@ -106,6 +108,7 @@ var _ = Describe("SettingsController", func() {
 			}
 			stack = &v1beta1.Stack{
 				ObjectMeta: RandObjectMeta(),
+				Spec:       v1beta1.StackSpec{Version: "v1.0.0"},
 			}
 		})
 		JustBeforeEach(func() {

--- a/internal/tests/settings_controller_test.go
+++ b/internal/tests/settings_controller_test.go
@@ -19,7 +19,7 @@ var _ = Describe("SettingsController", func() {
 		BeforeEach(func() {
 			stack = &v1beta1.Stack{
 				ObjectMeta: RandObjectMeta(),
-				Spec:       v1beta1.StackSpec{Version: "v1.0.0"},
+				Spec:       v1beta1.StackSpec{Version: "v99.0.0"},
 			}
 			setting = &v1beta1.Settings{
 				ObjectMeta: RandObjectMeta(),
@@ -68,7 +68,7 @@ var _ = Describe("SettingsController", func() {
 
 			stack = &v1beta1.Stack{
 				ObjectMeta: RandObjectMeta(),
-				Spec:       v1beta1.StackSpec{Version: "v1.0.0"},
+				Spec:       v1beta1.StackSpec{Version: "v99.0.0"},
 			}
 
 		})
@@ -108,7 +108,7 @@ var _ = Describe("SettingsController", func() {
 			}
 			stack = &v1beta1.Stack{
 				ObjectMeta: RandObjectMeta(),
-				Spec:       v1beta1.StackSpec{Version: "v1.0.0"},
+				Spec:       v1beta1.StackSpec{Version: "v99.0.0"},
 			}
 		})
 		JustBeforeEach(func() {

--- a/internal/tests/stack_controller_test.go
+++ b/internal/tests/stack_controller_test.go
@@ -278,6 +278,7 @@ var _ = Describe("StackController", func() {
 		})
 		When("locked", func() {
 			BeforeEach(func() {
+				stack.Spec.Version = "v1.0.0"
 				stack.Annotations = map[string]string{
 					v1beta1.SkipLabel: "true",
 				}

--- a/internal/tests/stack_controller_test.go
+++ b/internal/tests/stack_controller_test.go
@@ -1,6 +1,8 @@
 package tests_test
 
 import (
+	"errors"
+
 	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -38,10 +40,11 @@ var _ = Describe("StackController", func() {
 					return Get(core.GetResourceName(stack.Name), &corev1.Namespace{})
 				}).Should(Succeed())
 			})
-			By("Should resolve to 'latest' version", func() {
-				version, err := core.GetModuleVersion(TestContext(), stack, &v1beta1.Ledger{})
-				Expect(err).To(Succeed())
-				Expect(version).To(Equal("latest"))
+			By("Should return error when no version is specified", func() {
+				_, err := core.GetModuleVersion(TestContext(), stack, &v1beta1.Ledger{})
+				Expect(err).To(HaveOccurred())
+				Expect(errors.Is(err, core.ErrNoVersionFound)).To(BeTrue())
+				Expect(err.Error()).To(ContainSubstring("stack must define spec.version"))
 			})
 			By("Should be ready", func() {
 				Eventually(func() bool {
@@ -123,10 +126,12 @@ var _ = Describe("StackController", func() {
 				Expect(Delete(versions)).To(Succeed())
 			})
 			Context("with no specific version", func() {
-				It("should resolve a module to 'latest'", func() {
-					version, err := core.GetModuleVersion(TestContext(), stack, &v1beta1.Ledger{})
-					Expect(err).To(Succeed())
-					Expect(version).To(Equal("latest"))
+				It("should return error when module not in versions file", func() {
+					_, err := core.GetModuleVersion(TestContext(), stack, &v1beta1.Ledger{})
+					Expect(err).To(HaveOccurred())
+					Expect(errors.Is(err, core.ErrNoVersionFound)).To(BeTrue())
+					Expect(err.Error()).To(ContainSubstring("module not found in Versions resource"))
+					Expect(err.Error()).To(ContainSubstring(versions.Name))
 				})
 			})
 			Context("with specific version for a module", func() {
@@ -146,6 +151,9 @@ var _ = Describe("StackController", func() {
 			var (
 				ledger *v1beta1.Ledger
 			)
+			BeforeEach(func() {
+				stack.Spec.Version = "v1.0.0"
+			})
 			JustBeforeEach(func() {
 				By("stack should be ready", func() {
 					Eventually(func() bool {

--- a/internal/tests/stargate_controller_test.go
+++ b/internal/tests/stargate_controller_test.go
@@ -19,7 +19,7 @@ var _ = Describe("StargateController", func() {
 		BeforeEach(func() {
 			stack = &v1beta1.Stack{
 				ObjectMeta: RandObjectMeta(),
-				Spec:       v1beta1.StackSpec{Version: "v1.0.0"},
+				Spec:       v1beta1.StackSpec{Version: "v99.0.0"},
 			}
 			stargate = &v1beta1.Stargate{
 				ObjectMeta: RandObjectMeta(),

--- a/internal/tests/stargate_controller_test.go
+++ b/internal/tests/stargate_controller_test.go
@@ -19,7 +19,7 @@ var _ = Describe("StargateController", func() {
 		BeforeEach(func() {
 			stack = &v1beta1.Stack{
 				ObjectMeta: RandObjectMeta(),
-				Spec:       v1beta1.StackSpec{},
+				Spec:       v1beta1.StackSpec{Version: "v1.0.0"},
 			}
 			stargate = &v1beta1.Stargate{
 				ObjectMeta: RandObjectMeta(),

--- a/internal/tests/transactionplane_controller_test.go
+++ b/internal/tests/transactionplane_controller_test.go
@@ -28,7 +28,7 @@ var _ = Describe("TransactionPlaneController", func() {
 		BeforeEach(func() {
 			stack = &v1beta1.Stack{
 				ObjectMeta: RandObjectMeta(),
-				Spec:       v1beta1.StackSpec{Version: "v1.0.0"},
+				Spec:       v1beta1.StackSpec{Version: "v99.0.0"},
 			}
 			databaseSettings = settings.New(uuid.NewString(), "postgres.*.uri", "postgresql://localhost", stack.Name)
 			brokerDSNSettings = settings.New(uuid.NewString(), "broker.dsn", "nats://localhost:1234", stack.Name)
@@ -152,7 +152,7 @@ var _ = Describe("TransactionPlaneController", func() {
 		BeforeEach(func() {
 			stack = &v1beta1.Stack{
 				ObjectMeta: RandObjectMeta(),
-				Spec:       v1beta1.StackSpec{Version: "v1.0.0"},
+				Spec:       v1beta1.StackSpec{Version: "v99.0.0"},
 			}
 			databaseSettings = settings.New(uuid.NewString(), "postgres.*.uri", "postgresql://localhost", stack.Name)
 			brokerDSNSettings = settings.New(uuid.NewString(), "broker.dsn", "nats://localhost:1234", stack.Name)
@@ -253,7 +253,7 @@ var _ = Describe("TransactionPlaneController", func() {
 		BeforeEach(func() {
 			stack = &v1beta1.Stack{
 				ObjectMeta: RandObjectMeta(),
-				Spec:       v1beta1.StackSpec{Version: "v1.0.0"},
+				Spec:       v1beta1.StackSpec{Version: "v99.0.0"},
 			}
 			databaseSettings = settings.New(uuid.NewString(), "postgres.*.uri", "postgresql://localhost", stack.Name)
 			brokerDSNSettings = settings.New(uuid.NewString(), "broker.dsn", "nats://localhost:1234", stack.Name)

--- a/internal/tests/transactionplane_controller_test.go
+++ b/internal/tests/transactionplane_controller_test.go
@@ -28,7 +28,7 @@ var _ = Describe("TransactionPlaneController", func() {
 		BeforeEach(func() {
 			stack = &v1beta1.Stack{
 				ObjectMeta: RandObjectMeta(),
-				Spec:       v1beta1.StackSpec{},
+				Spec:       v1beta1.StackSpec{Version: "v1.0.0"},
 			}
 			databaseSettings = settings.New(uuid.NewString(), "postgres.*.uri", "postgresql://localhost", stack.Name)
 			brokerDSNSettings = settings.New(uuid.NewString(), "broker.dsn", "nats://localhost:1234", stack.Name)
@@ -152,7 +152,7 @@ var _ = Describe("TransactionPlaneController", func() {
 		BeforeEach(func() {
 			stack = &v1beta1.Stack{
 				ObjectMeta: RandObjectMeta(),
-				Spec:       v1beta1.StackSpec{},
+				Spec:       v1beta1.StackSpec{Version: "v1.0.0"},
 			}
 			databaseSettings = settings.New(uuid.NewString(), "postgres.*.uri", "postgresql://localhost", stack.Name)
 			brokerDSNSettings = settings.New(uuid.NewString(), "broker.dsn", "nats://localhost:1234", stack.Name)
@@ -253,7 +253,7 @@ var _ = Describe("TransactionPlaneController", func() {
 		BeforeEach(func() {
 			stack = &v1beta1.Stack{
 				ObjectMeta: RandObjectMeta(),
-				Spec:       v1beta1.StackSpec{},
+				Spec:       v1beta1.StackSpec{Version: "v1.0.0"},
 			}
 			databaseSettings = settings.New(uuid.NewString(), "postgres.*.uri", "postgresql://localhost", stack.Name)
 			brokerDSNSettings = settings.New(uuid.NewString(), "broker.dsn", "nats://localhost:1234", stack.Name)

--- a/internal/tests/wallets_controller_test.go
+++ b/internal/tests/wallets_controller_test.go
@@ -27,7 +27,7 @@ var _ = Describe("WalletsController", func() {
 		BeforeEach(func() {
 			stack = &v1beta1.Stack{
 				ObjectMeta: RandObjectMeta(),
-				Spec:       v1beta1.StackSpec{Version: "v1.0.0"},
+				Spec:       v1beta1.StackSpec{Version: "v99.0.0"},
 			}
 			databaseSettings = settings.New(uuid.NewString(), "postgres.*.uri", "postgresql://localhost", stack.Name)
 			resourceLimitsSettings = settings.New(uuid.NewString(),

--- a/internal/tests/wallets_controller_test.go
+++ b/internal/tests/wallets_controller_test.go
@@ -27,7 +27,7 @@ var _ = Describe("WalletsController", func() {
 		BeforeEach(func() {
 			stack = &v1beta1.Stack{
 				ObjectMeta: RandObjectMeta(),
-				Spec:       v1beta1.StackSpec{},
+				Spec:       v1beta1.StackSpec{Version: "v1.0.0"},
 			}
 			databaseSettings = settings.New(uuid.NewString(), "postgres.*.uri", "postgresql://localhost", stack.Name)
 			resourceLimitsSettings = settings.New(uuid.NewString(),


### PR DESCRIPTION
## Summary
- Replace the implicit `"latest"` version fallback in `GetModuleVersion()` with an explicit `ErrNoVersionFound` sentinel error
- When no version is resolved (module, stack, or Versions resource), modules are marked NotReady with a contextual error message guiding users to the fix
- Payments finalizer handles `ErrNoVersionFound` gracefully (skip cleanup) while still propagating transient errors

## Motivation
Deploying with `"latest"` creates unpredictable dependency coupling between modules. Silent defaults mask configuration errors and can lead to incompatible versions being deployed together.

## Changes
| File | Change |
|------|--------|
| `internal/core/version.go` | `ErrNoVersionFound` sentinel, contextual error messages (versionsFromFile vs no config) |
| `api/formance.com/v1beta1/stack_types.go` | `GetVersion()` returns `""` instead of `"latest"`, CRD comment updated |
| `internal/resources/payments/finalizer.go` | `errors.Is(ErrNoVersionFound)` → skip cleanup; transient errors → propagate |
| `internal/tests/stack_controller_test.go` | Tests verify `errors.Is`, contextual messages, explicit version |
| CRD YAML + Helm + Docs | Updated to reflect new behavior |

## Breaking Change
Stacks without explicit version configuration will have NotReady modules. Users must configure `spec.version`, `spec.versionsFromFile`, or per-module versions.

## Test plan
- [x] `go vet` passes on all modified packages
- [x] Tests verify `errors.Is(err, core.ErrNoVersionFound)` works
- [x] Tests verify contextual error messages (versionsFromFile path vs no-config path)
- [x] Tests verify modules with explicit versions still resolve correctly
- [ ] Run full integration test suite (`go test ./internal/tests/...`)