### PR TITLE
feat: import shared helm recipes from formancehq/just-lib

### DIFF
--- a/.github/actions/default/action.yml
+++ b/.github/actions/default/action.yml
@@ -9,6 +9,9 @@ runs:
   steps:
     - name: Install Nix
       uses: cachix/install-nix-action@v31
+      with:
+        extra_nix_config: |
+          access-tokens = github.com=${{ inputs.token }}
     ## Disabling cache for now, as it's slowing down the build. Downloading nix
     ## dependencies from cache.nixos.org is faster than restoring from the cache.
     #- name: Cache dependencies

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,5 @@ Dockerfile.cross
 charts
 
 *.tgz
+
+.just-lib

--- a/Justfile
+++ b/Justfile
@@ -1,6 +1,9 @@
 set dotenv-load
 set positional-arguments
 
+import '.just-lib/helm/recipes.just'
+export HELM_DIR := "helm"
+
 default:
   @just --list
 
@@ -39,56 +42,6 @@ generate:
 
 generate-mock:
   go generate -run mockgen ./...
-
-helm-update:
-  #!/bin/bash
-  set pipefail -e
-
-  rm -f helm/operator/templates/gen/*
-  rm -f helm/crds/templates/crds/*
-
-  kustomize build config/default --output helm/operator/templates/gen
-  kustomize build config/crd --output helm/crds/templates/crds
-
-  # Patch all CRD files to add helm.sh/resource-policy and custom annotations support
-  for file in helm/crds/templates/crds/*.yaml; do
-    awk '/controller-gen.kubebuilder.io\/version:/ {
-      print
-      print "    helm.sh/resource-policy: keep"
-      print "    {{{{- with .Values.annotations }}"
-      print "    {{{{- toYaml . | nindent 4 }}"
-      print "    {{{{- end }}"
-      next
-    } 1' "$file" > "$file.tmp" && mv "$file.tmp" "$file"
-  done
-
-  rm -f helm/operator/templates/gen/v1_namespace*.yaml
-  rm -f helm/operator/templates/gen/apps_v1_deployment_*.yaml
-  helm dependencies update ./helm/operator
-
-helm-validate args='':
-  for dir in $(ls -d helm/*); do \
-    helm lint ./$dir --strict {{args}}; \
-    helm template ./$dir {{args}}; \
-  done
-
-helm-package suffix='': helm-update
-  #!/bin/bash
-  set -e
-  for dir in $(ls -d helm/*); do
-    if [ -n "{{suffix}}" ]; then
-      version=$(grep '^version:' "$dir/Chart.yaml" | awk '{print $2}' | tr -d '"')
-      pushd "$dir" && helm package . --version "${version}-{{suffix}}" && popd
-    else
-      pushd "$dir" && helm package . && popd
-    fi
-  done
-
-helm-publish suffix='': (helm-package suffix)
-  echo $GITHUB_TOKEN | docker login ghcr.io -u NumaryBot --password-stdin
-  for path in $(ls -d helm/*/*.tgz); do \
-    helm push ${path} oci://ghcr.io/formancehq/helm; \
-  done
 
 generate-docs:
   mkdir -p "docs/09-Configuration reference"

--- a/flake.lock
+++ b/flake.lock
@@ -21,6 +21,23 @@
         "type": "github"
       }
     },
+    "just-lib": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1775050988,
+        "narHash": "sha256-8JEACb/nm2o3pWQtSB3axaLnTpPPvDT03GvR5DHihQA=",
+        "owner": "formancehq",
+        "repo": "just-lib",
+        "rev": "5708b133512d8670e29920819a80acd4c192ee28",
+        "type": "github"
+      },
+      "original": {
+        "owner": "formancehq",
+        "ref": "feat/actions-and-tests",
+        "repo": "just-lib",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1773068389,
@@ -72,6 +89,7 @@
     },
     "root": {
       "inputs": {
+        "just-lib": "just-lib",
         "nixpkgs": "nixpkgs",
         "nixpkgs-unstable": "nixpkgs-unstable",
         "nur": "nur"

--- a/flake.nix
+++ b/flake.nix
@@ -9,9 +9,11 @@
       url = "github:nix-community/NUR";
       inputs.nixpkgs.follows = "nixpkgs";
     };
+
+    just-lib = { url = "git+ssh://git@github.com/formancehq/just-lib"; flake = false; };
   };
 
-  outputs = { self, nixpkgs, nixpkgs-unstable, nur }:
+  outputs = { self, nixpkgs, nixpkgs-unstable, nur, just-lib }:
     let
       supportedSystems = [
         "x86_64-linux"
@@ -46,7 +48,6 @@
             go_1_26
             gotools
             just
-            kubernetes-helm
             kustomize_4
             setup-envtest
             yq
@@ -60,7 +61,11 @@
         in
         {
           default = pkgs.mkShell {
-            packages = stablePackages ++ unstablePackages ++ otherPackages;
+            shellHook = ''
+              ln -sfn ${just-lib} .just-lib
+            '';
+            packages = stablePackages ++ unstablePackages ++ otherPackages
+            ++ (import "${just-lib}/helm/pkgs.nix" { inherit pkgs; });
           };
         }
       );

--- a/flake.nix
+++ b/flake.nix
@@ -10,7 +10,7 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
 
-    just-lib = { url = "git+ssh://git@github.com/formancehq/just-lib"; flake = false; };
+    just-lib = { url = "github:formancehq/just-lib/feat/actions-and-tests"; flake = false; };
   };
 
   outputs = { self, nixpkgs, nixpkgs-unstable, nur, just-lib }:
@@ -63,6 +63,7 @@
           default = pkgs.mkShell {
             shellHook = ''
               ln -sfn ${just-lib} .just-lib
+              source ${just-lib}/helm/setup-plugins.sh
             '';
             packages = stablePackages ++ unstablePackages ++ otherPackages
             ++ (import "${just-lib}/helm/pkgs.nix" { inherit pkgs; });


### PR DESCRIPTION
## Summary
Import shared Helm recipes from [formancehq/just-lib](https://github.com/formancehq/just-lib).

### Changes
- `flake.nix`: added just-lib input, helm pkgs from library
- `Justfile`: import shared helm recipes, removed inline helm recipes
- `.gitignore`: added `.just-lib`

### New recipes from library
- `helm-deps` — build deps, schema, docs
- `helm-test` — datree validation
- `helm-push` / `helm-push-dev` — push to production/dev registry
- `helm-publish` / `helm-publish-dev` — full publish flow
- `helm-version` — stamp version on charts

🤖 Generated with [Claude Code](https://claude.com/claude-code)