### PR TITLE
feat: add static settings catalog exporter

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -4,7 +4,7 @@ set positional-arguments
 default:
   @just --list
 
-pre-commit: tidy lint generate manifests helm-update helm-validate generate-docs
+pre-commit: tidy lint generate manifests helm-update helm-validate generate-docs generate-settings-catalog
 pc: pre-commit
 
 lint:
@@ -98,6 +98,9 @@ generate-docs:
     --output-path="./docs/09-Configuration reference/02-Custom Resource Definitions.md" \
     --templates-dir=./crd-doc-templates \
     --config=./docs.config.yaml
+
+generate-settings-catalog:
+  go run ./cmd/settings-catalog --format json --output "./docs/09-Configuration reference/settings.catalog.json"
 
 deploy: helm-update
   earthly +deploy

--- a/README.md
+++ b/README.md
@@ -205,6 +205,14 @@ make undeploy
 
 See defined settings in [Settings](docs/09-Configuration%20reference/01-Settings.md)
 
+For a machine-readable catalog that can be used by provisioning tooling, run:
+
+```sh
+just generate-settings-catalog
+```
+
+This scans the operator code for `settings.*` usage and writes `docs/09-Configuration reference/settings.catalog.json`.
+
 ## Contributing
 
 **NOTE:** Run `make --help` for more information on all potential `make` targets
@@ -226,4 +234,3 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-

--- a/cmd/settings-catalog/main.go
+++ b/cmd/settings-catalog/main.go
@@ -36,11 +36,6 @@ type objectField struct {
 	Type string `json:"type" yaml:"type"`
 }
 
