### PR TITLE
fix(orchestrations): provision broker topic for events

### DIFF
--- a/internal/resources/brokers/init.go
+++ b/internal/resources/brokers/init.go
@@ -2,6 +2,8 @@ package brokers
 
 import (
 	v1 "k8s.io/api/batch/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/formancehq/operator/v3/api/formance.com/v1beta1"
 	"github.com/formancehq/operator/v3/internal/core"
@@ -17,6 +19,15 @@ func init() {
 			core.WithFinalizer[*v1beta1.Broker]("clear", deleteBroker),
 			core.WithOwn[*v1beta1.Broker](&v1.Job{}),
 			core.WithWatchSettings[*v1beta1.Broker](),
+			// In one-stream-by-service mode, new topics require the broker to reconcile
+			// and provision the matching stream.
+			core.WithWatch[*v1beta1.Broker, *v1beta1.BrokerTopic](func(ctx core.Context, topic *v1beta1.BrokerTopic) []reconcile.Request {
+				return []reconcile.Request{{
+					NamespacedName: types.NamespacedName{
+						Name: topic.Spec.Stack,
+					},
+				}}
+			}),
 		),
 	)
 }

--- a/internal/resources/brokertopics/brokertopics.go
+++ b/internal/resources/brokertopics/brokertopics.go
@@ -1,11 +1,40 @@
 package brokertopics
 
 import (
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	v1beta1 "github.com/formancehq/operator/v3/api/formance.com/v1beta1"
 	"github.com/formancehq/operator/v3/internal/core"
 )
+
+func Create(ctx core.Context, stack *v1beta1.Stack, owner interface {
+	client.Object
+	GetStack() string
+}, service string) (*v1beta1.BrokerTopic, error) {
+	topic, _, err := core.CreateOrUpdate[*v1beta1.BrokerTopic](ctx, types.NamespacedName{
+		Name: core.GetObjectName(stack.Name, service),
+	}, func(t *v1beta1.BrokerTopic) error {
+		t.Spec.Stack = owner.GetStack()
+		t.Spec.Service = service
+
+		if err := controllerutil.SetOwnerReference(owner, t, ctx.GetScheme()); err != nil {
+			return err
+		}
+
+		if err := controllerutil.SetOwnerReference(stack, t, ctx.GetScheme()); err != nil {
+			return err
+		}
+
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return topic, nil
+}
 
 func Find(ctx core.Context, stack *v1beta1.Stack, name string) (*v1beta1.BrokerTopic, error) {
 	topicList := &v1beta1.BrokerTopicList{}

--- a/internal/resources/orchestrations/init.go
+++ b/internal/resources/orchestrations/init.go
@@ -52,12 +52,21 @@ func Reconcile(ctx Context, stack *v1beta1.Stack, o *v1beta1.Orchestration, vers
 		return err
 	}
 
+	topic, err := brokertopics.Create(ctx, stack, o, "orchestration")
+	if err != nil {
+		return err
+	}
+
 	if err := gatewayhttpapis.Create(ctx, o, gatewayhttpapis.WithHealthCheckEndpoint("_healthcheck")); err != nil {
 		return err
 	}
 
 	if !database.Status.Ready {
 		return NewPendingError().WithMessage("database not ready")
+	}
+
+	if !topic.Status.Ready {
+		return NewPendingError().WithMessage("broker topic not ready")
 	}
 
 	imageConfiguration, err := registries.GetFormanceImage(ctx, stack, "orchestration", version)

--- a/internal/tests/orchestration_controller_test.go
+++ b/internal/tests/orchestration_controller_test.go
@@ -128,6 +128,13 @@ var _ = Describe("OrchestrationController", func() {
 					return LoadResource("", orchestration.Name+"-orchestration", consumer)
 				}).Should(Succeed())
 			})
+			By("Should create a BrokerTopic for orchestration events", func() {
+				topic := &v1beta1.BrokerTopic{}
+				Eventually(func(g Gomega) *v1beta1.BrokerTopic {
+					g.Expect(LoadResource("", core.GetObjectName(stack.Name, "orchestration"), topic)).To(Succeed())
+					return topic
+				}).Should(BeOwnedBy(orchestration))
+			})
 		})
 	})
 })


### PR DESCRIPTION
## Summary
- create a BrokerTopic for orchestration's own published events
- wait for that topic to be ready before deploying orchestration
- reconcile Broker resources when BrokerTopic resources change, so newly-created topics get their NATS streams

## Context
A production stack using OneStreamByService had publisher mapping `*:xjqfdgkwngtt-rzbk-orchestration` with NATS auto-provision disabled, but no matching BrokerTopic/JetStream stream was created. Workflow startup events then failed with `nats: no response from stream`.

## Tests
- `go test ./internal/resources/brokers ./internal/resources/brokertopics ./internal/resources/orchestrations ./internal/resources/brokerconsumers`
- `ASSETS=$(go run sigs.k8s.io/controller-runtime/tools/setup-envtest@latest use 1.32.0 -p path) && CGO_ENABLED=0 KUBEBUILDER_ASSETS="$ASSETS" go test ./internal/tests -ginkgo.focus 'OrchestrationController|BrokerTopicController|BrokerConsumer'`
