### PR TITLE
chore(ci): migrate from Shipfox to Namespace.so runners

### DIFF
--- a/.github/actions/default/action.yml
+++ b/.github/actions/default/action.yml
@@ -9,24 +9,14 @@ runs:
   steps:
     - name: Install Nix
       uses: cachix/install-nix-action@v31
-    ## Disabling cache for now, as it's slowing down the build. Downloading nix
-    ## dependencies from cache.nixos.org is faster than restoring from the cache.
-    #- name: Cache dependencies
-    #  uses: nix-community/cache-nix-action@v6
-    #  with:
-    #    primary-key: nix-${{ runner.os }}-${{ hashFiles('**/flake.nix', '**/flake.lock') }}
-    #    restore-prefixes-first-match: nix-${{ runner.os }}-
     - name: go env
       id: go-env
       shell: bash
       run: |
         nix develop --command bash -c "go env | sed -E \"s/^([^=]+)='(.*)'\$/\1=\2/\"" >> "$GITHUB_OUTPUT"
-    - uses: actions/cache@v5
+    - uses: namespacelabs/nscloud-cache-action@v1
       with:
         path: |
           ${{ steps.go-env.outputs.GOCACHE }}
           ${{ steps.go-env.outputs.GOMODCACHE }}
           ~/.cache/golangci-lint
-        key: ${{ runner.os }}-${{ github.job }}-go-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-${{ github.job }}-go-

--- a/.github/actions/env/action.yml
+++ b/.github/actions/env/action.yml
@@ -18,10 +18,8 @@ runs:
         registry: ghcr.io
         username: "NumaryBot"
         password: ${{ inputs.token }}
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@v4
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v4
+      uses: namespacelabs/nscloud-setup-buildx-action@v0
     - name: "Put back the git branch into git (Earthly uses it for tagging)"
       shell: bash
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
   PR:
     if: github.event_name == 'pull_request'
     name: Check PR Title
-    runs-on: "shipfox-2vcpu-ubuntu-2404"
+    runs-on: "namespace-profile-linux-amd64-2vcpu"
     permissions:
       statuses: write
     steps:
@@ -25,9 +25,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   Dirty:
-    runs-on: "shipfox-4vcpu-ubuntu-2404"
+    runs-on: "namespace-profile-linux-amd64-4vcpu"
     steps:
-      - uses: 'actions/checkout@v6'
+      - uses: 'namespacelabs/nscloud-checkout-action@v7'
         with:
           fetch-depth: 0
       - name: Setup Env
@@ -55,9 +55,9 @@ jobs:
           PR_URL: ${{github.event.pull_request.html_url}}
           GH_TOKEN: ${{secrets.NUMARY_GITHUB_TOKEN}}
   Tests:
-    runs-on: "shipfox-8vcpu-ubuntu-2404"
+    runs-on: "namespace-profile-linux-amd64-8vcpu"
     steps:
-      - uses: 'actions/checkout@v6'
+      - uses: 'namespacelabs/nscloud-checkout-action@v7'
         with:
           fetch-depth: 0
       - name: Setup Env
@@ -69,10 +69,10 @@ jobs:
         env:
           SPEAKEASY_API_KEY: ${{ secrets.SPEAKEASY_API_KEY }}
   GoReleaser:
-    runs-on: "shipfox-4vcpu-ubuntu-2404"
+    runs-on: "namespace-profile-linux-amd64-4vcpu"
     if: contains(github.event.pull_request.labels.*.name, 'build-images') || github.ref == 'refs/heads/main' || github.event_name == 'merge_group'
     steps:
-      - uses: 'actions/checkout@v6'
+      - uses: 'namespacelabs/nscloud-checkout-action@v7'
         with:
           fetch-depth: 0
       - name: Setup Env
@@ -105,7 +105,7 @@ jobs:
           args: ${{ vars.TS_ARGS }}
           retry: ${{ vars.TS_RETRY }}
           timeout: ${{ vars.TS_TIMEOUT }}
-      - uses: 'actions/checkout@v6'
+      - uses: 'namespacelabs/nscloud-checkout-action@v7'
         with:
           fetch-depth: 0
       - name: Install Nix

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -8,9 +8,9 @@ permissions:
 
 jobs:
   GoReleaser:
-    runs-on: "shipfox-4vcpu-ubuntu-2404"
+    runs-on: "namespace-profile-linux-amd64-4vcpu"
     steps:
-      - uses: 'actions/checkout@v6'
+      - uses: 'namespacelabs/nscloud-checkout-action@v7'
         with:
           fetch-depth: 0
       - name: Setup Env


### PR DESCRIPTION
## Summary

Migrate CI runners from Shipfox to Namespace.so as part of the org-wide CI infrastructure migration.

### Per-workflow changes
- `runs-on: shipfox-Xvcpu-ubuntu-2404` → `runs-on: namespace-profile-linux-amd64-Xvcpu`
- `actions/checkout@v6` → `namespacelabs/nscloud-checkout-action@v7` (git mirror caching)
- `docker/setup-qemu-action` removed (Namespace builds AMD64+ARM64 natively without emulation)
- `docker/setup-buildx-action` → `namespacelabs/nscloud-setup-buildx-action@v0` (Remote Builders)

### Composite changes
- `nix-community/cache-nix-action` removed (incompatible with Namespace runner setup)
- `actions/cache` → `namespacelabs/nscloud-cache-action@v1` (paths preserved)

### Validation
- Reference migration: formancehq/ledger#1336 plus 4× banking-bridge + 16 other repos already merged or green.

## Test plan
- [ ] CI passes on this PR
- [ ] No regression in build duration vs prior shipfox runs