-type structField struct {
-	Name string
-	Type string
-}
-
 type functionSpec struct {
 	Name         string
 	ValueType    string
@@ -77,10 +72,10 @@ func main() {
 		return
 	}
 
-	if err := os.MkdirAll(filepath.Dir(*output), 0o755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(*output), 0o750); err != nil {
 		fail(err)
 	}
-	if err := os.WriteFile(*output, data, 0o644); err != nil {
+	if err := os.WriteFile(*output, data, 0o600); err != nil {
 		fail(err)
 	}
 }

--- a/cmd/settings-catalog/main.go
+++ b/cmd/settings-catalog/main.go
@@ -1,0 +1,661 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"go/ast"
+	"go/format"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"slices"
+	"strconv"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+type catalog struct {
+	Source   string           `json:"source" yaml:"source"`
+	Settings []catalogSetting `json:"settings" yaml:"settings"`
+}
+
+type catalogSetting struct {
+	Key         string         `json:"key" yaml:"key"`
+	ValueType   string         `json:"valueType" yaml:"valueType"`
+	Default     string         `json:"default,omitempty" yaml:"default,omitempty"`
+	ObjectType  string         `json:"objectType,omitempty" yaml:"objectType,omitempty"`
+	ObjectFields []objectField `json:"objectFields,omitempty" yaml:"objectFields,omitempty"`
+	Sources     []string       `json:"sources" yaml:"sources"`
+}
+
+type objectField struct {
+	Name string `json:"name" yaml:"name"`
+	Type string `json:"type" yaml:"type"`
+}
+
+type structField struct {
+	Name string
+	Type string
+}
+
+type functionSpec struct {
+	Name         string
+	ValueType    string
+	KeyArgStart  int
+	Expand       func(prefix []string, defaultValue string, objectType string, objectFields []objectField, source string) []catalogSetting
+	ExtractType  func(*ast.CallExpr) (string, []objectField)
+}
+
+type scanner struct {
+	root        string
+	fset        *token.FileSet
+	structsByDir map[string]map[string][]objectField
+	structsByName map[string][]objectField
+}
+
+func main() {
+	root := flag.String("root", ".", "Repository root to scan")
+	formatName := flag.String("format", "yaml", "Output format: yaml or json")
+	output := flag.String("output", "", "Write output to file instead of stdout")
+	flag.Parse()
+
+	c, err := newScanner(*root).scan()
+	if err != nil {
+		fail(err)
+	}
+
+	data, err := marshalCatalog(c, *formatName)
+	if err != nil {
+		fail(err)
+	}
+
+	if *output == "" {
+		_, _ = os.Stdout.Write(data)
+		return
+	}
+
+	if err := os.MkdirAll(filepath.Dir(*output), 0o755); err != nil {
+		fail(err)
+	}
+	if err := os.WriteFile(*output, data, 0o644); err != nil {
+		fail(err)
+	}
+}
+
+func fail(err error) {
+	_, _ = fmt.Fprintln(os.Stderr, err)
+	os.Exit(1)
+}
+
+func marshalCatalog(c catalog, formatName string) ([]byte, error) {
+	switch strings.ToLower(formatName) {
+	case "yaml", "yml":
+		return yaml.Marshal(c)
+	case "json":
+		data, err := json.MarshalIndent(c, "", "  ")
+		if err != nil {
+			return nil, err
+		}
+		return append(data, '\n'), nil
+	default:
+		return nil, fmt.Errorf("unsupported format %q", formatName)
+	}
+}
+
+func newScanner(root string) *scanner {
+	return &scanner{
+		root:         root,
+		fset:         token.NewFileSet(),
+		structsByDir: map[string]map[string][]objectField{},
+		structsByName: map[string][]objectField{},
+	}
+}
+
+func (s *scanner) scan() (catalog, error) {
+	files, err := s.goFiles()
+	if err != nil {
+		return catalog{}, err
+	}
+
+	parsedFiles := make(map[string]*ast.File, len(files))
+	for _, path := range files {
+		file, err := parser.ParseFile(s.fset, path, nil, 0)
+		if err != nil {
+			return catalog{}, err
+		}
+		parsedFiles[path] = file
+		s.collectStructs(path, file)
+	}
+
+	settingsByKey := map[string]*catalogSetting{}
+	for path, file := range parsedFiles {
+		if err := s.collectSettings(path, file, settingsByKey); err != nil {
+			return catalog{}, err
+		}
+	}
+
+	settings := make([]catalogSetting, 0, len(settingsByKey))
+	for _, setting := range settingsByKey {
+		slices.Sort(setting.Sources)
+		settings = append(settings, *setting)
+	}
+	slices.SortFunc(settings, func(a, b catalogSetting) int {
+		if a.Key < b.Key {
+			return -1
+		}
+		if a.Key > b.Key {
+			return 1
+		}
+		if a.ValueType < b.ValueType {
+			return -1
+		}
+		if a.ValueType > b.ValueType {
+			return 1
+		}
+		return 0
+	})
+
+	return catalog{
+		Source:   "code",
+		Settings: settings,
+	}, nil
+}
+
+func (s *scanner) goFiles() ([]string, error) {
+	var files []string
+	err := filepath.WalkDir(s.root, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			base := d.Name()
+			switch base {
+			case ".git", "bin", "vendor":
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		if strings.Contains(path, string(filepath.Separator)+"cmd"+string(filepath.Separator)+"settings-catalog"+string(filepath.Separator)) {
+			return nil
+		}
+		files = append(files, path)
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	slices.Sort(files)
+	return files, nil
+}
+
+func (s *scanner) collectStructs(path string, file *ast.File) {
+	dir := filepath.Dir(path)
+	if _, ok := s.structsByDir[dir]; !ok {
+		s.structsByDir[dir] = map[string][]objectField{}
+	}
+
+	for _, decl := range file.Decls {
+		gen, ok := decl.(*ast.GenDecl)
+		if !ok || gen.Tok != token.TYPE {
+			continue
+		}
+		for _, spec := range gen.Specs {
+			typeSpec, ok := spec.(*ast.TypeSpec)
+			if !ok {
+				continue
+			}
+			structType, ok := typeSpec.Type.(*ast.StructType)
+			if !ok {
+				continue
+			}
+
+			fields := make([]objectField, 0, len(structType.Fields.List))
+			for _, field := range structType.Fields.List {
+				name := fieldJSONName(field)
+				if name == "" {
+					continue
+				}
+				fields = append(fields, objectField{
+					Name: name,
+					Type: exprString(s.fset, field.Type),
+				})
+			}
+			s.structsByDir[dir][typeSpec.Name.Name] = fields
+			if _, exists := s.structsByName[typeSpec.Name.Name]; !exists {
+				s.structsByName[typeSpec.Name.Name] = fields
+			}
+		}
+	}
+}
+
+func (s *scanner) collectSettings(path string, file *ast.File, settingsByKey map[string]*catalogSetting) error {
+	settingsAliases := settingsImportAliases(file)
+	dir := filepath.Dir(path)
+	if shouldSkipFile(path) {
+		return nil
+	}
+
+	ast.Inspect(file, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+
+		funcName, qualifier := calledFunction(call.Fun)
+		spec, ok := knownFunction(funcName)
+		if !ok {
+			return true
+		}
+		if qualifier != "" && !settingsAliases[qualifier] {
+			return true
+		}
+		if qualifier == "" && file.Name.Name != "settings" {
+			return true
+		}
+
+		keyParts, defaultValue, ok := extractKeyParts(call, spec.KeyArgStart)
+		if !ok {
+			return true
+		}
+
+		objectType := ""
+		var objectFields []objectField
+		if spec.ExtractType != nil {
+			objectType, objectFields = spec.ExtractType(call)
+			if objectType != "" {
+				objectFields = s.resolveStructFields(dir, objectType)
+			}
+		}
+
+		source := relativeSource(s.root, s.fset.Position(call.Pos()))
+		for _, setting := range spec.Expand(keyParts, defaultValue, objectType, objectFields, source) {
+			if shouldSkipSetting(setting) {
+				continue
+			}
+			mergeSetting(settingsByKey, setting)
+		}
+		return true
+	})
+
+	return nil
+}
+
+func settingsImportAliases(file *ast.File) map[string]bool {
+	ret := map[string]bool{}
+	for _, imp := range file.Imports {
+		path, err := strconv.Unquote(imp.Path.Value)
+		if err != nil {
+			continue
+		}
+		if path != "github.com/formancehq/operator/v3/internal/resources/settings" {
+			continue
+		}
+		if imp.Name != nil {
+			ret[imp.Name.Name] = true
+		} else {
+			ret["settings"] = true
+		}
+	}
+	return ret
+}
+
+func knownFunction(name string) (functionSpec, bool) {
+	specs := map[string]functionSpec{
+		"GetString":          directSpec("string", 2),
+		"GetStringOrDefault": directSpec("string", 3),
+		"GetStringOrEmpty":   directSpec("string", 2),
+		"RequireString":      directSpec("string", 2),
+		"GetStringSlice":     directSpec("string[]", 2),
+		"GetTrimmedStringSlice": directSpec("string[]", 2),
+		"GetURL":             directSpec("uri", 2),
+		"RequireURL":         directSpec("uri", 2),
+		"GetInt":             directSpec("int", 2),
+		"GetInt32":           directSpec("int32", 2),
+		"GetInt64":           directSpec("int64", 2),
+		"GetIntOrDefault":    directSpec("int", 3),
+		"GetInt32OrDefault":  directSpec("int32", 3),
+		"GetUInt16OrDefault": directSpec("uint16", 3),
+		"GetBool":            directSpec("bool", 2),
+		"GetBoolOrDefault":   directSpec("bool", 3),
+		"GetBoolOrFalse":     directSpec("bool", 2),
+		"GetBoolOrTrue":      directSpec("bool", 2),
+		"GetMap":             directSpec("map[string]string", 2),
+		"GetMapOrEmpty":      directSpec("map[string]string", 2),
+		"GetEnvVars": {
+			Name:        "GetEnvVars",
+			ValueType:   "map[string]string",
+			KeyArgStart: 2,
+			Expand: func(prefix []string, _ string, _ string, _ []objectField, source string) []catalogSetting {
+				return []catalogSetting{{
+					Key:       strings.Join(append(prefix, "env-vars"), "."),
+					ValueType: "map[string]string",
+					Sources:   []string{source},
+				}}
+			},
+		},
+		"GetResourceRequirements": {
+			Name:        "GetResourceRequirements",
+			KeyArgStart: 2,
+			Expand: func(prefix []string, _ string, _ string, _ []objectField, source string) []catalogSetting {
+				return []catalogSetting{
+					{Key: strings.Join(append(prefix, "limits"), "."), ValueType: "map[string]string", Sources: []string{source}},
+					{Key: strings.Join(append(prefix, "requests"), "."), ValueType: "map[string]string", Sources: []string{source}},
+					{Key: strings.Join(append(prefix, "claims"), "."), ValueType: "string[]", Sources: []string{source}},
+				}
+			},
+		},
+		"GetAs": {
+			Name:        "GetAs",
+			ValueType:   "object",
+			KeyArgStart: 2,
+			ExtractType: extractGenericType,
+			Expand: func(prefix []string, _ string, objectType string, objectFields []objectField, source string) []catalogSetting {
+				return []catalogSetting{{
+					Key:          strings.Join(prefix, "."),
+					ValueType:    "object",
+					ObjectType:   objectType,
+					ObjectFields: objectFields,
+					Sources:      []string{source},
+				}}
+			},
+		},
+	}
+	spec, ok := specs[name]
+	return spec, ok
+}
+
+func directSpec(valueType string, keyArgStart int) functionSpec {
+	return functionSpec{
+		ValueType:   valueType,
+		KeyArgStart: keyArgStart,
+		Expand: func(prefix []string, defaultValue string, _ string, _ []objectField, source string) []catalogSetting {
+			return []catalogSetting{{
+				Key:       strings.Join(prefix, "."),
+				ValueType: valueType,
+				Default:   defaultValue,
+				Sources:   []string{source},
+			}}
+		},
+	}
+}
+
+func calledFunction(fun ast.Expr) (string, string) {
+	switch typed := fun.(type) {
+	case *ast.SelectorExpr:
+		if ident, ok := typed.X.(*ast.Ident); ok {
+			return typed.Sel.Name, ident.Name
+		}
+	case *ast.IndexExpr:
+		return calledFunction(typed.X)
+	case *ast.IndexListExpr:
+		return calledFunction(typed.X)
+	case *ast.Ident:
+		return typed.Name, ""
+	}
+	return "", ""
+}
+
+func extractGenericType(call *ast.CallExpr) (string, []objectField) {
+	switch fun := call.Fun.(type) {
+	case *ast.IndexExpr:
+		switch idx := fun.Index.(type) {
+		case *ast.Ident:
+			return idx.Name, nil
+		case *ast.SelectorExpr:
+			return idx.Sel.Name, nil
+		}
+	case *ast.IndexListExpr:
+		if len(fun.Indices) == 1 {
+			switch idx := fun.Indices[0].(type) {
+			case *ast.Ident:
+				return idx.Name, nil
+			case *ast.SelectorExpr:
+				return idx.Sel.Name, nil
+			}
+		}
+	}
+	return "", nil
+}
+
+func extractKeyParts(call *ast.CallExpr, keyArgStart int) ([]string, string, bool) {
+	if len(call.Args) <= keyArgStart {
+		return nil, "", false
+	}
+
+	defaultValue := ""
+	if keyArgStart == 3 {
+		defaultValue = literalOrExpr(call.Args[2])
+	}
+
+	var parts []string
+	for _, arg := range call.Args[keyArgStart:] {
+		part, ok := keyPart(arg)
+		if !ok {
+			return nil, "", false
+		}
+		parts = append(parts, part)
+	}
+	return parts, defaultValue, true
+}
+
+func keyPart(expr ast.Expr) (string, bool) {
+	switch typed := expr.(type) {
+	case *ast.BasicLit:
+		if typed.Kind != token.STRING {
+			return typed.Value, true
+		}
+		value, err := strconv.Unquote(typed.Value)
+		if err != nil {
+			return "", false
+		}
+		return value, true
+	case *ast.Ident:
+		return placeholderForName(typed.Name), true
+	case *ast.SelectorExpr:
+		return placeholderForSelector(typed), true
+	case *ast.CallExpr:
+		return placeholderForCall(typed), true
+	default:
+		return "", false
+	}
+}
+
+func placeholderForName(name string) string {
+	switch name {
+	case "moduleName":
+		return "<module-name>"
+	case "serviceName":
+		return "<service-name>"
+	case "monitoringType":
+		return "<monitoring-type>"
+	case "dnsType":
+		return "<dns-type>"
+	case "registry":
+		return "<name>"
+	case "imageWithoutRegistry":
+		return "<path>"
+	case "kind":
+		return "<owner-kind>"
+	default:
+		if name == "module" || strings.Contains(strings.ToLower(name), "module") {
+			return "<module-name>"
+		}
+		if strings.Contains(strings.ToLower(name), "deployment") {
+			return "<deployment-name>"
+		}
+		if strings.Contains(strings.ToLower(name), "container") {
+			return "<container-name>"
+		}
+		if strings.Contains(strings.ToLower(name), "service") {
+			return "<service-name>"
+		}
+		if strings.Contains(strings.ToLower(name), "registry") {
+			return "<name>"
+		}
+		return "<" + kebab(name) + ">"
+	}
+}
+
+func placeholderForSelector(expr *ast.SelectorExpr) string {
+	left := strings.ToLower(exprString(token.NewFileSet(), expr.X))
+	if expr.Sel.Name == "Name" {
+		switch {
+		case strings.Contains(left, "deployment"):
+			return "<deployment-name>"
+		case strings.Contains(left, "container"):
+			return "<container-name>"
+		}
+	}
+	if expr.Sel.Name == "Kind" {
+		return "<owner-kind>"
+	}
+	if expr.Sel.Name == "Service" {
+		return "<module-name>"
+	}
+	return placeholderForName(expr.Sel.Name)
+}
+
+func placeholderForCall(expr *ast.CallExpr) string {
+	rendered := exprString(token.NewFileSet(), expr)
+	switch {
+	case strings.Contains(rendered, "GetKind("):
+		return "<owner-kind>"
+	case strings.Contains(rendered, "ToLower") && strings.Contains(rendered, "monitoringType"):
+		return "<monitoring-type>"
+	case strings.Contains(rendered, "LowerCamelCaseKind"):
+		return "<owner-kind>"
+	default:
+		return "<dynamic>"
+	}
+}
+
+func literalOrExpr(expr ast.Expr) string {
+	switch typed := expr.(type) {
+	case *ast.BasicLit:
+		if typed.Kind == token.STRING {
+			value, err := strconv.Unquote(typed.Value)
+			if err == nil {
+				return value
+			}
+		}
+		return typed.Value
+	default:
+		return exprString(token.NewFileSet(), expr)
+	}
+}
+
+func mergeSetting(dst map[string]*catalogSetting, setting catalogSetting) {
+	key := setting.Key + "|" + setting.ValueType
+	existing, ok := dst[key]
+	if !ok {
+		copySetting := setting
+		dst[key] = &copySetting
+		return
+	}
+	if existing.Default == "" {
+		existing.Default = setting.Default
+	}
+	if existing.ObjectType == "" {
+		existing.ObjectType = setting.ObjectType
+	}
+	if len(existing.ObjectFields) == 0 && len(setting.ObjectFields) > 0 {
+		existing.ObjectFields = slices.Clone(setting.ObjectFields)
+	}
+	existing.Sources = append(existing.Sources, setting.Sources...)
+	existing.Sources = uniqueStrings(existing.Sources)
+}
+
+func (s *scanner) resolveStructFields(dir, typeName string) []objectField {
+	if fields := s.structsByDir[dir][typeName]; len(fields) > 0 {
+		return slices.Clone(fields)
+	}
+	if fields := s.structsByName[typeName]; len(fields) > 0 {
+		return slices.Clone(fields)
+	}
+	return nil
+}
+
+func shouldSkipFile(path string) bool {
+	slashed := filepath.ToSlash(path)
+	return strings.HasSuffix(slashed, "/internal/resources/settings/helpers.go") ||
+		strings.HasSuffix(slashed, "/internal/resources/settings/resourcerequirements.go")
+}
+
+func shouldSkipSetting(setting catalogSetting) bool {
+	return strings.Contains(setting.Key, "<dynamic>") || strings.Contains(setting.Key, "<keys>")
+}
+
+func uniqueStrings(values []string) []string {
+	seen := map[string]bool{}
+	ret := make([]string, 0, len(values))
+	for _, value := range values {
+		if seen[value] {
+			continue
+		}
+		seen[value] = true
+		ret = append(ret, value)
+	}
+	return ret
+}
+
+func relativeSource(root string, pos token.Position) string {
+	rel, err := filepath.Rel(root, pos.Filename)
+	if err != nil {
+		rel = pos.Filename
+	}
+	return fmt.Sprintf("%s:%d", filepath.ToSlash(rel), pos.Line)
+}
+
+func fieldJSONName(field *ast.Field) string {
+	if field.Tag != nil {
+		tagValue, err := strconv.Unquote(field.Tag.Value)
+		if err == nil {
+			tag := reflectJSONTag(tagValue)
+			if tag != "" && tag != "-" {
+				return tag
+			}
+		}
+	}
+	if len(field.Names) == 1 {
+		return kebab(field.Names[0].Name)
+	}
+	return ""
+}
+
+func reflectJSONTag(tag string) string {
+	for _, part := range strings.Split(tag, " ") {
+		if !strings.HasPrefix(part, `json:"`) {
+			continue
+		}
+		value := strings.TrimPrefix(part, `json:"`)
+		value = strings.TrimSuffix(value, `"`)
+		value = strings.Split(value, ",")[0]
+		return value
+	}
+	return ""
+}
+
+func exprString(fset *token.FileSet, expr ast.Expr) string {
+	var builder strings.Builder
+	if err := format.Node(&builder, fset, expr); err != nil {
+		return ""
+	}
+	return builder.String()
+}
+
+func kebab(value string) string {
+	var parts []rune
+	for i, r := range value {
+		if i > 0 && r >= 'A' && r <= 'Z' {
+			parts = append(parts, '-')
+		}
+		parts = append(parts, rune(strings.ToLower(string(r))[0]))
+	}
+	return string(parts)
+}

--- a/cmd/settings-catalog/main.go
+++ b/cmd/settings-catalog/main.go
@@ -23,12 +23,12 @@ type catalog struct {
 }
 
 type catalogSetting struct {
-	Key         string         `json:"key" yaml:"key"`
-	ValueType   string         `json:"valueType" yaml:"valueType"`
-	Default     string         `json:"default,omitempty" yaml:"default,omitempty"`
-	ObjectType  string         `json:"objectType,omitempty" yaml:"objectType,omitempty"`
+	Key          string        `json:"key" yaml:"key"`
+	ValueType    string        `json:"valueType" yaml:"valueType"`
+	Default      string        `json:"default,omitempty" yaml:"default,omitempty"`
+	ObjectType   string        `json:"objectType,omitempty" yaml:"objectType,omitempty"`
 	ObjectFields []objectField `json:"objectFields,omitempty" yaml:"objectFields,omitempty"`
-	Sources     []string       `json:"sources" yaml:"sources"`
+	Sources      []string      `json:"sources" yaml:"sources"`
 }
 
 type objectField struct {
@@ -37,17 +37,17 @@ type objectField struct {
 }
 
 type functionSpec struct {
-	Name         string
-	ValueType    string
-	KeyArgStart  int
-	Expand       func(prefix []string, defaultValue string, objectType string, objectFields []objectField, source string) []catalogSetting
-	ExtractType  func(*ast.CallExpr) (string, []objectField)
+	Name        string
+	ValueType   string
+	KeyArgStart int
+	Expand      func(prefix []string, defaultValue string, objectType string, objectFields []objectField, source string) []catalogSetting
+	ExtractType func(*ast.CallExpr) (string, []objectField)
 }
 
 type scanner struct {
-	root        string
-	fset        *token.FileSet
-	structsByDir map[string]map[string][]objectField
+	root          string
+	fset          *token.FileSet
+	structsByDir  map[string]map[string][]objectField
 	structsByName map[string][]objectField
 }
 
@@ -102,9 +102,9 @@ func marshalCatalog(c catalog, formatName string) ([]byte, error) {
 
 func newScanner(root string) *scanner {
 	return &scanner{
-		root:         root,
-		fset:         token.NewFileSet(),
-		structsByDir: map[string]map[string][]objectField{},
+		root:          root,
+		fset:          token.NewFileSet(),
+		structsByDir:  map[string]map[string][]objectField{},
 		structsByName: map[string][]objectField{},
 	}
 }
@@ -302,26 +302,26 @@ func settingsImportAliases(file *ast.File) map[string]bool {
 
 func knownFunction(name string) (functionSpec, bool) {
 	specs := map[string]functionSpec{
-		"GetString":          directSpec("string", 2),
-		"GetStringOrDefault": directSpec("string", 3),
-		"GetStringOrEmpty":   directSpec("string", 2),
-		"RequireString":      directSpec("string", 2),
-		"GetStringSlice":     directSpec("string[]", 2),
+		"GetString":             directSpec("string", 2),
+		"GetStringOrDefault":    directSpec("string", 3),
+		"GetStringOrEmpty":      directSpec("string", 2),
+		"RequireString":         directSpec("string", 2),
+		"GetStringSlice":        directSpec("string[]", 2),
 		"GetTrimmedStringSlice": directSpec("string[]", 2),
-		"GetURL":             directSpec("uri", 2),
-		"RequireURL":         directSpec("uri", 2),
-		"GetInt":             directSpec("int", 2),
-		"GetInt32":           directSpec("int32", 2),
-		"GetInt64":           directSpec("int64", 2),
-		"GetIntOrDefault":    directSpec("int", 3),
-		"GetInt32OrDefault":  directSpec("int32", 3),
-		"GetUInt16OrDefault": directSpec("uint16", 3),
-		"GetBool":            directSpec("bool", 2),
-		"GetBoolOrDefault":   directSpec("bool", 3),
-		"GetBoolOrFalse":     directSpec("bool", 2),
-		"GetBoolOrTrue":      directSpec("bool", 2),
-		"GetMap":             directSpec("map[string]string", 2),
-		"GetMapOrEmpty":      directSpec("map[string]string", 2),
+		"GetURL":                directSpec("uri", 2),
+		"RequireURL":            directSpec("uri", 2),
+		"GetInt":                directSpec("int", 2),
+		"GetInt32":              directSpec("int32", 2),
+		"GetInt64":              directSpec("int64", 2),
+		"GetIntOrDefault":       directSpec("int", 3),
+		"GetInt32OrDefault":     directSpec("int32", 3),
+		"GetUInt16OrDefault":    directSpec("uint16", 3),
+		"GetBool":               directSpec("bool", 2),
+		"GetBoolOrDefault":      directSpec("bool", 3),
+		"GetBoolOrFalse":        directSpec("bool", 2),
+		"GetBoolOrTrue":         directSpec("bool", 2),
+		"GetMap":                directSpec("map[string]string", 2),
+		"GetMapOrEmpty":         directSpec("map[string]string", 2),
 		"GetEnvVars": {
 			Name:        "GetEnvVars",
 			ValueType:   "map[string]string",

--- a/cmd/settings-catalog/main_test.go
+++ b/cmd/settings-catalog/main_test.go
@@ -1,0 +1,35 @@
+package main
+
+import "testing"
+
+func TestScanCatalogFromCode(t *testing.T) {
+	t.Parallel()
+
+	c, err := newScanner("../..").scan()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(c.Settings) == 0 {
+		t.Fatal("expected settings to be discovered from code")
+	}
+
+	assertHasKey := func(key string) {
+		t.Helper()
+		for _, setting := range c.Settings {
+			if setting.Key == key {
+				return
+			}
+		}
+		t.Fatalf("expected key %q to be present", key)
+	}
+
+	assertHasKey("auth.<module-name>.check-scopes")
+	assertHasKey("aws.service-account")
+	assertHasKey("deployments.<deployment-name>.containers.<container-name>.resource-requirements.limits")
+	assertHasKey("deployments.<deployment-name>.containers.<container-name>.resource-requirements.requests")
+	assertHasKey("jobs.<owner-kind>.containers.<container-name>.run-as")
+	assertHasKey("modules.<module-name>.database.connection-pool")
+	assertHasKey("opentelemetry.<monitoring-type>.dsn")
+	assertHasKey("registries.<name>.images.<path>.rewrite")
+}

--- a/docs/09-Configuration reference/settings.catalog.json
+++ b/docs/09-Configuration reference/settings.catalog.json
@@ -1,0 +1,668 @@
+{
+  "source": "code",
+  "settings": [
+    {
+      "key": "auth.\u003cmodule-name\u003e.check-scopes",
+      "valueType": "bool",
+      "sources": [
+        "internal/resources/auths/env.go:79"
+      ]
+    },
+    {
+      "key": "auth.issuers",
+      "valueType": "string",
+      "sources": [
+        "internal/resources/auths/deployment.go:69",
+        "internal/resources/auths/env.go:34"
+      ]
+    },
+    {
+      "key": "aws.service-account",
+      "valueType": "string",
+      "sources": [
+        "internal/resources/settings/aws_role.go:6"
+      ]
+    },
+    {
+      "key": "broker.dsn",
+      "valueType": "uri",
+      "sources": [
+        "internal/resources/brokers/reconcile.go:25",
+        "internal/resources/webhooks/deployment.go:22"
+      ]
+    },
+    {
+      "key": "caddy.image",
+      "valueType": "string",
+      "default": "defaultCaddyImage",
+      "sources": [
+        "internal/resources/registries/image.go:50"
+      ]
+    },
+    {
+      "key": "clear-database",
+      "valueType": "bool",
+      "sources": [
+        "internal/resources/databases/init.go:112"
+      ]
+    },
+    {
+      "key": "deployments.\u003cdeployment-name\u003e.containers.\u003ccontainer-name\u003e.env-vars",
+      "valueType": "map[string]string",
+      "sources": [
+        "internal/resources/applications/application.go:282"
+      ]
+    },
+    {
+      "key": "deployments.\u003cdeployment-name\u003e.containers.\u003ccontainer-name\u003e.resource-requirements.claims",
+      "valueType": "string[]",
+      "sources": [
+        "internal/resources/applications/application.go:263"
+      ]
+    },
+    {
+      "key": "deployments.\u003cdeployment-name\u003e.containers.\u003ccontainer-name\u003e.resource-requirements.limits",
+      "valueType": "map[string]string",
+      "sources": [
+        "internal/resources/applications/application.go:263"
+      ]
+    },
+    {
+      "key": "deployments.\u003cdeployment-name\u003e.containers.\u003ccontainer-name\u003e.resource-requirements.requests",
+      "valueType": "map[string]string",
+      "sources": [
+        "internal/resources/applications/application.go:263"
+      ]
+    },
+    {
+      "key": "deployments.\u003cdeployment-name\u003e.containers.\u003ccontainer-name\u003e.run-as",
+      "valueType": "object",
+      "objectType": "RunAs",
+      "objectFields": [
+        {
+          "name": "user",
+          "type": "*int64"
+        },
+        {
+          "name": "group",
+          "type": "*int64"
+        }
+      ],
+      "sources": [
+        "internal/resources/applications/application.go:270"
+      ]
+    },
+    {
+      "key": "deployments.\u003cdeployment-name\u003e.init-containers.\u003ccontainer-name\u003e.env-vars",
+      "valueType": "map[string]string",
+      "sources": [
+        "internal/resources/applications/application.go:253"
+      ]
+    },
+    {
+      "key": "deployments.\u003cdeployment-name\u003e.init-containers.\u003ccontainer-name\u003e.resource-requirements.claims",
+      "valueType": "string[]",
+      "sources": [
+        "internal/resources/applications/application.go:238"
+      ]
+    },
+    {
+      "key": "deployments.\u003cdeployment-name\u003e.init-containers.\u003ccontainer-name\u003e.resource-requirements.limits",
+      "valueType": "map[string]string",
+      "sources": [
+        "internal/resources/applications/application.go:238"
+      ]
+    },
+    {
+      "key": "deployments.\u003cdeployment-name\u003e.init-containers.\u003ccontainer-name\u003e.resource-requirements.requests",
+      "valueType": "map[string]string",
+      "sources": [
+        "internal/resources/applications/application.go:238"
+      ]
+    },
+    {
+      "key": "deployments.\u003cdeployment-name\u003e.init-containers.\u003ccontainer-name\u003e.run-as",
+      "valueType": "object",
+      "objectType": "RunAs",
+      "objectFields": [
+        {
+          "name": "user",
+          "type": "*int64"
+        },
+        {
+          "name": "group",
+          "type": "*int64"
+        }
+      ],
+      "sources": [
+        "internal/resources/applications/application.go:245"
+      ]
+    },
+    {
+      "key": "deployments.\u003cdeployment-name\u003e.pod-disruption-budget",
+      "valueType": "object",
+      "objectType": "podDisruptionBudgetConfiguration",
+      "objectFields": [
+        {
+          "name": "minAvailable",
+          "type": "string"
+        },
+        {
+          "name": "maxUnavailable",
+          "type": "string"
+        }
+      ],
+      "sources": [
+        "internal/resources/applications/application.go:554"
+      ]
+    },
+    {
+      "key": "deployments.\u003cdeployment-name\u003e.replicas",
+      "valueType": "int32",
+      "sources": [
+        "internal/resources/applications/application.go:299"
+      ]
+    },
+    {
+      "key": "deployments.\u003cdeployment-name\u003e.semconv-metrics-names",
+      "valueType": "bool",
+      "sources": [
+        "internal/resources/applications/application.go:419"
+      ]
+    },
+    {
+      "key": "deployments.\u003cdeployment-name\u003e.spec.template.annotations",
+      "valueType": "map[string]string",
+      "sources": [
+        "internal/resources/applications/application.go:176"
+      ]
+    },
+    {
+      "key": "deployments.\u003cdeployment-name\u003e.spec.template.spec.termination-grace-period-seconds",
+      "valueType": "int64",
+      "sources": [
+        "internal/resources/applications/application.go:470"
+      ]
+    },
+    {
+      "key": "deployments.\u003cdeployment-name\u003e.topology-spread-constraints",
+      "valueType": "bool",
+      "sources": [
+        "internal/resources/applications/application.go:357"
+      ]
+    },
+    {
+      "key": "gateway.caddyfile.trusted-proxies",
+      "valueType": "string[]",
+      "sources": [
+        "internal/resources/gateways/configuration.go:17"
+      ]
+    },
+    {
+      "key": "gateway.caddyfile.trusted-proxies-strict",
+      "valueType": "bool",
+      "sources": [
+        "internal/resources/gateways/configuration.go:25"
+      ]
+    },
+    {
+      "key": "gateway.config.idle-timeout",
+      "valueType": "string",
+      "sources": [
+        "internal/resources/gateways/configuration.go:33"
+      ]
+    },
+    {
+      "key": "gateway.dns.\u003cdns-type\u003e.annotations",
+      "valueType": "map[string]string",
+      "sources": [
+        "internal/resources/gateways/dnsendpoints.go:58"
+      ]
+    },
+    {
+      "key": "gateway.dns.\u003cdns-type\u003e.dns-names",
+      "valueType": "string[]",
+      "sources": [
+        "internal/resources/gateways/dnsendpoints.go:37"
+      ]
+    },
+    {
+      "key": "gateway.dns.\u003cdns-type\u003e.enabled",
+      "valueType": "bool",
+      "default": "false",
+      "sources": [
+        "internal/resources/gateways/dnsendpoints.go:28"
+      ]
+    },
+    {
+      "key": "gateway.dns.\u003cdns-type\u003e.provider-specific",
+      "valueType": "map[string]string",
+      "sources": [
+        "internal/resources/gateways/dnsendpoints.go:53"
+      ]
+    },
+    {
+      "key": "gateway.dns.\u003cdns-type\u003e.record-type",
+      "valueType": "string",
+      "default": "CNAME",
+      "sources": [
+        "internal/resources/gateways/dnsendpoints.go:63"
+      ]
+    },
+    {
+      "key": "gateway.dns.\u003cdns-type\u003e.targets",
+      "valueType": "string[]",
+      "sources": [
+        "internal/resources/gateways/dnsendpoints.go:45"
+      ]
+    },
+    {
+      "key": "gateway.ingress.annotations",
+      "valueType": "map[string]string",
+      "sources": [
+        "internal/resources/gateways/ingress.go:17"
+      ]
+    },
+    {
+      "key": "gateway.ingress.class",
+      "valueType": "string",
+      "sources": [
+        "internal/resources/gateways/ingress.go:93"
+      ]
+    },
+    {
+      "key": "gateway.ingress.hosts",
+      "valueType": "string[]",
+      "sources": [
+        "internal/resources/gateways/ingress.go:54"
+      ]
+    },
+    {
+      "key": "gateway.ingress.labels",
+      "valueType": "map[string]string",
+      "sources": [
+        "internal/resources/gateways/ingress.go:39"
+      ]
+    },
+    {
+      "key": "gateway.ingress.tls.enabled",
+      "valueType": "bool",
+      "sources": [
+        "internal/resources/gateways/ingress.go:70"
+      ]
+    },
+    {
+      "key": "jobs.\u003cowner-kind\u003e.containers.\u003ccontainer-name\u003e.env-vars",
+      "valueType": "map[string]string",
+      "sources": [
+        "internal/resources/jobs/job.go:122"
+      ]
+    },
+    {
+      "key": "jobs.\u003cowner-kind\u003e.containers.\u003ccontainer-name\u003e.run-as",
+      "valueType": "object",
+      "objectType": "RunAs",
+      "objectFields": [
+        {
+          "name": "user",
+          "type": "*int64"
+        },
+        {
+          "name": "group",
+          "type": "*int64"
+        }
+      ],
+      "sources": [
+        "internal/resources/jobs/job.go:66"
+      ]
+    },
+    {
+      "key": "jobs.\u003cowner-kind\u003e.init-containers.\u003ccontainer-name\u003e.env-vars",
+      "valueType": "map[string]string",
+      "sources": [
+        "internal/resources/jobs/job.go:132"
+      ]
+    },
+    {
+      "key": "jobs.\u003cowner-kind\u003e.init-containers.\u003ccontainer-name\u003e.run-as",
+      "valueType": "object",
+      "objectType": "RunAs",
+      "objectFields": [
+        {
+          "name": "user",
+          "type": "*int64"
+        },
+        {
+          "name": "group",
+          "type": "*int64"
+        }
+      ],
+      "sources": [
+        "internal/resources/jobs/job.go:77"
+      ]
+    },
+    {
+      "key": "jobs.\u003cowner-kind\u003e.spec.template.annotations",
+      "valueType": "map[string]string",
+      "sources": [
+        "internal/resources/jobs/job.go:150"
+      ]
+    },
+    {
+      "key": "ledger.api.bulk-max-size",
+      "valueType": "int",
+      "sources": [
+        "internal/resources/ledgers/deployments.go:148"
+      ]
+    },
+    {
+      "key": "ledger.api.default-page-size",
+      "valueType": "int",
+      "sources": [
+        "internal/resources/ledgers/deployments.go:102"
+      ]
+    },
+    {
+      "key": "ledger.api.max-page-size",
+      "valueType": "int",
+      "sources": [
+        "internal/resources/ledgers/deployments.go:112"
+      ]
+    },
+    {
+      "key": "ledger.experimental-exporters",
+      "valueType": "bool",
+      "sources": [
+        "internal/resources/ledgers/deployments.go:174",
+        "internal/resources/ledgers/deployments.go:289"
+      ]
+    },
+    {
+      "key": "ledger.experimental-features",
+      "valueType": "bool",
+      "sources": [
+        "internal/resources/ledgers/deployments.go:74"
+      ]
+    },
+    {
+      "key": "ledger.experimental-numscript",
+      "valueType": "bool",
+      "sources": [
+        "internal/resources/ledgers/deployments.go:84"
+      ]
+    },
+    {
+      "key": "ledger.experimental-numscript-flags",
+      "valueType": "string[]",
+      "sources": [
+        "internal/resources/ledgers/deployments.go:94"
+      ]
+    },
+    {
+      "key": "ledger.logs.max-batch-size",
+      "valueType": "int",
+      "sources": [
+        "internal/resources/ledgers/deployments.go:480"
+      ]
+    },
+    {
+      "key": "ledger.schema-enforcement-mode",
+      "valueType": "string",
+      "sources": [
+        "internal/resources/ledgers/deployments.go:156",
+        "internal/resources/ledgers/deployments.go:264"
+      ]
+    },
+    {
+      "key": "ledger.worker.async-block-hasher",
+      "valueType": "object",
+      "objectType": "asyncBlockHasherConfiguration",
+      "objectFields": [
+        {
+          "name": "max-block-size",
+          "type": "string"
+        },
+        {
+          "name": "schedule",
+          "type": "string"
+        }
+      ],
+      "sources": [
+        "internal/resources/ledgers/deployments.go:234"
+      ]
+    },
+    {
+      "key": "ledger.worker.bucket-cleanup",
+      "valueType": "object",
+      "objectType": "bucketCleanupConfiguration",
+      "objectFields": [
+        {
+          "name": "retention-period",
+          "type": "string"
+        },
+        {
+          "name": "schedule",
+          "type": "string"
+        }
+      ],
+      "sources": [
+        "internal/resources/ledgers/deployments.go:273"
+      ]
+    },
+    {
+      "key": "ledger.worker.pipelines",
+      "valueType": "object",
+      "objectType": "pipelinesConfiguration",
+      "objectFields": [
+        {
+          "name": "pull-interval",
+          "type": "string"
+        },
+        {
+          "name": "push-retry-period",
+          "type": "string"
+        },
+        {
+          "name": "sync-period",
+          "type": "string"
+        },
+        {
+          "name": "logs-page-size",
+          "type": "string"
+        }
+      ],
+      "sources": [
+        "internal/resources/ledgers/deployments.go:246"
+      ]
+    },
+    {
+      "key": "logging.json",
+      "valueType": "bool",
+      "sources": [
+        "internal/resources/applications/application.go:392"
+      ]
+    },
+    {
+      "key": "modules.\u003cmodule-name\u003e.database.connection-pool",
+      "valueType": "object",
+      "objectType": "connectionPoolConfiguration",
+      "objectFields": [
+        {
+          "name": "max-idle",
+          "type": "string"
+        },
+        {
+          "name": "max-idle-time",
+          "type": "string"
+        },
+        {
+          "name": "max-open",
+          "type": "string"
+        },
+        {
+          "name": "max-lifetime",
+          "type": "string"
+        }
+      ],
+      "sources": [
+        "internal/resources/databases/env.go:72"
+      ]
+    },
+    {
+      "key": "namespace.annotations",
+      "valueType": "map[string]string",
+      "sources": [
+        "internal/resources/stacks/init.go:173"
+      ]
+    },
+    {
+      "key": "namespace.labels",
+      "valueType": "map[string]string",
+      "sources": [
+        "internal/resources/stacks/init.go:154"
+      ]
+    },
+    {
+      "key": "networkpolicies.enabled",
+      "valueType": "bool",
+      "sources": [
+        "internal/resources/stacks/networkpolicies.go:14"
+      ]
+    },
+    {
+      "key": "opentelemetry.\u003cmonitoring-type\u003e.dsn",
+      "valueType": "uri",
+      "sources": [
+        "internal/resources/settings/opentelemetry.go:52"
+      ]
+    },
+    {
+      "key": "opentelemetry.\u003cmonitoring-type\u003e.resource-attributes",
+      "valueType": "map[string]string",
+      "sources": [
+        "internal/resources/settings/opentelemetry.go:96"
+      ]
+    },
+    {
+      "key": "opentelemetry.traces.dsn",
+      "valueType": "uri",
+      "sources": [
+        "internal/resources/settings/opentelemetry.go:38"
+      ]
+    },
+    {
+      "key": "orchestration.max-parallel-activities",
+      "valueType": "int",
+      "default": "10",
+      "sources": [
+        "internal/resources/orchestrations/deployments.go:173"
+      ]
+    },
+    {
+      "key": "payments.encryption-key",
+      "valueType": "string",
+      "sources": [
+        "internal/resources/payments/deployments.go:31"
+      ]
+    },
+    {
+      "key": "payments.worker.temporal-max-concurrent-activity-task-pollers",
+      "valueType": "int",
+      "default": "4",
+      "sources": [
+        "internal/resources/payments/deployments.go:124"
+      ]
+    },
+    {
+      "key": "payments.worker.temporal-max-concurrent-workflow-task-pollers",
+      "valueType": "int",
+      "default": "4",
+      "sources": [
+        "internal/resources/payments/deployments.go:116"
+      ]
+    },
+    {
+      "key": "payments.worker.temporal-max-local-activity-slots",
+      "valueType": "int",
+      "default": "50",
+      "sources": [
+        "internal/resources/payments/deployments.go:140"
+      ]
+    },
+    {
+      "key": "payments.worker.temporal-max-slots-per-poller",
+      "valueType": "int",
+      "default": "10",
+      "sources": [
+        "internal/resources/payments/deployments.go:132"
+      ]
+    },
+    {
+      "key": "postgres.\u003cmodule-name\u003e.uri",
+      "valueType": "uri",
+      "sources": [
+        "internal/resources/databases/init.go:49"
+      ]
+    },
+    {
+      "key": "registries.\u003cname\u003e.endpoint",
+      "valueType": "string",
+      "sources": [
+        "internal/resources/registries/registries.go:76"
+      ]
+    },
+    {
+      "key": "registries.\u003cname\u003e.images.\u003cpath\u003e.rewrite",
+      "valueType": "string",
+      "sources": [
+        "internal/resources/registries/registries.go:68"
+      ]
+    },
+    {
+      "key": "services.\u003cservice-name\u003e.annotations",
+      "valueType": "map[string]string",
+      "sources": [
+        "internal/resources/services/services.go:83"
+      ]
+    },
+    {
+      "key": "services.\u003cservice-name\u003e.traffic-distribution",
+      "valueType": "string",
+      "sources": [
+        "internal/resources/services/services.go:88"
+      ]
+    },
+    {
+      "key": "temporal.dsn",
+      "valueType": "uri",
+      "sources": [
+        "internal/resources/orchestrations/deployments.go:80",
+        "internal/resources/payments/deployments.go:43"
+      ]
+    },
+    {
+      "key": "temporal.tls.crt",
+      "valueType": "string",
+      "sources": [
+        "internal/resources/orchestrations/deployments.go:124",
+        "internal/resources/payments/deployments.go:81"
+      ]
+    },
+    {
+      "key": "temporal.tls.key",
+      "valueType": "string",
+      "sources": [
+        "internal/resources/orchestrations/deployments.go:129",
+        "internal/resources/payments/deployments.go:89"
+      ]
+    },
+    {
+      "key": "transactionplane.worker-enabled",
+      "valueType": "bool",
+      "default": "false",
+      "sources": [
+        "internal/resources/transactionplane/deployments.go:125"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Why
The current settings reference is documented in Markdown, which is not a reliable source for deterministic generation of up-to-date docs.

This PR adds a code-derived exporter that scans the operator's Go call sites to `settings.*` and emits a machine-readable catalog from what the operator actually consumes.

## What Changed
- add `cmd/settings-catalog`, a static-analysis based exporter over Go AST call sites
- generate `docs/09-Configuration reference/settings.catalog.json`
- add a focused test for the exporter in `cmd/settings-catalog/main_test.go`
- wire regeneration into `just generate-settings-catalog`
- document the new generation flow in the README

## Output
The generated JSON catalog currently captures:
- setting keys and key patterns
- inferred value types such as `string`, `bool`, `int`, `uri`, `map[string]string`, and `object`
- defaults where the code uses `...OrDefault(...)`
- object field shapes for `GetAs[T]`
- source locations for each discovered setting consumer

## Approach
This is intentionally code-derived using statical analysis.

The exporter walks Go files, finds calls into the `settings` package, and reconstructs key patterns from the arguments passed to those helpers. It also expands helper patterns such as:
- `GetEnvVars(...)` to `...env-vars`
- `GetResourceRequirements(...)` to `...limits`, `...requests`, and `...claims`
- `GetAs[T](...)` to an `object` entry with the inferred object field shape when available

Static analysis was chosen here instead of introducing a runtime registry because the registry does not exist today, and adding one would turn this into a broader refactor of the settings layer rather than a focused exporter.

More concretely:
- the current source of truth for what settings exist is the set of `settings.*` call sites spread across the codebase
- static analysis lets us extract a useful catalog from that existing reality without changing runtime behavior
- it keeps the scope limited to documentation/export concerns rather than mixing in a new metadata model for settings
- it is a good bootstrap step even if we later decide to add a first-class registry and generate both docs and exports from it

In other words, this PR optimizes for extracting deterministic data from the current codebase with minimal behavioral risk. A registry is still a reasonable future direction, but it is a separate design change.

## Current Limits
This does not try to solve everything yet.

In particular, it does not currently provide:
- curated human descriptions or examples
- full URI query parameter semantics
- a first-class registry of settings metadata in code

Those can be layered on later. The goal here is to establish a deterministic machine-readable export from real code usage.

## Validation
- `go test ./cmd/settings-catalog`
- `go run ./cmd/settings-catalog --format json --output "./docs/09-Configuration reference/settings.catalog.json"`
