### PR TITLE
chore(deps): bump go-libs to pick up migrator index name fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.25
 toolchain go1.25.5
 
 require (
-	github.com/formancehq/go-libs/v2 v2.2.3
+	github.com/formancehq/go-libs/v2 v2.2.5-0.20260429152130-9d6efc1eb666
 	github.com/go-logr/logr v1.4.3
 	github.com/google/go-cmp v0.7.0
 	github.com/google/uuid v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -12,8 +12,8 @@ github.com/evanphx/json-patch v4.12.0+incompatible h1:4onqiflcdA9EOZ4RxV643DvftH
 github.com/evanphx/json-patch v4.12.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch/v5 v5.9.11 h1:/8HVnzMq13/3x9TPvjG08wUGqBTmZBsCWzjTM0wiaDU=
 github.com/evanphx/json-patch/v5 v5.9.11/go.mod h1:3j+LviiESTElxA4p3EMKAB9HXj3/XEtnUf6OZxqIQTM=
-github.com/formancehq/go-libs/v2 v2.2.3 h1:7irBJ4NfSkJdVKxXPktqVAoQa7hJcejmrXgjdgh27Zk=
-github.com/formancehq/go-libs/v2 v2.2.3/go.mod h1:JvBjEDWNf7izCy2dq/eI3aMc9d28gChBe1rjw5yYlAs=
+github.com/formancehq/go-libs/v2 v2.2.5-0.20260429152130-9d6efc1eb666 h1:9syUkZio+2nnwqw45141WCkWeup8Q6yI0GUcSsJXZLc=
+github.com/formancehq/go-libs/v2 v2.2.5-0.20260429152130-9d6efc1eb666/go.mod h1:JvBjEDWNf7izCy2dq/eI3aMc9d28gChBe1rjw5yYlAs=
 github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=
 github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/fxamacker/cbor/v2 v2.9.0 h1:NpKPmjDBgUfBms6tr6JZkTHtfFGcMKsw3eGcmD/sapM=


### PR DESCRIPTION
## Summary
- Bumps `github.com/formancehq/go-libs/v2` from `v2.2.3` to the head of [formancehq/go-libs#595](https://github.com/formancehq/go-libs/pull/595) (`9d6efc1eb666dcc8ceea39c40a7352bf0cea0364`).
- PR #595 is the backport of #594 to `release/v2.2` and fixes a hardcoded `idx_version_id` name collision between migrators sharing a schema (services were crashing at startup with `SQLSTATE 42P10`).
- Affected DBs self-heal on next deploy.

## Notes
- This uses a pseudo-version targeting the PR head. It should be re-pinned to a real `v2.2.x` tag once #595 is merged and tagged.

## Test plan
- [x] `go mod tidy` clean
- [x] `go build ./...` succeeds
- [ ] CI green
- [ ] Smoke deploy verifies migrator no longer panics on startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)