### PR TITLE
test: improve critical deployment coverage

### DIFF
--- a/api/formance.com/v1beta1/shared_test.go
+++ b/api/formance.com/v1beta1/shared_test.go
@@ -1,0 +1,100 @@
+package v1beta1
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestConditionsAppendReplaceDeleteAndCheck(t *testing.T) {
+	t.Parallel()
+
+	conditions := Conditions{}
+	conditions.AppendOrReplace(*NewCondition("Ready", 1).SetReason("B"), ConditionTypeMatch("Ready"))
+	conditions.AppendOrReplace(*NewCondition("Ready", 2).SetReason("A"), ConditionTypeMatch("Ready"))
+	conditions.AppendOrReplace(*NewCondition("Synced", 2).SetReason("A"), ConditionTypeMatch("Synced"))
+
+	require.Len(t, conditions, 2)
+	require.Equal(t, "Ready", conditions[0].Type)
+	require.Equal(t, int64(2), conditions[0].ObservedGeneration)
+	require.True(t, conditions.Check(AndConditions(
+		ConditionTypeMatch("Ready"),
+		ConditionReasonMatch("A"),
+		ConditionGenerationMatch(2),
+	)))
+	require.NotNil(t, conditions.Get("Synced"))
+
+	conditions.Delete(ConditionTypeMatch("Ready"))
+	require.Len(t, conditions, 1)
+	require.Nil(t, conditions.Get("Ready"))
+}
+
+func TestConditionStatusHelpers(t *testing.T) {
+	t.Parallel()
+
+	condition := NewCondition("Ready", 3).SetReason("Spec").Fail("not ready")
+	require.Equal(t, metav1.ConditionFalse, condition.Status)
+	require.Equal(t, "not ready", condition.Message)
+	require.Equal(t, "Spec", condition.Reason)
+
+	status := Status{}
+	status.SetReady(true)
+	status.SetError("ok")
+	require.True(t, status.Ready)
+	require.Equal(t, "ok", status.Info)
+}
+
+func TestModulePropertiesCompareVersion(t *testing.T) {
+	t.Parallel()
+
+	stack := &Stack{Spec: StackSpec{Version: "v2.0.0"}}
+	require.Equal(t, 0, (&ModuleProperties{}).CompareVersion(stack, "v2.0.0"))
+	require.Equal(t, 1, (&ModuleProperties{Version: "v2.1.0"}).CompareVersion(stack, "v2.0.0"))
+	require.Equal(t, -1, (&ModuleProperties{Version: "v1.9.0"}).CompareVersion(stack, "v2.0.0"))
+	require.Equal(t, 1, (&ModuleProperties{Version: "main"}).CompareVersion(stack, "v2.0.0"))
+}
+
+func TestURIJSONAndWithoutQuery(t *testing.T) {
+	t.Parallel()
+
+	uri, err := ParseURL("postgresql://user:pass@example.com:5432/db?secret=value")
+	require.NoError(t, err)
+
+	data, err := json.Marshal(uri)
+	require.NoError(t, err)
+	require.JSONEq(t, `"postgresql://user:pass@example.com:5432/db?secret=value"`, string(data))
+
+	var decoded URI
+	require.NoError(t, json.Unmarshal(data, &decoded))
+	require.Equal(t, uri.String(), decoded.String())
+	require.Equal(t, "postgresql://user:pass@example.com:5432/db", uri.WithoutQuery().String())
+	require.False(t, uri.IsZero())
+	require.Equal(t, "nil", URI{}.String())
+}
+
+func TestGatewayHosts(t *testing.T) {
+	t.Parallel()
+
+	ingress := GatewayIngress{
+		Host:  "primary.example.com",
+		Hosts: []string{"", "secondary.example.com", "primary.example.com"},
+	}
+
+	require.Equal(t, []string{"primary.example.com", "secondary.example.com"}, ingress.GetHosts())
+	require.Equal(t, []string{"a", "b"}, DedupHosts([]string{"a", "", "b", "a"}))
+}
+
+func TestAuthClientSpecMarshalYAMLShape(t *testing.T) {
+	t.Parallel()
+
+	withSecret, err := yaml.Marshal(AuthClientSpec{ID: "client", Secret: "secret"})
+	require.NoError(t, err)
+	require.Contains(t, string(withSecret), "secrets:\n    - secret")
+
+	withoutSecret, err := yaml.Marshal(AuthClientSpec{ID: "public"})
+	require.NoError(t, err)
+	require.Contains(t, string(withoutSecret), "secrets: []")
+}

--- a/api/formance.com/v1beta1/status_methods_test.go
+++ b/api/formance.com/v1beta1/status_methods_test.go
@@ -1,0 +1,159 @@
+package v1beta1
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type readyObject interface {
+	SetReady(bool)
+	IsReady() bool
+	SetError(string)
+	GetConditions() *Conditions
+}
+
+func TestReadyObjectsStatusMethods(t *testing.T) {
+	t.Parallel()
+
+	objects := []readyObject{
+		&Auth{}, &AuthClient{}, &Benthos{}, &BenthosStream{}, &Broker{}, &BrokerConsumer{},
+		&BrokerTopic{}, &Database{}, &Gateway{}, &GatewayHTTPAPI{}, &Ledger{}, &Orchestration{},
+		&Payments{}, &Reconciliation{}, &ResourceReference{}, &Search{}, &Stack{}, &Stargate{},
+		&TransactionPlane{}, &Wallets{}, &Webhooks{},
+	}
+
+	for _, object := range objects {
+		object.SetReady(true)
+		object.SetError("ready")
+		object.GetConditions().AppendOrReplace(*NewCondition("Ready", 1), ConditionTypeMatch("Ready"))
+
+		require.True(t, object.IsReady())
+		require.NotNil(t, object.GetConditions().Get("Ready"))
+	}
+}
+
+func TestStackAndSettingsMethods(t *testing.T) {
+	t.Parallel()
+
+	stack := &Stack{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{SkipLabel: "true"},
+		},
+		Spec: StackSpec{Version: "v1.2.3"},
+	}
+
+	require.True(t, stack.MustSkip())
+	require.Equal(t, "v1.2.3", stack.GetVersion())
+
+	settings := &Settings{Spec: SettingsSpec{Stacks: []string{"*"}}}
+	require.Equal(t, []string{"*"}, settings.GetStacks())
+	require.True(t, settings.IsWildcard())
+
+	settings.Spec.Stacks = []string{"stack0", "stack1"}
+	require.False(t, settings.IsWildcard())
+}
+
+func TestModuleMethods(t *testing.T) {
+	t.Parallel()
+
+	auth := Auth{Spec: AuthSpec{StackDependency: StackDependency{Stack: "stack0"}, ModuleProperties: ModuleProperties{Version: "v1", DevProperties: DevProperties{Debug: true, Dev: true}}}}
+	require.True(t, auth.IsEE())
+	require.Equal(t, "v1", (&auth).GetVersion())
+	require.Equal(t, "stack0", auth.GetStack())
+	require.True(t, auth.IsDebug())
+	require.True(t, auth.IsDev())
+
+	gateway := Gateway{Spec: GatewaySpec{StackDependency: StackDependency{Stack: "stack0"}, ModuleProperties: ModuleProperties{Version: "v1", DevProperties: DevProperties{Debug: true, Dev: true}}}}
+	require.False(t, gateway.IsEE())
+	require.Equal(t, "v1", (&gateway).GetVersion())
+	require.Equal(t, "stack0", gateway.GetStack())
+	require.True(t, gateway.IsDebug())
+	require.True(t, gateway.IsDev())
+
+	ledger := Ledger{Spec: LedgerSpec{StackDependency: StackDependency{Stack: "stack0"}, ModuleProperties: ModuleProperties{Version: "v1", DevProperties: DevProperties{Debug: true, Dev: true}}}}
+	require.False(t, ledger.IsEE())
+	require.Equal(t, "v1", (&ledger).GetVersion())
+	require.Equal(t, "stack0", ledger.GetStack())
+	require.True(t, ledger.IsDebug())
+	require.True(t, ledger.IsDev())
+	ledger.isEventPublisher()
+
+	orchestration := Orchestration{Spec: OrchestrationSpec{StackDependency: StackDependency{Stack: "stack0"}, ModuleProperties: ModuleProperties{Version: "v1", DevProperties: DevProperties{Debug: true, Dev: true}}}}
+	require.True(t, orchestration.IsEE())
+	require.Equal(t, "v1", (&orchestration).GetVersion())
+	require.Equal(t, "stack0", orchestration.GetStack())
+	require.True(t, orchestration.IsDebug())
+	require.True(t, orchestration.IsDev())
+	orchestration.isEventPublisher()
+
+	payments := Payments{Spec: PaymentsSpec{StackDependency: StackDependency{Stack: "stack0"}, ModuleProperties: ModuleProperties{Version: "v1", DevProperties: DevProperties{Debug: true, Dev: true}}}}
+	require.False(t, payments.IsEE())
+	require.Equal(t, "v1", (&payments).GetVersion())
+	require.Equal(t, "stack0", payments.GetStack())
+	require.True(t, payments.IsDebug())
+	require.True(t, payments.IsDev())
+	payments.isEventPublisher()
+
+	reconciliation := Reconciliation{Spec: ReconciliationSpec{StackDependency: StackDependency{Stack: "stack0"}, ModuleProperties: ModuleProperties{Version: "v1", DevProperties: DevProperties{Debug: true, Dev: true}}}}
+	require.True(t, reconciliation.IsEE())
+	require.Equal(t, "v1", (&reconciliation).GetVersion())
+	require.Equal(t, "stack0", reconciliation.GetStack())
+	require.True(t, reconciliation.IsDebug())
+	require.True(t, reconciliation.IsDev())
+
+	search := Search{Spec: SearchSpec{StackDependency: StackDependency{Stack: "stack0"}, ModuleProperties: ModuleProperties{Version: "v1", DevProperties: DevProperties{Debug: true, Dev: true}}}}
+	require.True(t, search.IsEE())
+	require.Equal(t, "v1", (&search).GetVersion())
+	require.Equal(t, "stack0", search.GetStack())
+	require.True(t, search.IsDebug())
+	require.True(t, search.IsDev())
+
+	stargate := Stargate{Spec: StargateSpec{StackDependency: StackDependency{Stack: "stack0"}, ModuleProperties: ModuleProperties{Version: "v1", DevProperties: DevProperties{Debug: true, Dev: true}}}}
+	require.False(t, stargate.IsEE())
+	require.Equal(t, "v1", (&stargate).GetVersion())
+	require.Equal(t, "stack0", stargate.GetStack())
+	require.True(t, stargate.IsDebug())
+	require.True(t, stargate.IsDev())
+
+	transactionPlane := TransactionPlane{Spec: TransactionPlaneSpec{StackDependency: StackDependency{Stack: "stack0"}, ModuleProperties: ModuleProperties{Version: "v1", DevProperties: DevProperties{Debug: true, Dev: true}}}}
+	require.False(t, transactionPlane.IsEE())
+	require.Equal(t, "v1", (&transactionPlane).GetVersion())
+	require.Equal(t, "stack0", transactionPlane.GetStack())
+	require.True(t, transactionPlane.IsDebug())
+	require.True(t, transactionPlane.IsDev())
+	transactionPlane.isEventPublisher()
+
+	wallets := Wallets{Spec: WalletsSpec{StackDependency: StackDependency{Stack: "stack0"}, ModuleProperties: ModuleProperties{Version: "v1", DevProperties: DevProperties{Debug: true, Dev: true}}}}
+	require.True(t, wallets.IsEE())
+	require.Equal(t, "v1", (&wallets).GetVersion())
+	require.Equal(t, "stack0", wallets.GetStack())
+	require.True(t, wallets.IsDebug())
+	require.True(t, wallets.IsDev())
+
+	webhooks := Webhooks{Spec: WebhooksSpec{StackDependency: StackDependency{Stack: "stack0"}, ModuleProperties: ModuleProperties{Version: "v1", DevProperties: DevProperties{Debug: true, Dev: true}}}}
+	require.True(t, webhooks.IsEE())
+	require.Equal(t, "v1", (&webhooks).GetVersion())
+	require.Equal(t, "stack0", webhooks.GetStack())
+	require.True(t, webhooks.IsDebug())
+	require.True(t, webhooks.IsDev())
+}
+
+func TestDependentAndResourceGetStackMethods(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, "stack0", AuthClient{Spec: AuthClientSpec{StackDependency: StackDependency{Stack: "stack0"}}}.GetStack())
+	require.Equal(t, "stack0", Benthos{Spec: BenthosSpec{StackDependency: StackDependency{Stack: "stack0"}}}.GetStack())
+	require.Equal(t, "stack0", BenthosStream{Spec: BenthosStreamSpec{StackDependency: StackDependency{Stack: "stack0"}}}.GetStack())
+	require.Equal(t, "stack0", (&Broker{Spec: BrokerSpec{StackDependency: StackDependency{Stack: "stack0"}}}).GetStack())
+	require.Equal(t, "stack0", (&BrokerConsumer{Spec: BrokerConsumerSpec{StackDependency: StackDependency{Stack: "stack0"}}}).GetStack())
+	topic := &BrokerTopic{Spec: BrokerTopicSpec{StackDependency: StackDependency{Stack: "stack0"}}}
+	require.Equal(t, "stack0", topic.GetStack())
+	topic.isResource()
+	database := &Database{Spec: DatabaseSpec{StackDependency: StackDependency{Stack: "stack0"}}}
+	require.Equal(t, "stack0", database.GetStack())
+	database.isResource()
+	require.Equal(t, "stack0", GatewayHTTPAPI{Spec: GatewayHTTPAPISpec{StackDependency: StackDependency{Stack: "stack0"}}}.GetStack())
+	require.Equal(t, "stack0", (&ResourceReference{Spec: ResourceReferenceSpec{StackDependency: StackDependency{Stack: "stack0"}}}).GetStack())
+}

--- a/internal/core/dependencies_test.go
+++ b/internal/core/dependencies_test.go
@@ -1,0 +1,467 @@
+package core_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/formancehq/operator/v3/api/formance.com/v1beta1"
+	"github.com/formancehq/operator/v3/internal/core"
+	"github.com/formancehq/operator/v3/internal/testutil"
+)
+
+func TestStackDependencyLookups(t *testing.T) {
+	t.Parallel()
+
+	auth := unstructuredDependency("Auth", "auth0", "stack0")
+	other := unstructuredDependency("Auth", "auth1", "stack1")
+	ctx := testutil.NewContext(auth, other)
+
+	var auths []*v1beta1.Auth
+	require.NoError(t, core.GetAllStackDependencies(ctx, "stack0", &auths))
+	require.Len(t, auths, 1)
+	require.Equal(t, "auth0", auths[0].Name)
+	require.Equal(t, "stack0", auths[0].Spec.Stack)
+
+	single := &v1beta1.Auth{}
+	require.NoError(t, core.GetSingleDependency(ctx, "stack0", single))
+	require.Equal(t, "auth0", single.Name)
+
+	found, err := core.HasDependency(ctx, "stack0", &v1beta1.Auth{})
+	require.NoError(t, err)
+	require.True(t, found)
+
+	found, err = core.GetIfExists(ctx, "missing", &v1beta1.Auth{})
+	require.NoError(t, err)
+	require.False(t, found)
+}
+
+func TestStackDependencyLookupErrors(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.NewContext(
+		unstructuredDependency("Auth", "auth0", "stack0"),
+		unstructuredDependency("Auth", "auth1", "stack0"),
+	)
+
+	require.True(t, errors.Is(core.GetSingleDependency(ctx, "missing", &v1beta1.Auth{}), core.ErrNotFound))
+	require.True(t, errors.Is(core.GetSingleDependency(ctx, "stack0", &v1beta1.Auth{}), core.ErrMultipleInstancesFound))
+
+	found, err := core.HasDependency(ctx, "stack0", &v1beta1.Auth{})
+	require.NoError(t, err)
+	require.True(t, found)
+
+	found, err = core.GetIfExists(ctx, "stack0", &v1beta1.Auth{})
+	require.ErrorIs(t, err, core.ErrMultipleInstancesFound)
+	require.False(t, found)
+}
+
+func TestBuildAndMapReconcileRequests(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.NewContext(
+		unstructuredDependency("Auth", "auth0", "stack0"),
+		unstructuredDependency("Auth", "auth1", "stack1"),
+	)
+
+	requests := core.BuildReconcileRequests(context.Background(), ctx.GetClient(), ctx.GetScheme(), &v1beta1.Auth{}, client.MatchingFields{"stack": "stack0"})
+	require.Equal(t, []reconcile.Request{{
+		NamespacedName: types.NamespacedName{Name: "auth0"},
+	}}, requests)
+
+	require.Equal(t, []reconcile.Request{{
+		NamespacedName: types.NamespacedName{Name: "manual", Namespace: "ns"},
+	}}, core.MapObjectToReconcileRequests(&v1beta1.Auth{
+		ObjectMeta: withNamespace(testutil.ObjectMeta("manual"), "ns"),
+	}))
+}
+
+func TestWatchDependentsAndStack(t *testing.T) {
+	t.Parallel()
+
+	auth := unstructuredDependency("Auth", "auth0", "stack0")
+	ctx := testutil.NewContext(auth)
+	mgr := &testutil.Manager{Client: ctx.GetClient(), Scheme: ctx.GetScheme()}
+
+	dependentWatcher := core.WatchDependents(mgr, &v1beta1.Auth{})
+	requests := dependentWatcher(context.Background(), &v1beta1.Database{Spec: v1beta1.DatabaseSpec{
+		StackDependency: v1beta1.StackDependency{Stack: "stack0"},
+	}})
+	require.Equal(t, []reconcile.Request{{
+		NamespacedName: types.NamespacedName{Name: "auth0"},
+	}}, requests)
+
+	stackWatcher := core.Watch(mgr, &v1beta1.Auth{})
+	requests = stackWatcher(context.Background(), &v1beta1.Stack{ObjectMeta: testutil.ObjectMeta("stack0")})
+	require.Equal(t, []reconcile.Request{{
+		NamespacedName: types.NamespacedName{Name: "auth0"},
+	}}, requests)
+}
+
+func TestForObjectControllerStatusHandling(t *testing.T) {
+	t.Parallel()
+
+	t.Run("success", func(t *testing.T) {
+		object := &v1beta1.Auth{}
+		controller := core.ForObjectController(func(core.Context, *core.ReconcilerOptions[*v1beta1.Auth], *v1beta1.Auth) error {
+			return nil
+		})
+
+		err := controller(testutil.NewContext(), &core.ReconcilerOptions[*v1beta1.Auth]{}, object)
+		require.NoError(t, err)
+		require.True(t, object.IsReady())
+		require.Equal(t, "Up to date", object.Status.Info)
+	})
+
+	t.Run("application error updates status without requeue error", func(t *testing.T) {
+		object := &v1beta1.Auth{}
+		controller := core.ForObjectController(func(core.Context, *core.ReconcilerOptions[*v1beta1.Auth], *v1beta1.Auth) error {
+			return core.NewPendingError().WithMessage("waiting")
+		})
+
+		err := controller(testutil.NewContext(), &core.ReconcilerOptions[*v1beta1.Auth]{}, object)
+		require.NoError(t, err)
+		require.False(t, object.IsReady())
+		require.Equal(t, "waiting", object.Status.Info)
+	})
+
+	t.Run("regular error bubbles up", func(t *testing.T) {
+		object := &v1beta1.Auth{}
+		controller := core.ForObjectController(func(core.Context, *core.ReconcilerOptions[*v1beta1.Auth], *v1beta1.Auth) error {
+			return fmt.Errorf("boom")
+		})
+
+		err := controller(testutil.NewContext(), &core.ReconcilerOptions[*v1beta1.Auth]{}, object)
+		require.EqualError(t, err, "boom")
+		require.False(t, object.IsReady())
+		require.Equal(t, "boom", object.Status.Info)
+	})
+
+	t.Run("pending observed condition marks object not ready", func(t *testing.T) {
+		object := &v1beta1.Auth{ObjectMeta: metav1.ObjectMeta{Generation: 7}}
+		object.GetConditions().AppendOrReplace(v1beta1.Condition{
+			Type:               "DatabaseReady",
+			Status:             metav1.ConditionFalse,
+			Reason:             "Pending",
+			ObservedGeneration: 7,
+		}, v1beta1.ConditionTypeMatch("DatabaseReady"))
+		controller := core.ForObjectController(func(core.Context, *core.ReconcilerOptions[*v1beta1.Auth], *v1beta1.Auth) error {
+			return nil
+		})
+
+		err := controller(testutil.NewContext(), &core.ReconcilerOptions[*v1beta1.Auth]{}, object)
+		require.NoError(t, err)
+		require.False(t, object.IsReady())
+		require.Equal(t, "pending condition: DatabaseReady/Pending", object.Status.Info)
+	})
+}
+
+func TestForStackDependency(t *testing.T) {
+	t.Parallel()
+
+	t.Run("missing stack returns application error", func(t *testing.T) {
+		object := &v1beta1.Auth{Spec: v1beta1.AuthSpec{StackDependency: v1beta1.StackDependency{Stack: "missing"}}}
+		controller := core.ForStackDependency(func(core.Context, *v1beta1.Stack, *core.ReconcilerOptions[*v1beta1.Auth], *v1beta1.Auth) error {
+			t.Fatal("controller should not be called")
+			return nil
+		}, false)
+
+		err := controller(testutil.NewContext(), &core.ReconcilerOptions[*v1beta1.Auth]{}, object)
+		require.True(t, core.IsApplicationError(err))
+		require.EqualError(t, err, "stack not found")
+	})
+
+	t.Run("skipped stack records reconciled condition", func(t *testing.T) {
+		stack := &v1beta1.Stack{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:       "stack0",
+				Generation: 3,
+				Annotations: map[string]string{
+					v1beta1.SkipLabel: "true",
+				},
+			},
+		}
+		object := &v1beta1.Auth{Spec: v1beta1.AuthSpec{StackDependency: v1beta1.StackDependency{Stack: "stack0"}}}
+		controller := core.ForStackDependency(func(core.Context, *v1beta1.Stack, *core.ReconcilerOptions[*v1beta1.Auth], *v1beta1.Auth) error {
+			t.Fatal("controller should not be called")
+			return nil
+		}, false)
+
+		err := controller(testutil.NewContext(stack), &core.ReconcilerOptions[*v1beta1.Auth]{}, object)
+		require.NoError(t, err)
+		condition := object.GetConditions().Get("ReconciledWithStack")
+		require.NotNil(t, condition)
+		require.Equal(t, "Skipped", condition.Reason)
+		require.Equal(t, int64(3), condition.ObservedGeneration)
+	})
+
+	t.Run("deleted stack is rejected unless allowed", func(t *testing.T) {
+		now := metav1.Now()
+		stack := &v1beta1.Stack{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "stack0",
+				DeletionTimestamp: &now,
+				Finalizers:        []string{"keep"},
+			},
+		}
+		object := &v1beta1.Auth{Spec: v1beta1.AuthSpec{StackDependency: v1beta1.StackDependency{Stack: "stack0"}}}
+		called := false
+		controller := core.ForStackDependency(func(core.Context, *v1beta1.Stack, *core.ReconcilerOptions[*v1beta1.Auth], *v1beta1.Auth) error {
+			called = true
+			return nil
+		}, false)
+
+		err := controller(testutil.NewContext(stack), &core.ReconcilerOptions[*v1beta1.Auth]{}, object)
+		require.True(t, core.IsApplicationError(err))
+		require.False(t, called)
+
+		allowDeletedController := core.ForStackDependency(func(core.Context, *v1beta1.Stack, *core.ReconcilerOptions[*v1beta1.Auth], *v1beta1.Auth) error {
+			called = true
+			return nil
+		}, true)
+		err = allowDeletedController(testutil.NewContext(stack), &core.ReconcilerOptions[*v1beta1.Auth]{}, object)
+		require.NoError(t, err)
+		require.True(t, called)
+	})
+}
+
+func TestReconcilerOptions(t *testing.T) {
+	t.Parallel()
+
+	options := core.ReconcilerOptions[*v1beta1.Auth]{
+		Owns:     map[client.Object][]builder.OwnsOption{},
+		Watchers: map[client.Object]core.ReconcilerOptionsWatch{},
+	}
+
+	rawCalled := false
+	core.WithOwn[*v1beta1.Auth](&appsv1.Deployment{})(&options)
+	core.WithRaw[*v1beta1.Auth](func(core.Context, *builder.Builder) error {
+		rawCalled = true
+		return nil
+	})(&options)
+	core.WithFinalizer[*v1beta1.Auth]("cleanup", func(core.Context, *v1beta1.Auth) error {
+		return nil
+	})(&options)
+	core.WithWatchSettings[*v1beta1.Auth]()(&options)
+	core.WithWatchDependency[*v1beta1.Auth](&v1beta1.Database{})(&options)
+	core.WithWatchStack[*v1beta1.Auth]()(&options)
+	core.WithWatch[*v1beta1.Auth](func(core.Context, *v1beta1.Database) []reconcile.Request {
+		return []reconcile.Request{{NamespacedName: types.NamespacedName{Name: "auth0"}}}
+	})(&options)
+
+	require.Len(t, options.Owns, 1)
+	require.Len(t, options.Raws, 1)
+	require.Len(t, options.Finalizers, 1)
+	require.Len(t, options.Watchers, 4)
+	require.NoError(t, options.Raws[0](testutil.NewContext(), nil))
+	require.True(t, rawCalled)
+
+	ctx := testutil.NewContext(unstructuredDependency("Auth", "auth0", "stack0"))
+	mgr := &testutil.Manager{Client: ctx.GetClient(), Scheme: ctx.GetScheme()}
+	for watched, watcher := range options.Watchers {
+		handler, watchOptions := watcher.Handler(mgr, nil, &v1beta1.Auth{})
+		require.NotNil(t, handler)
+		if _, ok := watched.(*v1beta1.Stack); ok {
+			require.Len(t, watchOptions, 1)
+		}
+	}
+}
+
+func TestGetModuleVersion(t *testing.T) {
+	t.Parallel()
+
+	t.Run("module version wins", func(t *testing.T) {
+		ctx := testutil.NewContext()
+		stack := &v1beta1.Stack{ObjectMeta: testutil.ObjectMeta("stack0"), Spec: v1beta1.StackSpec{Version: "v-stack"}}
+		module := &v1beta1.Auth{Spec: v1beta1.AuthSpec{ModuleProperties: v1beta1.ModuleProperties{Version: "v-module"}}}
+
+		version, err := core.GetModuleVersion(ctx, stack, module)
+		require.NoError(t, err)
+		require.Equal(t, "v-module", version)
+	})
+
+	t.Run("stack version is fallback", func(t *testing.T) {
+		ctx := testutil.NewContext()
+		stack := &v1beta1.Stack{ObjectMeta: testutil.ObjectMeta("stack0"), Spec: v1beta1.StackSpec{Version: "v-stack"}}
+
+		version, err := core.GetModuleVersion(ctx, stack, &v1beta1.Auth{})
+		require.NoError(t, err)
+		require.Equal(t, "v-stack", version)
+	})
+
+	t.Run("versions file resolves by lower-case kind", func(t *testing.T) {
+		ctx := testutil.NewContext(&v1beta1.Versions{
+			ObjectMeta: testutil.ObjectMeta("versions0"),
+			Spec: map[string]string{
+				"auth":   "v-auth",
+				"ledger": "v-ledger",
+			},
+		})
+		stack := &v1beta1.Stack{ObjectMeta: testutil.ObjectMeta("stack0"), Spec: v1beta1.StackSpec{VersionsFromFile: "versions0"}}
+
+		version, err := core.GetModuleVersion(ctx, stack, &v1beta1.Auth{})
+		require.NoError(t, err)
+		require.Equal(t, "v-auth", version)
+	})
+
+	t.Run("missing versions file value returns explicit no version error", func(t *testing.T) {
+		ctx := testutil.NewContext(&v1beta1.Versions{
+			ObjectMeta: testutil.ObjectMeta("versions0"),
+			Spec:       map[string]string{"ledger": "v-ledger"},
+		})
+		stack := &v1beta1.Stack{ObjectMeta: testutil.ObjectMeta("stack0"), Spec: v1beta1.StackSpec{VersionsFromFile: "versions0"}}
+
+		_, err := core.GetModuleVersion(ctx, stack, &v1beta1.Auth{})
+		require.ErrorIs(t, err, core.ErrNoVersionFound)
+		require.Contains(t, err.Error(), "module not found in Versions resource versions0")
+	})
+
+	t.Run("no source returns explicit no version error", func(t *testing.T) {
+		_, err := core.GetModuleVersion(testutil.NewContext(), &v1beta1.Stack{ObjectMeta: testutil.ObjectMeta("stack0")}, &v1beta1.Auth{})
+		require.ErrorIs(t, err, core.ErrNoVersionFound)
+		require.Contains(t, err.Error(), "stack must define spec.version")
+	})
+}
+
+func TestVersionComparisons(t *testing.T) {
+	t.Parallel()
+
+	require.True(t, core.IsGreaterOrEqual("v2.0.0", "v1.9.0"))
+	require.True(t, core.IsGreaterOrEqual("latest", "v1.9.0"))
+	require.False(t, core.IsGreaterOrEqual("v1.8.0", "v1.9.0"))
+	require.False(t, core.IsGreaterOrEqual("v1.8.0", "latest"))
+	require.True(t, core.IsGreaterOrEqual("latest", "latest"))
+
+	require.True(t, core.IsLower("v1.8.0", "v1.9.0"))
+	require.True(t, core.IsLower("v1.8.0", "latest"))
+	require.False(t, core.IsLower("latest", "v1.9.0"))
+	require.False(t, core.IsLower("v2.0.0", "v1.9.0"))
+}
+
+func TestForModule(t *testing.T) {
+	t.Parallel()
+
+	t.Run("adds stack owner reference and calls controller with resolved version", func(t *testing.T) {
+		stack := &v1beta1.Stack{
+			ObjectMeta: metav1.ObjectMeta{Name: "stack0", UID: types.UID("stack-uid"), Generation: 4},
+			Spec:       v1beta1.StackSpec{Version: "v-stack"},
+		}
+		module := &v1beta1.Auth{
+			ObjectMeta: metav1.ObjectMeta{Name: "auth0", UID: types.UID("auth-uid")},
+			Spec:       v1beta1.AuthSpec{StackDependency: v1beta1.StackDependency{Stack: "stack0"}},
+		}
+		ctx := testutil.NewContext(stack, module)
+		var gotVersion string
+		called := false
+		controller := core.ForModule(func(ctx core.Context, stack *v1beta1.Stack, options *core.ReconcilerOptions[*v1beta1.Auth], req *v1beta1.Auth, version string) error {
+			called = true
+			gotVersion = version
+			return nil
+		})
+
+		err := controller(ctx, stack, &core.ReconcilerOptions[*v1beta1.Auth]{Owns: map[client.Object][]builder.OwnsOption{}}, module)
+		require.NoError(t, err)
+		require.True(t, called)
+		require.Equal(t, "v-stack", gotVersion)
+		require.True(t, hasOwnerReferenceNamed(module.OwnerReferences, "Stack", "stack0"))
+		require.Equal(t, "Spec", module.GetConditions().Get("ReconciledWithStack").Reason)
+
+		persisted := &v1beta1.Auth{}
+		require.NoError(t, ctx.GetClient().Get(ctx, types.NamespacedName{Name: "auth0"}, persisted))
+		require.True(t, hasOwnerReferenceNamed(persisted.OwnerReferences, "Stack", "stack0"))
+	})
+
+	t.Run("disabled stack deletes controlled owned objects and skips resources", func(t *testing.T) {
+		stack := &v1beta1.Stack{
+			ObjectMeta: metav1.ObjectMeta{Name: "stack0", UID: types.UID("stack-uid"), Generation: 5},
+			Spec:       v1beta1.StackSpec{Version: "v-stack", Disabled: true},
+		}
+		module := &v1beta1.Auth{
+			ObjectMeta: metav1.ObjectMeta{Name: "auth0", UID: types.UID("auth-uid")},
+			Spec:       v1beta1.AuthSpec{StackDependency: v1beta1.StackDependency{Stack: "stack0"}},
+		}
+		deployment := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "owned", Namespace: "stack0"}}
+		require.NoError(t, controllerutil.SetControllerReference(module, deployment, testutil.NewScheme()))
+		database := &v1beta1.Database{
+			ObjectMeta: metav1.ObjectMeta{Name: "database0"},
+			Spec:       v1beta1.DatabaseSpec{StackDependency: v1beta1.StackDependency{Stack: "stack0"}},
+		}
+		ctx := testutil.NewContext(stack, module, deployment, database)
+		called := false
+		controller := core.ForModule(func(ctx core.Context, stack *v1beta1.Stack, options *core.ReconcilerOptions[*v1beta1.Auth], req *v1beta1.Auth, version string) error {
+			called = true
+			return nil
+		})
+
+		err := controller(ctx, stack, &core.ReconcilerOptions[*v1beta1.Auth]{
+			Owns: map[client.Object][]builder.OwnsOption{
+				&appsv1.Deployment{}: {},
+				&v1beta1.Database{}:  {},
+			},
+		}, module)
+		require.NoError(t, err)
+		require.False(t, called)
+		require.Equal(t, "Spec", module.GetConditions().Get("ReconciledWithStack").Reason)
+
+		require.Error(t, ctx.GetClient().Get(ctx, types.NamespacedName{Name: "owned", Namespace: "stack0"}, &appsv1.Deployment{}))
+		require.NoError(t, ctx.GetClient().Get(ctx, types.NamespacedName{Name: "database0"}, &v1beta1.Database{}))
+	})
+
+	t.Run("underlying controller error stops reconciled condition", func(t *testing.T) {
+		stack := &v1beta1.Stack{
+			ObjectMeta: metav1.ObjectMeta{Name: "stack0", UID: types.UID("stack-uid")},
+			Spec:       v1beta1.StackSpec{Version: "v-stack"},
+		}
+		module := &v1beta1.Auth{
+			ObjectMeta: metav1.ObjectMeta{Name: "auth0", UID: types.UID("auth-uid")},
+			Spec:       v1beta1.AuthSpec{StackDependency: v1beta1.StackDependency{Stack: "stack0"}},
+		}
+		ctx := testutil.NewContext(stack, module)
+		controller := core.ForModule(func(ctx core.Context, stack *v1beta1.Stack, options *core.ReconcilerOptions[*v1beta1.Auth], req *v1beta1.Auth, version string) error {
+			return fmt.Errorf("module failed")
+		})
+
+		err := controller(ctx, stack, &core.ReconcilerOptions[*v1beta1.Auth]{Owns: map[client.Object][]builder.OwnsOption{}}, module)
+		require.EqualError(t, err, "module failed")
+		require.Nil(t, module.GetConditions().Get("ReconciledWithStack"))
+	})
+}
+
+func unstructuredDependency(kind, name, stack string) *unstructured.Unstructured {
+	object := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "formance.com/v1beta1",
+		"kind":       kind,
+		"metadata": map[string]any{
+			"name": name,
+		},
+		"spec": map[string]any{
+			"stack": stack,
+		},
+	}}
+	return object
+}
+
+func withNamespace(meta metav1.ObjectMeta, namespace string) metav1.ObjectMeta {
+	meta.Namespace = namespace
+	return meta
+}
+
+func hasOwnerReferenceNamed(references []metav1.OwnerReference, kind, name string) bool {
+	for _, reference := range references {
+		if reference.Kind == kind && reference.Name == name {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/core/utils_test.go
+++ b/internal/core/utils_test.go
@@ -1,0 +1,100 @@
+package core
+
+import (
+	"testing"
+	"testing/fstest"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func TestHashFromConfigMapsIsStableAndOrderSensitive(t *testing.T) {
+	t.Parallel()
+
+	first := &corev1.ConfigMap{Data: map[string]string{"a": "1"}}
+	second := &corev1.ConfigMap{Data: map[string]string{"b": "2"}}
+
+	require.Equal(t, HashFromConfigMaps(first, second), HashFromConfigMaps(first, second))
+	require.NotEqual(t, HashFromConfigMaps(first, second), HashFromConfigMaps(second, first))
+}
+
+func TestHashFromResourcesUsesUIDAndResourceVersion(t *testing.T) {
+	t.Parallel()
+
+	resource := &unstructured.Unstructured{}
+	resource.SetUID("uid-1")
+	resource.SetResourceVersion("rv-1")
+
+	same := &unstructured.Unstructured{}
+	same.SetUID("uid-1")
+	same.SetResourceVersion("rv-1")
+
+	changed := &unstructured.Unstructured{}
+	changed.SetUID("uid-1")
+	changed.SetResourceVersion("rv-2")
+
+	require.Equal(t, HashFromResources(resource), HashFromResources(same))
+	require.NotEqual(t, HashFromResources(resource), HashFromResources(changed))
+}
+
+func TestCopyDirCopiesRelativeFileNames(t *testing.T) {
+	t.Parallel()
+
+	files := fstest.MapFS{
+		"root/a.txt":        {Data: []byte("a")},
+		"root/nested/b.txt": {Data: []byte("b")},
+	}
+	ret := map[string]string{}
+
+	CopyDir(files, "root", "root", &ret)
+
+	require.Equal(t, map[string]string{
+		"a.txt":        "a",
+		"nested/b.txt": "b",
+	}, ret)
+}
+
+func TestObjectMutators(t *testing.T) {
+	t.Parallel()
+
+	cm := &corev1.ConfigMap{}
+	require.NoError(t, WithAnnotations[*corev1.ConfigMap](map[string]string{"a": "1"})(cm))
+	require.NoError(t, WithLabels[*corev1.ConfigMap](map[string]string{"app": "operator"})(cm))
+
+	require.Equal(t, map[string]string{"a": "1"}, cm.Annotations)
+	require.Equal(t, map[string]string{"app": "operator"}, cm.Labels)
+}
+
+func TestUnstructuredSpecHelpers(t *testing.T) {
+	t.Parallel()
+
+	obj := &unstructured.Unstructured{Object: map[string]any{
+		"spec": map[string]any{
+			"stack": "stack0",
+			"debug": true,
+		},
+	}}
+
+	stack, ok := GetStackNameFromUnstructured(obj)
+	require.True(t, ok)
+	require.Equal(t, "stack0", stack)
+
+	spec, ok := GetSpecFromUnstructured(obj)
+	require.True(t, ok)
+	require.Equal(t, true, spec["debug"])
+
+	empty := &unstructured.Unstructured{Object: map[string]any{"metadata": map[string]any{}}}
+	_, ok = GetStackNameFromUnstructured(empty)
+	require.False(t, ok)
+	_, ok = GetSpecFromUnstructured(empty)
+	require.False(t, ok)
+}
+
+func TestFormatCallerFramesTrimsLogDeletionFrame(t *testing.T) {
+	t.Parallel()
+
+	stack := []byte("goroutine 1 [running]:\ninternal/core.LogDeletion()\n\tutils.go:1\ncaller.one()\n\tone.go:2\ncaller.two()\n\ttwo.go:3\n")
+
+	require.Equal(t, "\tutils.go:1\ncaller.one()\n\tone.go:2\ncaller.two()\n\ttwo.go:3\n", formatCallerFrames(stack))
+}

--- a/internal/resources/applications/application_settings_test.go
+++ b/internal/resources/applications/application_settings_test.go
@@ -1,0 +1,231 @@
+package applications
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/formancehq/operator/v3/api/formance.com/v1beta1"
+	settingspkg "github.com/formancehq/operator/v3/internal/resources/settings"
+	"github.com/formancehq/operator/v3/internal/testutil"
+)
+
+func TestApplicationInstallAppliesDeploymentSettingsToFinalDeployment(t *testing.T) {
+	t.Parallel()
+
+	owner := applicationSettingsOwner()
+	existingDeployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "ledger",
+			Namespace: "stack0",
+		},
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						RestartedAtAnnotationKey: "2026-05-11T10:00:00Z",
+					},
+				},
+			},
+		},
+	}
+	ctx := testutil.NewContext(append([]client.Object{
+		existingDeployment,
+		settingspkg.New("wildcard-annotations", "deployments.*.spec.template.annotations", "checksum=wildcard,team=platform", "stack0"),
+		settingspkg.New("specific-annotations", "deployments.ledger.spec.template.annotations", "checksum=specific", "stack0"),
+		settingspkg.New("replicas", "deployments.ledger.replicas", "3", "stack0"),
+		settingspkg.New("container-env", "deployments.ledger.containers.api.env-vars", "EXISTING=override,FROM_SETTINGS=yes", "stack0"),
+		settingspkg.New("init-env", "deployments.ledger.init-containers.init.env-vars", "INIT_FROM_SETTINGS=true", "stack0"),
+		settingspkg.New("limits", "deployments.ledger.containers.api.resource-requirements.limits", "cpu=500m,memory=256Mi", "stack0"),
+		settingspkg.New("requests", "deployments.ledger.containers.api.resource-requirements.requests", "cpu=250m,memory=128Mi", "stack0"),
+		settingspkg.New("run-as", "deployments.ledger.containers.api.run-as", "user=1001,group=2001", "stack0"),
+		settingspkg.New("topology", "deployments.ledger.topology-spread-constraints", "true", "stack0"),
+		settingspkg.New("semconv", "deployments.ledger.semconv-metrics-names", "true", "stack0"),
+		settingspkg.New("json-logging", "logging.json", "true", "stack0"),
+		settingspkg.New("grace-period", "modules.ledger.grace-period", "30s", "stack0"),
+		settingspkg.New("termination", "deployments.ledger.spec.template.spec.termination-grace-period-seconds", "45", "stack0"),
+	}, owner)...)
+
+	err := New(owner, applicationSettingsDeploymentTemplate()).Install(ctx)
+	require.NoError(t, err)
+
+	deployment := &appsv1.Deployment{}
+	require.NoError(t, ctx.GetClient().Get(ctx, types.NamespacedName{Name: "ledger", Namespace: "stack0"}, deployment))
+
+	require.Equal(t, int32(3), *deployment.Spec.Replicas)
+	require.Equal(t, appsv1.RollingUpdateDeploymentStrategyType, deployment.Spec.Strategy.Type)
+	require.Equal(t, int64(45), *deployment.Spec.Template.Spec.TerminationGracePeriodSeconds)
+	require.Len(t, deployment.Spec.Template.Spec.TopologySpreadConstraints, 2)
+
+	require.Equal(t, "2026-05-11T10:00:00Z", deployment.Spec.Template.Annotations[RestartedAtAnnotationKey])
+	require.Equal(t, "specific", deployment.Spec.Template.Annotations["checksum"])
+	require.NotContains(t, deployment.Spec.Template.Annotations, "team")
+
+	require.Len(t, deployment.Spec.Template.Spec.InitContainers, 1)
+	initEnv := testutil.EnvMap(deployment.Spec.Template.Spec.InitContainers[0].Env)
+	require.Equal(t, "base", initEnv["INIT_BASE"])
+	require.Equal(t, "true", initEnv["INIT_FROM_SETTINGS"])
+	require.Equal(t, "true", initEnv["JSON_FORMATTING_LOGGER"])
+	require.Equal(t, "true", initEnv["SEMCONV_METRICS_NAME"])
+	require.NotContains(t, initEnv, "GRACE_PERIOD")
+
+	require.Len(t, deployment.Spec.Template.Spec.Containers, 1)
+	container := deployment.Spec.Template.Spec.Containers[0]
+	env := testutil.EnvMap(container.Env)
+	require.Equal(t, "override", env["EXISTING"])
+	require.Equal(t, "yes", env["FROM_SETTINGS"])
+	require.Equal(t, "30s", env["GRACE_PERIOD"])
+	require.Equal(t, "true", env["JSON_FORMATTING_LOGGER"])
+	require.Equal(t, "true", env["SEMCONV_METRICS_NAME"])
+
+	require.Equal(t, resource.MustParse("500m"), container.Resources.Limits[corev1.ResourceCPU])
+	require.Equal(t, resource.MustParse("256Mi"), container.Resources.Limits[corev1.ResourceMemory])
+	require.Equal(t, resource.MustParse("250m"), container.Resources.Requests[corev1.ResourceCPU])
+	require.Equal(t, resource.MustParse("128Mi"), container.Resources.Requests[corev1.ResourceMemory])
+
+	require.NotNil(t, deployment.Spec.Template.Spec.SecurityContext)
+	require.True(t, *deployment.Spec.Template.Spec.SecurityContext.RunAsNonRoot)
+	require.NotNil(t, container.SecurityContext)
+	require.Equal(t, int64(1001), *container.SecurityContext.RunAsUser)
+	require.Equal(t, int64(2001), *container.SecurityContext.RunAsGroup)
+	require.True(t, *container.SecurityContext.RunAsNonRoot)
+	require.False(t, *container.SecurityContext.Privileged)
+	require.False(t, *container.SecurityContext.AllowPrivilegeEscalation)
+	require.True(t, *container.SecurityContext.ReadOnlyRootFilesystem)
+	require.Equal(t, []corev1.Capability{"all"}, container.SecurityContext.Capabilities.Drop)
+}
+
+func TestApplicationInstallAppliesPodDisruptionBudgetSettings(t *testing.T) {
+	t.Parallel()
+
+	owner := applicationSettingsOwner()
+	ctx := testutil.NewContext(
+		owner,
+		settingspkg.New("pdb", "deployments.ledger.pod-disruption-budget", "minAvailable=1", "stack0"),
+	)
+
+	err := New(owner, applicationSettingsDeploymentTemplate()).Install(ctx)
+	require.NoError(t, err)
+
+	pdb := &policyv1.PodDisruptionBudget{}
+	require.NoError(t, ctx.GetClient().Get(ctx, types.NamespacedName{Name: "ledger", Namespace: "stack0"}, pdb))
+	require.Equal(t, "1", pdb.Spec.MinAvailable.String())
+	require.Nil(t, pdb.Spec.MaxUnavailable)
+	require.Equal(t, map[string]string{"app.kubernetes.io/name": "ledger"}, pdb.Spec.Selector.MatchLabels)
+
+	condition := owner.Status.Conditions.Get("PodDisruptionBudgetConfigured")
+	require.NotNil(t, condition)
+	require.Equal(t, metav1.ConditionTrue, condition.Status)
+	require.Equal(t, "Ledger", condition.Reason)
+}
+
+func TestApplicationInstallDeletesPDBForStatefulApplication(t *testing.T) {
+	t.Parallel()
+
+	owner := applicationSettingsOwner()
+	existingPDB := &policyv1.PodDisruptionBudget{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "ledger",
+			Namespace: "stack0",
+		},
+	}
+	ctx := testutil.NewContext(
+		owner,
+		existingPDB,
+		settingspkg.New("pdb", "deployments.ledger.pod-disruption-budget", "minAvailable=1", "stack0"),
+	)
+
+	err := New(owner, applicationSettingsDeploymentTemplate()).Stateful().Install(ctx)
+	require.NoError(t, err)
+
+	pdb := &policyv1.PodDisruptionBudget{}
+	err = ctx.GetClient().Get(ctx, types.NamespacedName{Name: "ledger", Namespace: "stack0"}, pdb)
+	require.Error(t, err)
+
+	deployment := &appsv1.Deployment{}
+	require.NoError(t, ctx.GetClient().Get(ctx, types.NamespacedName{Name: "ledger", Namespace: "stack0"}, deployment))
+	require.Equal(t, appsv1.RecreateDeploymentStrategyType, deployment.Spec.Strategy.Type)
+}
+
+func TestApplicationInstallReturnsSettingsParsingErrors(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name    string
+		setting client.Object
+	}{
+		{
+			name:    "invalid resource quantity",
+			setting: settingspkg.New("invalid-quantity", "deployments.ledger.containers.api.resource-requirements.limits", "cpu=not-a-quantity", "stack0"),
+		},
+		{
+			name:    "invalid run-as user",
+			setting: settingspkg.New("invalid-run-as", "deployments.ledger.containers.api.run-as", "user=not-a-user", "stack0"),
+		},
+		{
+			name:    "invalid termination grace period",
+			setting: settingspkg.New("invalid-termination", "deployments.ledger.spec.template.spec.termination-grace-period-seconds", "not-an-int", "stack0"),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			owner := applicationSettingsOwner()
+			ctx := testutil.NewContext(owner, tc.setting)
+
+			err := New(owner, applicationSettingsDeploymentTemplate()).Install(ctx)
+			require.Error(t, err)
+		})
+	}
+}
+
+func applicationSettingsOwner() *v1beta1.Ledger {
+	return &v1beta1.Ledger{
+		TypeMeta: metav1.TypeMeta{APIVersion: "formance.com/v1beta1", Kind: "Ledger"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "ledger",
+			UID:        types.UID("ledger-uid"),
+			Generation: 2,
+		},
+		Spec: v1beta1.LedgerSpec{
+			StackDependency: v1beta1.StackDependency{Stack: "stack0"},
+		},
+	}
+}
+
+func applicationSettingsDeploymentTemplate() *appsv1.Deployment {
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "ledger"},
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					InitContainers: []corev1.Container{{
+						Name:  "init",
+						Image: "init:latest",
+						Env: []corev1.EnvVar{{
+							Name:  "INIT_BASE",
+							Value: "base",
+						}},
+					}},
+					Containers: []corev1.Container{{
+						Name:  "api",
+						Image: "ledger:latest",
+						Env: []corev1.EnvVar{{
+							Name:  "EXISTING",
+							Value: "original",
+						}},
+					}},
+				},
+			},
+		},
+	}
+}

--- a/internal/resources/auths/env_test.go
+++ b/internal/resources/auths/env_test.go
@@ -1,0 +1,84 @@
+package auths
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/formancehq/operator/v3/api/formance.com/v1beta1"
+	"github.com/formancehq/operator/v3/internal/resources/settings"
+	"github.com/formancehq/operator/v3/internal/testutil"
+)
+
+func TestProtectedEnvVarsWithoutAuthDependency(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.NewContext()
+	stack := &v1beta1.Stack{ObjectMeta: testutil.ObjectMeta("stack0")}
+
+	env, err := ProtectedEnvVars(ctx, stack, "payments", nil)
+	require.NoError(t, err)
+	require.Empty(t, env)
+}
+
+func TestProtectedEnvVarsWithAuthDependencyAndGateway(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.NewContext(
+		&v1beta1.Auth{
+			TypeMeta:   metav1.TypeMeta{APIVersion: "formance.com/v1beta1", Kind: "Auth"},
+			ObjectMeta: testutil.ObjectMeta("auth"),
+			Spec:       v1beta1.AuthSpec{StackDependency: v1beta1.StackDependency{Stack: "stack0"}},
+		},
+		&v1beta1.Gateway{
+			TypeMeta:   metav1.TypeMeta{APIVersion: "formance.com/v1beta1", Kind: "Gateway"},
+			ObjectMeta: testutil.ObjectMeta("gateway"),
+			Spec: v1beta1.GatewaySpec{
+				StackDependency: v1beta1.StackDependency{Stack: "stack0"},
+				Ingress: &v1beta1.GatewayIngress{
+					Scheme: "https",
+					Host:   "stack.example.com",
+				},
+			},
+		},
+		settings.New("issuers", "auth.issuers", "https://issuer-a https://issuer-b", "stack0"),
+	)
+	stack := &v1beta1.Stack{ObjectMeta: testutil.ObjectMeta("stack0")}
+
+	env, err := ProtectedEnvVars(ctx, stack, "payments", &v1beta1.AuthConfig{
+		ReadKeySetMaxRetries: 3,
+		CheckScopes:          true,
+	})
+	require.NoError(t, err)
+
+	values := testutil.EnvMap(env)
+	require.Equal(t, "true", values["AUTH_ENABLED"])
+	require.Equal(t, "https://stack.example.com/api/auth", values["AUTH_ISSUER"])
+	require.Equal(t, "https://issuer-a https://issuer-b", values["AUTH_ISSUERS"])
+	require.Equal(t, "3", values["AUTH_READ_KEY_SET_MAX_RETRIES"])
+	require.Equal(t, "true", values["AUTH_CHECK_SCOPES"])
+	require.Equal(t, "payments", values["AUTH_SERVICE"])
+}
+
+func TestProtectedEnvVarsUsesScopeSettingsWhenSpecDoesNotEnableScopes(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.NewContext(
+		&v1beta1.Auth{
+			TypeMeta:   metav1.TypeMeta{APIVersion: "formance.com/v1beta1", Kind: "Auth"},
+			ObjectMeta: testutil.ObjectMeta("auth"),
+			Spec:       v1beta1.AuthSpec{StackDependency: v1beta1.StackDependency{Stack: "stack0"}},
+		},
+		settings.New("scope", "auth.payments.check-scopes", "true", "stack0"),
+	)
+	stack := &v1beta1.Stack{ObjectMeta: testutil.ObjectMeta("stack0")}
+
+	env, err := ProtectedEnvVars(ctx, stack, "payments", nil)
+	require.NoError(t, err)
+
+	values := testutil.EnvMap(env)
+	require.Equal(t, "http://auth:8080", values["AUTH_ISSUER"])
+	require.Equal(t, "true", values["AUTH_CHECK_SCOPES"])
+	require.Equal(t, "payments", values["AUTH_SERVICE"])
+}

--- a/internal/resources/brokerconsumers/controller_test.go
+++ b/internal/resources/brokerconsumers/controller_test.go
@@ -1,0 +1,111 @@
+package brokerconsumers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	batchv1 "k8s.io/api/batch/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/formancehq/operator/v3/api/formance.com/v1beta1"
+	"github.com/formancehq/operator/v3/internal/core"
+	"github.com/formancehq/operator/v3/internal/testutil"
+)
+
+func TestCreateServiceNatsConsumerCreatesProvisioningJob(t *testing.T) {
+	t.Parallel()
+
+	stack := &v1beta1.Stack{ObjectMeta: testutil.ObjectMeta("stack0")}
+	consumer := &v1beta1.BrokerConsumer{
+		TypeMeta: metav1.TypeMeta{APIVersion: "formance.com/v1beta1", Kind: "BrokerConsumer"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "ledger-worker",
+			UID:  types.UID("consumer-uid"),
+		},
+		Spec: v1beta1.BrokerConsumerSpec{
+			StackDependency: v1beta1.StackDependency{Stack: "stack0"},
+			Services:        []string{"ledger"},
+			QueriedBy:       "worker",
+		},
+	}
+	broker := &v1beta1.Broker{
+		Status: v1beta1.BrokerStatus{
+			URI: testutil.MustParseURI("nats://nats.stack0:4222"),
+		},
+	}
+	ctx := testutil.NewContext(stack, consumer)
+
+	err := createServiceNatsConsumer(ctx, stack, consumer, broker, "ledger")
+	require.True(t, core.IsApplicationError(err))
+
+	job := &batchv1.Job{}
+	require.NoError(t, ctx.GetClient().Get(ctx, types.NamespacedName{Name: "consumer-uid-cc-ledger", Namespace: "stack0"}, job))
+	require.Len(t, job.Spec.Template.Spec.Containers, 1)
+
+	container := job.Spec.Template.Spec.Containers[0]
+	envMap := testutil.EnvMap(container.Env)
+	require.Contains(t, container.Image, "nats-box:0.19.2")
+	require.Equal(t, "create-consumer", container.Name)
+	require.Len(t, container.Args, 3)
+	require.Contains(t, container.Args[2], "nats --server $NATS_URI consumer add $STACK-$SERVICE $NAME")
+	require.Equal(t, "nats://nats.stack0:4222", envMap["NATS_URI"])
+	require.Equal(t, "stack0", envMap["STACK"])
+	require.Equal(t, "worker", envMap["NAME"])
+	require.Equal(t, "ledger", envMap["SERVICE"])
+
+	condition := consumer.Status.Conditions.Get(ConditionTypeNatsServiceConsumerCreated)
+	require.NotNil(t, condition)
+	require.Equal(t, "ledger", condition.Reason)
+	require.Equal(t, metav1.ConditionFalse, condition.Status)
+}
+
+func TestCreateStackNatsConsumerCreatesProvisioningJob(t *testing.T) {
+	t.Parallel()
+
+	stack := &v1beta1.Stack{ObjectMeta: testutil.ObjectMeta("stack0")}
+	consumer := &v1beta1.BrokerConsumer{
+		TypeMeta: metav1.TypeMeta{APIVersion: "formance.com/v1beta1", Kind: "BrokerConsumer"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "ledger-worker",
+			UID:        types.UID("consumer-uid"),
+			Generation: 7,
+		},
+		Spec: v1beta1.BrokerConsumerSpec{
+			StackDependency: v1beta1.StackDependency{Stack: "stack0"},
+			Services:        []string{"ledger", "payments"},
+			QueriedBy:       "worker",
+			Name:            "read",
+		},
+	}
+	broker := &v1beta1.Broker{
+		Status: v1beta1.BrokerStatus{
+			URI: testutil.MustParseURI("nats://nats.stack0:4222"),
+		},
+	}
+	ctx := testutil.NewContext(stack, consumer)
+
+	err := createStackNatsConsumer(ctx, stack, consumer, broker)
+	require.True(t, core.IsApplicationError(err))
+
+	job := &batchv1.Job{}
+	require.NoError(t, ctx.GetClient().Get(ctx, types.NamespacedName{Name: "consumer-uid-create-consumer", Namespace: "stack0"}, job))
+	require.Len(t, job.Spec.Template.Spec.Containers, 1)
+
+	container := job.Spec.Template.Spec.Containers[0]
+	envMap := testutil.EnvMap(container.Env)
+	require.Contains(t, container.Image, "nats-box:0.19.2")
+	require.Equal(t, "create-consumer", container.Name)
+	require.Len(t, container.Args, 3)
+	require.Contains(t, container.Args[2], "nats --server $NATS_URI consumer add $STREAM $NAME")
+	require.Equal(t, "nats://nats.stack0:4222", envMap["NATS_URI"])
+	require.Equal(t, "stack0", envMap["STREAM"])
+	require.Equal(t, "worker_read", envMap["NAME"])
+	require.Equal(t, "worker", envMap["DELIVER"])
+	require.Equal(t, "stack0.ledger stack0.payments", envMap["SUBJECTS"])
+
+	condition := consumer.Status.Conditions.Get(ConditionTypeNatsStackConsumerCreated)
+	require.NotNil(t, condition)
+	require.Equal(t, metav1.ConditionFalse, condition.Status)
+	require.Equal(t, int64(7), condition.ObservedGeneration)
+}

--- a/internal/resources/brokers/reconcile_test.go
+++ b/internal/resources/brokers/reconcile_test.go
@@ -1,0 +1,293 @@
+package brokers
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	batchv1 "k8s.io/api/batch/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/formancehq/operator/v3/api/formance.com/v1beta1"
+	"github.com/formancehq/operator/v3/internal/core"
+	"github.com/formancehq/operator/v3/internal/testutil"
+)
+
+func TestCreateNatsTopicCreatesProvisioningJob(t *testing.T) {
+	t.Parallel()
+
+	stack := &v1beta1.Stack{ObjectMeta: testutil.ObjectMeta("stack0")}
+	broker := brokerFixture(v1beta1.ModeOneStreamByService)
+	topic := &v1beta1.BrokerTopic{
+		ObjectMeta: testutil.ObjectMeta("topic0"),
+		Spec: v1beta1.BrokerTopicSpec{
+			StackDependency: v1beta1.StackDependency{Stack: "stack0"},
+			Service:         "ledger",
+		},
+	}
+	ctx := testutil.NewContext(stack, broker)
+
+	err := createNatsTopic(ctx, stack, broker, topic, testutil.MustParseURI("nats://nats.stack0:4222?replicas=3"))
+	require.True(t, core.IsApplicationError(err))
+
+	job := &batchv1.Job{}
+	require.NoError(t, ctx.GetClient().Get(ctx, types.NamespacedName{Name: "broker-uid-create-topic-ledger", Namespace: "stack0"}, job))
+	require.Len(t, job.Spec.Template.Spec.Containers, 1)
+
+	container := job.Spec.Template.Spec.Containers[0]
+	envMap := testutil.EnvMap(container.Env)
+	require.Contains(t, container.Image, "nats-box:0.19.2")
+	require.Equal(t, "create-topic", container.Name)
+	require.Equal(t, "nats://nats.stack0:4222", envMap["NATS_URI"])
+	require.Equal(t, "stack0-ledger", envMap["SUBJECT"])
+	require.Equal(t, "stack0-ledger", envMap["STREAM"])
+	require.Equal(t, "3", envMap["REPLICAS"])
+}
+
+func TestCreateOneStreamByStackCreatesProvisioningJob(t *testing.T) {
+	t.Parallel()
+
+	stack := &v1beta1.Stack{ObjectMeta: testutil.ObjectMeta("stack0")}
+	broker := brokerFixture(v1beta1.ModeOneStreamByStack)
+	ctx := testutil.NewContext(stack, broker)
+
+	err := createOneStreamByStack(ctx, stack, broker, testutil.MustParseURI("nats://nats.stack0:4222?replicas=2"))
+	require.True(t, core.IsApplicationError(err))
+
+	job := &batchv1.Job{}
+	require.NoError(t, ctx.GetClient().Get(ctx, types.NamespacedName{Name: "broker-uid-create-stream", Namespace: "stack0"}, job))
+	require.Len(t, job.Spec.Template.Spec.Containers, 1)
+
+	container := job.Spec.Template.Spec.Containers[0]
+	envMap := testutil.EnvMap(container.Env)
+	require.Contains(t, container.Image, "nats-box:0.19.2")
+	require.Equal(t, "create-topic", container.Name)
+	require.Equal(t, "nats://nats.stack0:4222", envMap["NATS_URI"])
+	require.Equal(t, "stack0", envMap["STREAM"])
+	require.Equal(t, "2", envMap["REPLICAS"])
+}
+
+func TestCreateOneStreamByStackSkipsReadyBroker(t *testing.T) {
+	t.Parallel()
+
+	stack := &v1beta1.Stack{ObjectMeta: testutil.ObjectMeta("stack0")}
+	broker := brokerFixture(v1beta1.ModeOneStreamByStack)
+	broker.Status.Ready = true
+
+	require.NoError(t, createOneStreamByStack(testutil.NewContext(stack, broker), stack, broker, testutil.MustParseURI("nats://nats.stack0:4222")))
+}
+
+func TestCreateOneStreamByTopicCreatesMissingTopicAndSortsStreams(t *testing.T) {
+	t.Parallel()
+
+	stack := &v1beta1.Stack{ObjectMeta: testutil.ObjectMeta("stack0")}
+	broker := brokerFixture(v1beta1.ModeOneStreamByService)
+	broker.Status.Streams = []string{"wallets"}
+	ledgerTopic := &v1beta1.BrokerTopic{
+		ObjectMeta: testutil.ObjectMeta("ledger-topic"),
+		Spec: v1beta1.BrokerTopicSpec{
+			StackDependency: v1beta1.StackDependency{Stack: "stack0"},
+			Service:         "ledger",
+		},
+	}
+	walletsTopic := &v1beta1.BrokerTopic{
+		ObjectMeta: testutil.ObjectMeta("wallets-topic"),
+		Spec: v1beta1.BrokerTopicSpec{
+			StackDependency: v1beta1.StackDependency{Stack: "stack0"},
+			Service:         "wallets",
+		},
+	}
+	ctx := newBrokerContextWithTopicIndexes(stack, broker, ledgerTopic, walletsTopic)
+
+	err := createOneStreamByTopic(ctx, stack, broker, testutil.MustParseURI("nats://nats.stack0:4222?replicas=4"))
+	require.Error(t, err)
+	require.True(t, core.IsApplicationError(err), err)
+	require.Equal(t, []string{"wallets"}, broker.Status.Streams)
+
+	job := &batchv1.Job{}
+	require.NoError(t, ctx.GetClient().Get(ctx, types.NamespacedName{Name: "broker-uid-create-topic-ledger", Namespace: "stack0"}, job))
+	envMap := testutil.EnvMap(job.Spec.Template.Spec.Containers[0].Env)
+	require.Equal(t, "stack0-ledger", envMap["SUBJECT"])
+	require.Equal(t, "4", envMap["REPLICAS"])
+}
+
+func TestCreateOneStreamByTopicMarksStreamsWhenProvisioningJobSucceeded(t *testing.T) {
+	t.Parallel()
+
+	stack := &v1beta1.Stack{ObjectMeta: testutil.ObjectMeta("stack0")}
+	broker := brokerFixture(v1beta1.ModeOneStreamByService)
+	broker.Status.Streams = []string{"wallets"}
+	ledgerTopic := &v1beta1.BrokerTopic{
+		ObjectMeta: testutil.ObjectMeta("ledger-topic"),
+		Spec: v1beta1.BrokerTopicSpec{
+			StackDependency: v1beta1.StackDependency{Stack: "stack0"},
+			Service:         "ledger",
+		},
+	}
+	job := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "broker-uid-create-topic-ledger",
+			Namespace: "stack0",
+		},
+		Status: batchv1.JobStatus{Succeeded: 1},
+	}
+	ctx := newBrokerContextWithTopicIndexes(stack, broker, ledgerTopic, job)
+
+	require.NoError(t, createOneStreamByTopic(ctx, stack, broker, testutil.MustParseURI("nats://nats.stack0:4222")))
+	require.Equal(t, []string{"ledger", "wallets"}, broker.Status.Streams)
+}
+
+func TestHasAllVersionsGreaterThan(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name     string
+		stack    *v1beta1.Stack
+		objects  []client.Object
+		expected bool
+	}{
+		{
+			name: "explicit version greater",
+			stack: &v1beta1.Stack{
+				Spec: v1beta1.StackSpec{Version: "v2.0.0"},
+			},
+			expected: true,
+		},
+		{
+			name: "explicit version older",
+			stack: &v1beta1.Stack{
+				Spec: v1beta1.StackSpec{Version: "v1.9.0"},
+			},
+			expected: false,
+		},
+		{
+			name: "invalid explicit version is treated as latest",
+			stack: &v1beta1.Stack{
+				Spec: v1beta1.StackSpec{Version: "latest"},
+			},
+			expected: true,
+		},
+		{
+			name: "versions file all greater ignoring control",
+			stack: &v1beta1.Stack{
+				Spec: v1beta1.StackSpec{VersionsFromFile: "versions"},
+			},
+			objects: []client.Object{&v1beta1.Versions{
+				ObjectMeta: testutil.ObjectMeta("versions"),
+				Spec: map[string]string{
+					"ledger":  "v2.0.0",
+					"control": "v1.0.0",
+				},
+			}},
+			expected: true,
+		},
+		{
+			name: "versions file with older service",
+			stack: &v1beta1.Stack{
+				Spec: v1beta1.StackSpec{VersionsFromFile: "versions"},
+			},
+			objects: []client.Object{&v1beta1.Versions{
+				ObjectMeta: testutil.ObjectMeta("versions"),
+				Spec: map[string]string{
+					"ledger":   "v2.0.0",
+					"payments": "v1.9.0",
+				},
+			}},
+			expected: false,
+		},
+		{
+			name:     "no version defaults to latest",
+			stack:    &v1beta1.Stack{},
+			expected: true,
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("%d-%s", i, tc.name), func(t *testing.T) {
+			t.Parallel()
+
+			ctx := testutil.NewContext(tc.objects...)
+			actual, err := hasAllVersionsGreaterThan(ctx, tc.stack, "v2.0.0-rc.27")
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, actual)
+		})
+	}
+}
+
+func TestDeleteBrokerCreatesDeleteStreamsJobForReadyNatsBroker(t *testing.T) {
+	t.Parallel()
+
+	stack := &v1beta1.Stack{ObjectMeta: testutil.ObjectMeta("stack0")}
+	broker := brokerFixture(v1beta1.ModeOneStreamByStack)
+	broker.Status.Ready = true
+	broker.Status.URI = testutil.MustParseURI("nats://nats.stack0:4222")
+	ctx := testutil.NewContext(stack, broker)
+
+	err := deleteBroker(ctx, broker)
+	require.True(t, core.IsApplicationError(err))
+
+	job := &batchv1.Job{}
+	require.NoError(t, ctx.GetClient().Get(ctx, types.NamespacedName{Name: "broker-uid-delete-streams", Namespace: "stack0"}, job))
+	container := job.Spec.Template.Spec.Containers[0]
+	require.Equal(t, "delete-streams", container.Name)
+	require.Equal(t, "stack0", testutil.EnvMap(container.Env)["STACK"])
+	require.Len(t, container.Args, 3)
+	require.Contains(t, container.Args[2], "nats stream rm")
+}
+
+func TestDeleteBrokerSkipsNonReadyOrNonNatsBroker(t *testing.T) {
+	t.Parallel()
+
+	require.NoError(t, deleteBroker(testutil.NewContext(), &v1beta1.Broker{
+		Status: v1beta1.BrokerStatus{Status: v1beta1.Status{Ready: false}},
+	}))
+
+	broker := brokerFixture(v1beta1.ModeOneStreamByStack)
+	broker.Status.Ready = true
+	broker.Status.URI = testutil.MustParseURI("kafka://kafka.stack0:9092")
+	require.NoError(t, deleteBroker(testutil.NewContext(), broker))
+}
+
+func brokerFixture(mode v1beta1.Mode) *v1beta1.Broker {
+	return &v1beta1.Broker{
+		TypeMeta: metav1.TypeMeta{APIVersion: "formance.com/v1beta1", Kind: "Broker"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "stack0",
+			UID:  types.UID("broker-uid"),
+		},
+		Spec: v1beta1.BrokerSpec{
+			StackDependency: v1beta1.StackDependency{Stack: "stack0"},
+		},
+		Status: v1beta1.BrokerStatus{Mode: mode},
+	}
+}
+
+func newBrokerContextWithTopicIndexes(objects ...client.Object) *testutil.Context {
+	scheme := testutil.NewScheme()
+	builder := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(objects...)
+	builder.WithIndex(&v1beta1.BrokerTopic{}, "stack", func(obj client.Object) []string {
+		topic := obj.(*v1beta1.BrokerTopic)
+		if topic.Spec.Stack == "" {
+			return nil
+		}
+		return []string{topic.Spec.Stack}
+	})
+	builder.WithIndex(&v1beta1.Settings{}, "stack", func(obj client.Object) []string {
+		return obj.(*v1beta1.Settings).GetStacks()
+	})
+	builder.WithIndex(&v1beta1.Settings{}, "keylen", func(obj client.Object) []string {
+		return []string{"0"}
+	})
+
+	return &testutil.Context{
+		Context: context.Background(),
+		Client:  builder.Build(),
+		Scheme:  scheme,
+	}
+}

--- a/internal/resources/brokers/utils_test.go
+++ b/internal/resources/brokers/utils_test.go
@@ -1,0 +1,98 @@
+package brokers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/formancehq/operator/v3/api/formance.com/v1beta1"
+	"github.com/formancehq/operator/v3/internal/resources/settings"
+	"github.com/formancehq/operator/v3/internal/testutil"
+)
+
+func TestGetBrokerEnvVarsKafka(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.NewContext(settings.New("aws", "aws.service-account", "aws-sa", "stack0"))
+	uri := testutil.MustParseURI("kafka://kafka:9092?saslEnabled=true&saslUsername=user&saslPassword=pass&saslMechanism=SCRAM-SHA-512&saslSCRAMSHASize=512&tls=true&circuitBreakerEnabled=true&circuitBreakerOpenInterval=10s")
+
+	env, err := GetBrokerEnvVars(ctx, uri, "stack0", "ledger")
+	require.NoError(t, err)
+
+	values := testutil.EnvMap(env)
+	require.Equal(t, "kafka", values["BROKER"])
+	require.Equal(t, "true", values["PUBLISHER_KAFKA_ENABLED"])
+	require.Equal(t, "kafka:9092", values["PUBLISHER_KAFKA_BROKER"])
+	require.Equal(t, "true", values["PUBLISHER_KAFKA_SASL_ENABLED"])
+	require.Equal(t, "user", values["PUBLISHER_KAFKA_SASL_USERNAME"])
+	require.Equal(t, "pass", values["PUBLISHER_KAFKA_SASL_PASSWORD"])
+	require.Equal(t, "SCRAM-SHA-512", values["PUBLISHER_KAFKA_SASL_MECHANISM"])
+	require.Equal(t, "512", values["PUBLISHER_KAFKA_SASL_SCRAM_SHA_SIZE"])
+	require.Equal(t, "true", values["PUBLISHER_KAFKA_SASL_IAM_ENABLED"])
+	require.Equal(t, "true", values["PUBLISHER_KAFKA_TLS_ENABLED"])
+	require.Equal(t, "true", values["PUBLISHER_CIRCUIT_BREAKER_ENABLED"])
+	require.Equal(t, "10s", values["PUBLISHER_CIRCUIT_BREAKER_OPEN_INTERVAL_DURATION"])
+}
+
+func TestGetBrokerEnvVarsNatsAndPublisherMappings(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.NewContext()
+	stack := &v1beta1.Stack{ObjectMeta: testutil.ObjectMeta("stack0")}
+	uri := testutil.MustParseURI("nats://nats:4222")
+
+	env, err := GetBrokerEnvVars(ctx, uri, "stack0", "payments")
+	require.NoError(t, err)
+	values := testutil.EnvMap(env)
+	require.Equal(t, "nats", values["BROKER"])
+	require.Equal(t, "true", values["PUBLISHER_NATS_ENABLED"])
+	require.Equal(t, "nats:4222", values["PUBLISHER_NATS_URL"])
+	require.Equal(t, "stack0-payments", values["PUBLISHER_NATS_CLIENT_ID"])
+
+	broker := &v1beta1.Broker{Status: v1beta1.BrokerStatus{Mode: v1beta1.ModeOneStreamByService, URI: uri}}
+	require.Equal(t, "*:stack0-payments", testutil.EnvMap(GetPublisherEnvVars(stack, broker, "payments"))["PUBLISHER_TOPIC_MAPPING"])
+
+	broker.Status.Mode = v1beta1.ModeOneStreamByStack
+	require.Equal(t, map[string]string{
+		"PUBLISHER_TOPIC_MAPPING":       "*:stack0.payments",
+		"PUBLISHER_NATS_AUTO_PROVISION": "false",
+	}, testutil.EnvMap(GetPublisherEnvVars(stack, broker, "payments")))
+}
+
+func TestGetTopicsEnvVars(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.NewContext(&v1beta1.Broker{
+		TypeMeta:   metav1.TypeMeta{APIVersion: "formance.com/v1beta1", Kind: "Broker"},
+		ObjectMeta: testutil.ObjectMeta("stack0"),
+		Status: v1beta1.BrokerStatus{
+			Status: v1beta1.Status{Ready: true},
+			Mode:   v1beta1.ModeOneStreamByStack,
+			URI:    testutil.MustParseURI("nats://nats:4222"),
+		},
+	})
+	stack := &v1beta1.Stack{ObjectMeta: testutil.ObjectMeta("stack0")}
+
+	env, err := GetTopicsEnvVars(ctx, stack, "TOPICS", "ledger", "payments")
+	require.NoError(t, err)
+
+	require.Equal(t, map[string]string{
+		"TOPICS":                        "stack0.ledger stack0.payments",
+		"PUBLISHER_NATS_AUTO_PROVISION": "false",
+	}, testutil.EnvMap(env))
+}
+
+func TestGetTopicsEnvVarsPendingBroker(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.NewContext(&v1beta1.Broker{
+		TypeMeta:   metav1.TypeMeta{APIVersion: "formance.com/v1beta1", Kind: "Broker"},
+		ObjectMeta: testutil.ObjectMeta("stack0"),
+		Status:     v1beta1.BrokerStatus{Status: v1beta1.Status{Ready: false}},
+	})
+	stack := &v1beta1.Stack{ObjectMeta: testutil.ObjectMeta("stack0")}
+
+	_, err := GetTopicsEnvVars(ctx, stack, "TOPICS", "ledger")
+	require.Error(t, err)
+}

--- a/internal/resources/caddy/caddy_test.go
+++ b/internal/resources/caddy/caddy_test.go
@@ -1,0 +1,54 @@
+package caddy
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/formancehq/operator/v3/api/formance.com/v1beta1"
+	"github.com/formancehq/operator/v3/internal/resources/registries"
+	"github.com/formancehq/operator/v3/internal/resources/settings"
+	"github.com/formancehq/operator/v3/internal/testutil"
+)
+
+func TestComputeCaddyfileUsesTemplateFunctionsAndOpenTelemetryFlag(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.NewContext(settings.New("otel", "opentelemetry.traces.dsn", "grpc://otel:4317", "stack0"))
+	stack := &v1beta1.Stack{ObjectMeta: testutil.ObjectMeta("stack0")}
+
+	out, err := ComputeCaddyfile(ctx, stack, `{{ if .EnableOpenTelemetry }}otel{{ end }} {{ join .Hosts "," }} {{ semver_compare "v2.0.0" "v1.0.0" }}`, map[string]any{
+		"Hosts": []string{"a", "b"},
+	})
+	require.NoError(t, err)
+	require.Equal(t, "otel a,b 1", strings.TrimSpace(out))
+}
+
+func TestDeploymentTemplate(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.NewContext()
+	stack := &v1beta1.Stack{ObjectMeta: testutil.ObjectMeta("stack0")}
+	gateway := &v1beta1.Gateway{}
+	configMap := &corev1.ConfigMap{ObjectMeta: testutil.ObjectMeta("caddyfile"), Data: map[string]string{"Caddyfile": ":8080"}}
+	image := &registries.ImageConfiguration{
+		Registry: "docker.io",
+		Image:    "caddy",
+		Version:  "2.7.6",
+		PullSecrets: []corev1.LocalObjectReference{
+			{Name: "pull-secret"},
+		},
+	}
+
+	deployment, err := DeploymentTemplate(ctx, stack, gateway, configMap, image, []corev1.EnvVar{{Name: "EXTRA", Value: "true"}})
+	require.NoError(t, err)
+
+	require.Equal(t, image.PullSecrets, deployment.Spec.Template.Spec.ImagePullSecrets)
+	require.Equal(t, "docker.io/caddy:2.7.6", deployment.Spec.Template.Spec.Containers[0].Image)
+	require.Equal(t, "true", testutil.EnvMap(deployment.Spec.Template.Spec.Containers[0].Env)["EXTRA"])
+	require.Equal(t, "caddyfile", deployment.Spec.Template.Spec.Volumes[0].Name)
+	require.Equal(t, "caddyfile", deployment.Spec.Template.Spec.Containers[0].VolumeMounts[0].Name)
+	require.NotEmpty(t, deployment.Spec.Template.Annotations["caddyfile-hash"])
+}

--- a/internal/resources/databases/postgres_env_test.go
+++ b/internal/resources/databases/postgres_env_test.go
@@ -1,0 +1,119 @@
+package databases
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/formancehq/operator/v3/api/formance.com/v1beta1"
+	"github.com/formancehq/operator/v3/internal/resources/settings"
+	"github.com/formancehq/operator/v3/internal/testutil"
+)
+
+func TestGetPostgresEnvVarsWithPasswordAndConnectionPool(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.NewContext(
+		settings.New("aws", "aws.service-account", "aws-access", "stack0"),
+		settings.New("pool", "modules.ledger.database.connection-pool", "max-idle=10,max-idle-time=30s,max-open=20,max-lifetime=1h", "stack0"),
+	)
+	stack := &v1beta1.Stack{ObjectMeta: testutil.ObjectMeta("stack0")}
+	database := &v1beta1.Database{
+		Spec: v1beta1.DatabaseSpec{Service: "ledger"},
+		Status: v1beta1.DatabaseStatus{
+			Database: "ledger-db",
+			URI:      testutil.MustParseURI("postgresql://ledger:p%40ss%20word@postgres:5432?disableSSLMode=true&application_name=operator&awsRole=ignored"),
+		},
+	}
+
+	env, err := GetPostgresEnvVars(ctx, stack, database)
+	require.NoError(t, err)
+
+	values := testutil.EnvMap(env)
+	require.Equal(t, "postgres", values["POSTGRES_HOST"])
+	require.Equal(t, "5432", values["POSTGRES_PORT"])
+	require.Equal(t, "ledger-db", values["POSTGRES_DATABASE"])
+	require.Equal(t, "ledger", values["POSTGRES_USERNAME"])
+	require.Equal(t, "p%40ss+word", values["POSTGRES_PASSWORD"])
+	require.Equal(t, "true", values["POSTGRES_AWS_ENABLE_IAM"])
+	require.Equal(t, "$(POSTGRES_NO_DATABASE_URI)/$(POSTGRES_DATABASE)?application_name=operator&sslmode=disable", values["POSTGRES_URI"])
+	require.Equal(t, "10", values["POSTGRES_MAX_IDLE_CONNS"])
+	require.Equal(t, "30s", values["POSTGRES_CONN_MAX_IDLE_TIME"])
+	require.Equal(t, "20", values["POSTGRES_MAX_OPEN_CONNS"])
+	require.Equal(t, "1h", values["POSTGRES_CONN_MAX_LIFETIME"])
+}
+
+func TestGetPostgresEnvVarsWithSecretCredentials(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.NewContext()
+	stack := &v1beta1.Stack{ObjectMeta: testutil.ObjectMeta("stack0")}
+	database := &v1beta1.Database{
+		Spec: v1beta1.DatabaseSpec{Service: "payments"},
+		Status: v1beta1.DatabaseStatus{
+			Database: "payments-db",
+			URI:      testutil.MustParseURI("postgresql://postgres:5432?secret=pg-creds&sslmode=require"),
+		},
+	}
+
+	env, err := GetPostgresEnvVars(ctx, stack, database)
+	require.NoError(t, err)
+
+	values := testutil.EnvMap(env)
+	require.Equal(t, "postgres", values["POSTGRES_HOST"])
+	require.Equal(t, "5432", values["POSTGRES_PORT"])
+	require.Equal(t, "$(POSTGRES_NO_DATABASE_URI)/$(POSTGRES_DATABASE)?sslmode=require", values["POSTGRES_URI"])
+
+	requireSecretEnv(t, env, "POSTGRES_USERNAME", "pg-creds", "username")
+	requireSecretEnv(t, env, "POSTGRES_PASSWORD", "pg-creds", "password")
+}
+
+func TestGetPostgresEnvVarsRejectsInvalidConnectionPool(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name  string
+		value string
+	}{
+		{name: "max idle", value: "max-idle=invalid"},
+		{name: "max idle time", value: "max-idle-time=invalid"},
+		{name: "max open", value: "max-open=invalid"},
+		{name: "max lifetime", value: "max-lifetime=invalid"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := testutil.NewContext(
+				settings.New("pool", "modules.ledger.database.connection-pool", tc.value, "stack0"),
+			)
+			stack := &v1beta1.Stack{ObjectMeta: testutil.ObjectMeta("stack0")}
+			database := &v1beta1.Database{
+				Spec: v1beta1.DatabaseSpec{Service: "ledger"},
+				Status: v1beta1.DatabaseStatus{
+					Database: "ledger-db",
+					URI:      testutil.MustParseURI("postgresql://postgres:5432"),
+				},
+			}
+
+			_, err := GetPostgresEnvVars(ctx, stack, database)
+			require.Error(t, err)
+		})
+	}
+}
+
+func requireSecretEnv(t *testing.T, env []corev1.EnvVar, name, secret, key string) {
+	t.Helper()
+
+	for _, item := range env {
+		if item.Name != name {
+			continue
+		}
+		require.NotNil(t, item.ValueFrom)
+		require.NotNil(t, item.ValueFrom.SecretKeyRef)
+		require.Equal(t, secret, item.ValueFrom.SecretKeyRef.Name)
+		require.Equal(t, key, item.ValueFrom.SecretKeyRef.Key)
+		return
+	}
+	require.Failf(t, "missing env var", "env var %s was not found", name)
+}

--- a/internal/resources/gatewayhttpapis/create_test.go
+++ b/internal/resources/gatewayhttpapis/create_test.go
@@ -1,0 +1,52 @@
+package gatewayhttpapis
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/formancehq/operator/v3/api/formance.com/v1beta1"
+	"github.com/formancehq/operator/v3/internal/testutil"
+)
+
+func TestRuleHelpers(t *testing.T) {
+	t.Parallel()
+
+	require.False(t, RuleSecured().Secured)
+	require.True(t, RuleUnsecured().Secured)
+
+	api := &v1beta1.GatewayHTTPAPI{}
+	WithRules(v1beta1.GatewayHTTPAPIRule{Path: "/api", Secured: true})(api)
+	WithHealthCheckEndpoint("_health")(api)
+	require.Equal(t, []v1beta1.GatewayHTTPAPIRule{{Path: "/api", Secured: true}}, api.Spec.Rules)
+	require.Equal(t, "_health", api.Spec.HealthCheckEndpoint)
+}
+
+func TestCreateGatewayHTTPAPI(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.NewContext()
+	owner := &v1beta1.Payments{
+		TypeMeta:   metav1.TypeMeta{APIVersion: "formance.com/v1beta1", Kind: "Payments"},
+		ObjectMeta: metav1.ObjectMeta{Name: "payments", UID: "uid-123"},
+		Spec:       v1beta1.PaymentsSpec{StackDependency: v1beta1.StackDependency{Stack: "stack0"}},
+	}
+
+	err := Create(ctx, owner,
+		WithHealthCheckEndpoint("_healthcheck"),
+		WithRules(v1beta1.GatewayHTTPAPIRule{Path: "/payments", Methods: []string{"GET"}, Secured: true}),
+	)
+	require.NoError(t, err)
+
+	api := &v1beta1.GatewayHTTPAPI{}
+	require.NoError(t, ctx.GetClient().Get(context.Background(), types.NamespacedName{Name: "stack0-payments"}, api))
+	require.Equal(t, "stack0", api.Spec.Stack)
+	require.Equal(t, "payments", api.Spec.Name)
+	require.Equal(t, "_healthcheck", api.Spec.HealthCheckEndpoint)
+	require.Equal(t, []v1beta1.GatewayHTTPAPIRule{{Path: "/payments", Methods: []string{"GET"}, Secured: true}}, api.Spec.Rules)
+	require.Len(t, api.OwnerReferences, 1)
+	require.Equal(t, "Payments", api.OwnerReferences[0].Kind)
+}

--- a/internal/resources/gateways/configuration_settings_test.go
+++ b/internal/resources/gateways/configuration_settings_test.go
@@ -1,0 +1,54 @@
+package gateways
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/formancehq/operator/v3/api/formance.com/v1beta1"
+	settingspkg "github.com/formancehq/operator/v3/internal/resources/settings"
+	"github.com/formancehq/operator/v3/internal/testutil"
+)
+
+func TestCreateConfigMapAppliesCaddyfileSettings(t *testing.T) {
+	t.Parallel()
+
+	stack := &v1beta1.Stack{ObjectMeta: testutil.ObjectMeta("stack0")}
+	gateway := gatewaySettingsFixture()
+	httpAPI := &v1beta1.GatewayHTTPAPI{
+		Spec: v1beta1.GatewayHTTPAPISpec{
+			StackDependency: v1beta1.StackDependency{Stack: "stack0"},
+			Name:            "ledger",
+			Rules: []v1beta1.GatewayHTTPAPIRule{{
+				Path:    "/accounts",
+				Methods: []string{"GET", "POST"},
+			}},
+			HealthCheckEndpoint: "_health",
+		},
+	}
+	ctx := testutil.NewContext(
+		stack,
+		gateway,
+		settingspkg.New("trusted-proxies", "gateway.caddyfile.trusted-proxies", "10.0.0.0/8,192.168.0.0/16", "stack0"),
+		settingspkg.New("trusted-proxies-strict", "gateway.caddyfile.trusted-proxies-strict", "true", "stack0"),
+		settingspkg.New("idle-timeout", "gateway.config.idle-timeout", "30s", "stack0"),
+	)
+
+	configMap, err := createConfigMap(ctx, stack, gateway, []*v1beta1.GatewayHTTPAPI{httpAPI}, nil)
+	require.NoError(t, err)
+
+	stored := &corev1.ConfigMap{}
+	require.NoError(t, ctx.GetClient().Get(ctx, types.NamespacedName{Name: "gateway", Namespace: "stack0"}, stored))
+	require.Equal(t, configMap.Data["Caddyfile"], stored.Data["Caddyfile"])
+	caddyfile := stored.Data["Caddyfile"]
+	require.Contains(t, caddyfile, "trusted_proxies 10.0.0.0/8 192.168.0.0/16")
+	require.Contains(t, caddyfile, "trusted_proxies_strict")
+	require.Contains(t, caddyfile, "timeouts")
+	require.Contains(t, caddyfile, "idle 30s")
+	require.Contains(t, caddyfile, "handle /api/ledger/accounts*")
+	require.Contains(t, caddyfile, "method GET POST")
+	require.Len(t, stored.OwnerReferences, 1)
+	require.Equal(t, "Gateway", stored.OwnerReferences[0].Kind)
+}

--- a/internal/resources/gateways/dns_settings_test.go
+++ b/internal/resources/gateways/dns_settings_test.go
@@ -1,0 +1,112 @@
+package gateways
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	externaldnsv1alpha1 "sigs.k8s.io/external-dns/apis/v1alpha1"
+	"sigs.k8s.io/external-dns/endpoint"
+
+	settingspkg "github.com/formancehq/operator/v3/internal/resources/settings"
+	"github.com/formancehq/operator/v3/internal/testutil"
+)
+
+func TestReconcileDNSEndpointsAppliesSettingsToFinalDNSEndpoints(t *testing.T) {
+	t.Parallel()
+
+	gateway := gatewaySettingsFixture()
+	ctx := testutil.NewContext(
+		gateway,
+		settingspkg.New("private-enabled", "gateway.dns.private.enabled", "true", "stack0"),
+		settingspkg.New("private-names", "gateway.dns.private.dns-names", "{stack}.internal.example.com, api.internal.example.com", "stack0"),
+		settingspkg.New("private-targets", "gateway.dns.private.targets", "10.0.0.1, 10.0.0.2", "stack0"),
+		settingspkg.New("private-provider", "gateway.dns.private.provider-specific", "aws-zone-type=private,aws-weight=100", "stack0"),
+		settingspkg.New("private-annotations", "gateway.dns.private.annotations", "owner=platform", "stack0"),
+		settingspkg.New("private-record", "gateway.dns.private.record-type", "A", "stack0"),
+		settingspkg.New("public-enabled", "gateway.dns.public.enabled", "true", "stack0"),
+		settingspkg.New("public-names", "gateway.dns.public.dns-names", "{stack}.public.example.com", "stack0"),
+		settingspkg.New("public-targets", "gateway.dns.public.targets", "gateway.example.net", "stack0"),
+	)
+
+	require.NoError(t, reconcileDNSEndpoints(ctx, gateway))
+
+	privateEndpoint := &externaldnsv1alpha1.DNSEndpoint{}
+	require.NoError(t, ctx.GetClient().Get(ctx, types.NamespacedName{Name: "gateway-private", Namespace: "stack0"}, privateEndpoint))
+	require.Equal(t, "platform", privateEndpoint.Annotations["owner"])
+	require.Len(t, privateEndpoint.OwnerReferences, 1)
+	require.Equal(t, "Gateway", privateEndpoint.OwnerReferences[0].Kind)
+	require.Len(t, privateEndpoint.Spec.Endpoints, 2)
+	require.Equal(t, "stack0.internal.example.com", privateEndpoint.Spec.Endpoints[0].DNSName)
+	require.Equal(t, "A", privateEndpoint.Spec.Endpoints[0].RecordType)
+	require.Equal(t, endpoint.Targets{"10.0.0.1", "10.0.0.2"}, privateEndpoint.Spec.Endpoints[0].Targets)
+	require.ElementsMatch(t, endpoint.ProviderSpecific{
+		{Name: "aws-zone-type", Value: "private"},
+		{Name: "aws-weight", Value: "100"},
+	}, privateEndpoint.Spec.Endpoints[0].ProviderSpecific)
+	require.Equal(t, "api.internal.example.com", privateEndpoint.Spec.Endpoints[1].DNSName)
+
+	publicEndpoint := &externaldnsv1alpha1.DNSEndpoint{}
+	require.NoError(t, ctx.GetClient().Get(ctx, types.NamespacedName{Name: "gateway-public", Namespace: "stack0"}, publicEndpoint))
+	require.Len(t, publicEndpoint.Spec.Endpoints, 1)
+	require.Equal(t, "stack0.public.example.com", publicEndpoint.Spec.Endpoints[0].DNSName)
+	require.Equal(t, "CNAME", publicEndpoint.Spec.Endpoints[0].RecordType)
+	require.Equal(t, endpoint.Targets{"gateway.example.net"}, publicEndpoint.Spec.Endpoints[0].Targets)
+}
+
+func TestReconcileDNSEndpointsDeletesDisabledEndpoints(t *testing.T) {
+	t.Parallel()
+
+	gateway := gatewaySettingsFixture()
+	existingPrivate := &externaldnsv1alpha1.DNSEndpoint{
+		ObjectMeta: metav1.ObjectMeta{Name: "gateway-private", Namespace: "stack0"},
+	}
+	existingPublic := &externaldnsv1alpha1.DNSEndpoint{
+		ObjectMeta: metav1.ObjectMeta{Name: "gateway-public", Namespace: "stack0"},
+	}
+	ctx := testutil.NewContext(gateway, existingPrivate, existingPublic)
+
+	require.NoError(t, reconcileDNSEndpoints(ctx, gateway))
+
+	err := ctx.GetClient().Get(ctx, types.NamespacedName{Name: "gateway-private", Namespace: "stack0"}, &externaldnsv1alpha1.DNSEndpoint{})
+	require.Error(t, err)
+	err = ctx.GetClient().Get(ctx, types.NamespacedName{Name: "gateway-public", Namespace: "stack0"}, &externaldnsv1alpha1.DNSEndpoint{})
+	require.Error(t, err)
+}
+
+func TestGetDNSConfigRequiresNamesAndTargetsWhenEnabled(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name     string
+		settings []client.Object
+	}{
+		{
+			name: "missing dns names",
+			settings: []client.Object{
+				settingspkg.New("enabled", "gateway.dns.private.enabled", "true", "stack0"),
+				settingspkg.New("targets", "gateway.dns.private.targets", "10.0.0.1", "stack0"),
+			},
+		},
+		{
+			name: "missing targets",
+			settings: []client.Object{
+				settingspkg.New("enabled", "gateway.dns.private.enabled", "true", "stack0"),
+				settingspkg.New("names", "gateway.dns.private.dns-names", "stack0.example.com", "stack0"),
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := testutil.NewContext(tc.settings...)
+
+			_, err := getDNSConfig(ctx, "stack0", "private")
+			require.Error(t, err)
+		})
+	}
+}

--- a/internal/resources/gateways/gateways_test.go
+++ b/internal/resources/gateways/gateways_test.go
@@ -1,0 +1,47 @@
+package gateways
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/formancehq/operator/v3/api/formance.com/v1beta1"
+	"github.com/formancehq/operator/v3/internal/testutil"
+)
+
+func TestGetEnvVarsAndURL(t *testing.T) {
+	t.Parallel()
+
+	gateway := &v1beta1.Gateway{}
+	require.Equal(t, "http://gateway:8080", URL(gateway))
+	require.Equal(t, map[string]string{"STACK_URL": "http://gateway:8080"}, testutil.EnvMap(GetEnvVars(gateway)))
+
+	gateway.Spec.Ingress = &v1beta1.GatewayIngress{Scheme: "https", Host: "stack.example.com"}
+	require.Equal(t, "https://stack.example.com", URL(gateway))
+	require.Equal(t, map[string]string{
+		"STACK_URL":        "http://gateway:8080",
+		"STACK_PUBLIC_URL": "https://stack.example.com",
+	}, testutil.EnvMap(GetEnvVars(gateway)))
+}
+
+func TestEnvVarsIfEnabled(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.NewContext(&v1beta1.Gateway{
+		TypeMeta:   metav1.TypeMeta{APIVersion: "formance.com/v1beta1", Kind: "Gateway"},
+		ObjectMeta: testutil.ObjectMeta("gateway"),
+		Spec: v1beta1.GatewaySpec{
+			StackDependency: v1beta1.StackDependency{Stack: "stack0"},
+			Ingress:         &v1beta1.GatewayIngress{Scheme: "https", Host: "stack.example.com"},
+		},
+	})
+
+	env, err := EnvVarsIfEnabled(ctx, "stack0")
+	require.NoError(t, err)
+	require.Equal(t, "https://stack.example.com", testutil.EnvMap(env)["STACK_PUBLIC_URL"])
+
+	env, err = EnvVarsIfEnabled(ctx, "missing")
+	require.NoError(t, err)
+	require.Nil(t, env)
+}

--- a/internal/resources/gateways/ingress_settings_test.go
+++ b/internal/resources/gateways/ingress_settings_test.go
@@ -1,0 +1,154 @@
+package gateways
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/formancehq/operator/v3/api/formance.com/v1beta1"
+	settingspkg "github.com/formancehq/operator/v3/internal/resources/settings"
+	"github.com/formancehq/operator/v3/internal/testutil"
+)
+
+func TestCreateIngressAppliesSettingsToFinalIngress(t *testing.T) {
+	t.Parallel()
+
+	stack := &v1beta1.Stack{ObjectMeta: testutil.ObjectMeta("stack0")}
+	gateway := gatewaySettingsFixture()
+	ctx := testutil.NewContext(
+		stack,
+		gateway,
+		settingspkg.New("hosts", "gateway.ingress.hosts", "{stack}.settings.example.com, extra.example.com, spec.example.com", "stack0"),
+		settingspkg.New("annotations-wildcard", "gateway.ingress.annotations", "from=settings,override=settings", "*"),
+		settingspkg.New("annotations-specific", "gateway.ingress.annotations", "override=specific", "stack0"),
+		settingspkg.New("labels", "gateway.ingress.labels", "team=edge", "stack0"),
+		settingspkg.New("tls", "gateway.ingress.tls.enabled", "true", "stack0"),
+		settingspkg.New("class", "gateway.ingress.class", "nginx", "stack0"),
+	)
+
+	require.NoError(t, createIngress(ctx, stack, gateway))
+
+	ingress := &networkingv1.Ingress{}
+	require.NoError(t, ctx.GetClient().Get(ctx, types.NamespacedName{Name: "gateway", Namespace: "stack0"}, ingress))
+	require.Equal(t, map[string]string{
+		"override": "gateway-spec",
+	}, ingress.Annotations)
+	require.Equal(t, "edge", ingress.Labels["team"])
+	require.Equal(t, "gateway", ingress.Labels["app.kubernetes.io/component"])
+	require.Equal(t, "stack0", ingress.Labels["app.kubernetes.io/name"])
+	require.Equal(t, "nginx", *ingress.Spec.IngressClassName)
+
+	require.Len(t, ingress.Spec.Rules, 4)
+	require.Equal(t, []string{
+		"spec.example.com",
+		"alt.example.com",
+		"stack0.settings.example.com",
+		"extra.example.com",
+	}, ingressHosts(ingress))
+	require.Len(t, ingress.Spec.TLS, 1)
+	require.Equal(t, "gateway-tls", ingress.Spec.TLS[0].SecretName)
+	require.Equal(t, ingressHosts(ingress), ingress.Spec.TLS[0].Hosts)
+	require.Len(t, ingress.OwnerReferences, 1)
+	require.Equal(t, "Gateway", ingress.OwnerReferences[0].Kind)
+}
+
+func TestCreateIngressPrefersGatewaySpecTLSAndIngressClass(t *testing.T) {
+	t.Parallel()
+
+	stack := &v1beta1.Stack{ObjectMeta: testutil.ObjectMeta("stack0")}
+	className := "from-spec"
+	gateway := gatewaySettingsFixture()
+	gateway.Spec.Ingress.IngressClassName = &className
+	gateway.Spec.Ingress.TLS = &v1beta1.GatewayIngressTLS{SecretName: "spec-tls"}
+	ctx := testutil.NewContext(
+		stack,
+		gateway,
+		settingspkg.New("tls", "gateway.ingress.tls.enabled", "true", "stack0"),
+		settingspkg.New("class", "gateway.ingress.class", "nginx", "stack0"),
+	)
+
+	require.NoError(t, createIngress(ctx, stack, gateway))
+
+	ingress := &networkingv1.Ingress{}
+	require.NoError(t, ctx.GetClient().Get(ctx, types.NamespacedName{Name: "gateway", Namespace: "stack0"}, ingress))
+	require.Equal(t, "from-spec", *ingress.Spec.IngressClassName)
+	require.Len(t, ingress.Spec.TLS, 1)
+	require.Equal(t, "spec-tls", ingress.Spec.TLS[0].SecretName)
+}
+
+func TestCreateIngressDeletesIngressWhenGatewayIngressIsNil(t *testing.T) {
+	t.Parallel()
+
+	stack := &v1beta1.Stack{ObjectMeta: testutil.ObjectMeta("stack0")}
+	gateway := gatewaySettingsFixture()
+	gateway.Spec.Ingress = nil
+	existing := &networkingv1.Ingress{ObjectMeta: metav1.ObjectMeta{Name: "gateway", Namespace: "stack0"}}
+	ctx := testutil.NewContext(stack, gateway, existing)
+
+	require.NoError(t, createIngress(ctx, stack, gateway))
+
+	ingress := &networkingv1.Ingress{}
+	err := ctx.GetClient().Get(ctx, types.NamespacedName{Name: "gateway", Namespace: "stack0"}, ingress)
+	require.Error(t, err)
+}
+
+func TestCreateIngressReturnsInvalidSettingsErrors(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name    string
+		setting *v1beta1.Settings
+	}{
+		{
+			name:    "invalid annotations",
+			setting: settingspkg.New("invalid-annotations", "gateway.ingress.annotations", `foo="unterminated`, "stack0"),
+		},
+		{
+			name:    "invalid labels",
+			setting: settingspkg.New("invalid-labels", "gateway.ingress.labels", `foo="unterminated`, "stack0"),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			stack := &v1beta1.Stack{ObjectMeta: testutil.ObjectMeta("stack0")}
+			gateway := gatewaySettingsFixture()
+			ctx := testutil.NewContext(stack, gateway, tc.setting)
+
+			require.Error(t, createIngress(ctx, stack, gateway))
+		})
+	}
+}
+
+func ingressHosts(ingress *networkingv1.Ingress) []string {
+	hosts := make([]string, 0, len(ingress.Spec.Rules))
+	for _, rule := range ingress.Spec.Rules {
+		hosts = append(hosts, rule.Host)
+	}
+	return hosts
+}
+
+func gatewaySettingsFixture() *v1beta1.Gateway {
+	return &v1beta1.Gateway{
+		TypeMeta: metav1.TypeMeta{APIVersion: "formance.com/v1beta1", Kind: "Gateway"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "gateway",
+			UID:  types.UID("gateway-uid"),
+		},
+		Spec: v1beta1.GatewaySpec{
+			StackDependency: v1beta1.StackDependency{Stack: "stack0"},
+			Ingress: &v1beta1.GatewayIngress{
+				Host:  "spec.example.com",
+				Hosts: []string{"alt.example.com"},
+				Annotations: map[string]string{
+					"override": "gateway-spec",
+				},
+			},
+		},
+	}
+}

--- a/internal/resources/jobs/job_test.go
+++ b/internal/resources/jobs/job_test.go
@@ -1,0 +1,175 @@
+package jobs
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/formancehq/operator/v3/api/formance.com/v1beta1"
+	"github.com/formancehq/operator/v3/internal/core"
+	"github.com/formancehq/operator/v3/internal/resources/settings"
+	"github.com/formancehq/operator/v3/internal/testutil"
+)
+
+func TestHandleCreatesJobWithOptionsAndSettings(t *testing.T) {
+	t.Parallel()
+
+	owner := paymentsOwner()
+	ctx := testutil.NewContext(
+		settings.New("env", "jobs.payments.containers.migrate.env-vars", "FROM_SETTINGS=true,EXISTING=override", "stack0"),
+		settings.New("annotations", "jobs.payments.spec.template.annotations", "checksum=abc", "stack0"),
+	)
+	preCreateCalled := false
+	policy := batchv1.PodFailurePolicy{Rules: []batchv1.PodFailurePolicyRule{{
+		Action: batchv1.PodFailurePolicyActionFailJob,
+		OnExitCodes: &batchv1.PodFailurePolicyOnExitCodesRequirement{
+			Operator: batchv1.PodFailurePolicyOnExitCodesOpIn,
+			Values:   []int32{1},
+		},
+	}}}
+
+	err := Handle(ctx, owner, "migrate", corev1.Container{
+		Name:  "migrate",
+		Image: "payments:test",
+		Env:   []corev1.EnvVar{core.Env("EXISTING", "base")},
+	},
+		PreCreate(func() error {
+			preCreateCalled = true
+			return nil
+		}),
+		WithServiceAccount("jobs-sa"),
+		WithEnvVars(core.Env("FROM_OPTION", "true")),
+		WithImagePullSecrets([]corev1.LocalObjectReference{{Name: "pull-secret"}}),
+		WithPodFailurePolicy(policy),
+	)
+	require.True(t, core.IsApplicationError(err))
+	require.True(t, preCreateCalled)
+
+	job := &batchv1.Job{}
+	require.NoError(t, ctx.GetClient().Get(context.Background(), types.NamespacedName{
+		Namespace: "stack0",
+		Name:      "uid-123-migrate",
+	}, job))
+
+	require.Equal(t, "jobs-sa", job.Spec.Template.Spec.ServiceAccountName)
+	require.Equal(t, []corev1.LocalObjectReference{{Name: "pull-secret"}}, job.Spec.Template.Spec.ImagePullSecrets)
+	require.Equal(t, corev1.RestartPolicyNever, job.Spec.Template.Spec.RestartPolicy)
+	require.NotNil(t, job.Spec.PodFailurePolicy)
+	require.Equal(t, "abc", job.Spec.Template.Annotations["checksum"])
+	require.Equal(t, map[string]string{
+		"EXISTING":      "override",
+		"FROM_OPTION":   "true",
+		"FROM_SETTINGS": "true",
+	}, testutil.EnvMap(job.Spec.Template.Spec.Containers[0].Env))
+	require.Len(t, job.OwnerReferences, 1)
+	require.Equal(t, "Payments", job.OwnerReferences[0].Kind)
+}
+
+func TestHandleReturnsNilWhenExistingJobIsValid(t *testing.T) {
+	t.Parallel()
+
+	owner := paymentsOwner()
+	existing := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "stack0",
+			Name:      "uid-123-migrate",
+		},
+		Status: batchv1.JobStatus{Succeeded: 1},
+	}
+	ctx := testutil.NewContext(existing)
+
+	err := Handle(ctx, owner, "migrate", corev1.Container{Name: "migrate"})
+	require.NoError(t, err)
+}
+
+func TestHandleAppliesRunAsAndInitContainerSettings(t *testing.T) {
+	t.Parallel()
+
+	owner := paymentsOwner()
+	ctx := testutil.NewContext(
+		settings.New("container-run-as", "jobs.payments.containers.migrate.run-as", "user=1000,group=2000", "stack0"),
+		settings.New("init-env", "jobs.payments.init-containers.setup.env-vars", "INIT_EXISTING=override,INIT_FROM_SETTINGS=true", "stack0"),
+		settings.New("init-run-as", "jobs.payments.init-containers.setup.run-as", "user=1002,group=2002", "stack0"),
+	)
+
+	err := Handle(ctx, owner, "migrate", corev1.Container{
+		Name:  "migrate",
+		Image: "payments:test",
+	}, Mutator(func(job *batchv1.Job) error {
+		job.Spec.Template.Spec.InitContainers = []corev1.Container{{
+			Name:  "setup",
+			Image: "setup:test",
+			Env:   []corev1.EnvVar{core.Env("INIT_EXISTING", "base")},
+		}}
+		return nil
+	}))
+	require.True(t, core.IsApplicationError(err))
+
+	job := &batchv1.Job{}
+	require.NoError(t, ctx.GetClient().Get(context.Background(), types.NamespacedName{
+		Namespace: "stack0",
+		Name:      "uid-123-migrate",
+	}, job))
+
+	require.Len(t, job.Spec.Template.Spec.Containers, 1)
+	containerSecurityContext := job.Spec.Template.Spec.Containers[0].SecurityContext
+	require.NotNil(t, containerSecurityContext)
+	require.Equal(t, int64(1000), *containerSecurityContext.RunAsUser)
+	require.Equal(t, int64(2000), *containerSecurityContext.RunAsGroup)
+	require.True(t, *containerSecurityContext.RunAsNonRoot)
+
+	require.Len(t, job.Spec.Template.Spec.InitContainers, 1)
+	initContainer := job.Spec.Template.Spec.InitContainers[0]
+	require.Equal(t, map[string]string{
+		"INIT_EXISTING":      "override",
+		"INIT_FROM_SETTINGS": "true",
+	}, testutil.EnvMap(initContainer.Env))
+	require.NotNil(t, initContainer.SecurityContext)
+	require.Equal(t, int64(1002), *initContainer.SecurityContext.RunAsUser)
+	require.Equal(t, int64(2002), *initContainer.SecurityContext.RunAsGroup)
+	require.True(t, *initContainer.SecurityContext.RunAsNonRoot)
+}
+
+func TestHandleRunsPreCreateErrorBeforeCreatingJob(t *testing.T) {
+	t.Parallel()
+
+	owner := paymentsOwner()
+	ctx := testutil.NewContext()
+
+	err := Handle(ctx, owner, "migrate", corev1.Container{Name: "migrate"},
+		PreCreate(func() error {
+			return errPreCreate
+		}),
+	)
+	require.ErrorIs(t, err, errPreCreate)
+
+	job := &batchv1.Job{}
+	err = ctx.GetClient().Get(context.Background(), types.NamespacedName{Namespace: "stack0", Name: "uid-123-migrate"}, job)
+	require.Error(t, err)
+}
+
+var errPreCreate = errSentinel("precreate failed")
+
+type errSentinel string
+
+func (e errSentinel) Error() string {
+	return string(e)
+}
+
+func paymentsOwner() *v1beta1.Payments {
+	return &v1beta1.Payments{
+		TypeMeta: metav1.TypeMeta{APIVersion: "formance.com/v1beta1", Kind: "Payments"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "payments",
+			UID:  "uid-123",
+		},
+		Spec: v1beta1.PaymentsSpec{
+			StackDependency: v1beta1.StackDependency{Stack: "stack0"},
+		},
+	}
+}

--- a/internal/resources/ledgers/deployments_test.go
+++ b/internal/resources/ledgers/deployments_test.go
@@ -1,0 +1,274 @@
+package ledgers
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/formancehq/operator/v3/api/formance.com/v1beta1"
+	"github.com/formancehq/operator/v3/internal/resources/registries"
+	settingspkg "github.com/formancehq/operator/v3/internal/resources/settings"
+	"github.com/formancehq/operator/v3/internal/testutil"
+)
+
+func TestSetCommonAPIContainerConfiguration(t *testing.T) {
+	t.Parallel()
+
+	stack := &v1beta1.Stack{ObjectMeta: testutil.ObjectMeta("stack0")}
+	ledger := &v1beta1.Ledger{
+		Spec: v1beta1.LedgerSpec{
+			StackDependency: v1beta1.StackDependency{Stack: "stack0"},
+			ModuleProperties: v1beta1.ModuleProperties{
+				DevProperties: v1beta1.DevProperties{Debug: true, Dev: true},
+			},
+		},
+	}
+	database := &v1beta1.Database{
+		Spec: v1beta1.DatabaseSpec{
+			StackDependency: v1beta1.StackDependency{Stack: "stack0"},
+			Service:         "ledger",
+		},
+		Status: v1beta1.DatabaseStatus{
+			URI:      testutil.MustParseURI("postgresql://ledger:secret@postgres.stack0:5432/ledger"),
+			Database: "ledger",
+		},
+	}
+	image := &registries.ImageConfiguration{
+		Registry: "ghcr.io",
+		Image:    "formancehq/ledger",
+		Version:  "v1.0.0",
+	}
+	ctx := testutil.NewContext(
+		settingspkg.New("connection-pool", "modules.ledger.database.connection-pool", "max-idle=4", "stack0"),
+	)
+	container := createBaseLedgerContainer()
+
+	require.NoError(t, setCommonAPIContainerConfiguration(ctx, stack, ledger, image, database, container))
+
+	envMap := testutil.EnvMap(container.Env)
+	require.Equal(t, "ghcr.io/formancehq/ledger:v1.0.0", container.Image)
+	require.Equal(t, ":8080", envMap["BIND"])
+	require.Equal(t, "true", envMap["DEBUG"])
+	require.Equal(t, "true", envMap["DEV"])
+	require.Equal(t, "$(POSTGRES_URI)", envMap["STORAGE_POSTGRES_CONN_STRING"])
+	require.Equal(t, "postgres", envMap["STORAGE_DRIVER"])
+	require.Equal(t, "4", envMap["POSTGRES_MAX_IDLE_CONNS"])
+	require.NotNil(t, container.LivenessProbe)
+	require.NotNil(t, container.ReadinessProbe)
+	require.Len(t, container.Ports, 1)
+}
+
+func TestInstallLedgerStatelessAppliesAPISettingsToFinalDeployment(t *testing.T) {
+	t.Parallel()
+
+	stack, ledger, database, image := ledgerSettingsFixtures()
+	ctx := newLedgerContextWithDependencyIndexes(
+		ledger,
+		settingspkg.New("experimental-features", "ledger.experimental-features", "true", "stack0"),
+		settingspkg.New("experimental-numscript", "ledger.experimental-numscript", "true", "stack0"),
+		settingspkg.New("experimental-numscript-flags", "ledger.experimental-numscript-flags", "flag-a,flag-b", "stack0"),
+		settingspkg.New("default-page-size", "ledger.api.default-page-size", "25", "stack0"),
+		settingspkg.New("max-page-size", "ledger.api.max-page-size", "100", "stack0"),
+		settingspkg.New("bulk-max-size", "ledger.api.bulk-max-size", "500", "stack0"),
+		settingspkg.New("schema", "ledger.schema-enforcement-mode", "strict", "stack0"),
+		settingspkg.New("exporters", "ledger.experimental-exporters", "true", "stack0"),
+		settingspkg.New("aws", "aws.service-account", "ledger-aws", "stack0"),
+	)
+
+	require.NoError(t, installLedgerStateless(ctx, stack, ledger, database, image))
+
+	deployment := &appsv1.Deployment{}
+	require.NoError(t, ctx.GetClient().Get(ctx, types.NamespacedName{Name: "ledger", Namespace: "stack0"}, deployment))
+	require.Equal(t, "ledger-aws", deployment.Spec.Template.Spec.ServiceAccountName)
+	require.Len(t, deployment.Spec.Template.Spec.Containers, 1)
+	container := deployment.Spec.Template.Spec.Containers[0]
+	envMap := testutil.EnvMap(container.Env)
+	require.Equal(t, "true", envMap["EXPERIMENTAL_FEATURES"])
+	require.Equal(t, "true", envMap["EXPERIMENTAL_NUMSCRIPT_INTERPRETER"])
+	require.Equal(t, "flag-a flag-b", envMap["EXPERIMENTAL_NUMSCRIPT_INTERPRETER_FLAGS"])
+	require.Equal(t, "25", envMap["DEFAULT_PAGE_SIZE"])
+	require.Equal(t, "100", envMap["MAX_PAGE_SIZE"])
+	require.Equal(t, "500", envMap["BULK_MAX_SIZE"])
+	require.Equal(t, "strict", envMap["SCHEMA_ENFORCEMENT_MODE"])
+	require.Equal(t, "true", envMap["EXPERIMENTAL_EXPORTERS"])
+	require.Equal(t, "ledger-worker.stack0:8081", envMap["WORKER_GRPC_ADDRESS"])
+	require.NotNil(t, container.LivenessProbe)
+	require.NotNil(t, container.ReadinessProbe)
+	require.Len(t, container.Ports, 1)
+}
+
+func TestInstallLedgerWorkerAppliesWorkerSettingsToFinalDeploymentAndService(t *testing.T) {
+	t.Parallel()
+
+	stack, ledger, database, image := ledgerSettingsFixtures()
+	ctx := testutil.NewContext(
+		ledger,
+		settingspkg.New("async-block-hasher", "ledger.worker.async-block-hasher", "max-block-size=1000,schedule=*/5 * * * *", "stack0"),
+		settingspkg.New("pipelines", "ledger.worker.pipelines", "pull-interval=1s,push-retry-period=2s,sync-period=3s,logs-page-size=42", "stack0"),
+		settingspkg.New("bucket-cleanup", "ledger.worker.bucket-cleanup", "retention-period=720h,schedule=0 0 * * *", "stack0"),
+		settingspkg.New("schema", "ledger.schema-enforcement-mode", "strict", "stack0"),
+		settingspkg.New("exporters", "ledger.experimental-exporters", "true", "stack0"),
+		settingspkg.New("aws", "aws.service-account", "ledger-worker-aws", "stack0"),
+	)
+
+	require.NoError(t, installLedgerWorker(ctx, stack, ledger, database, image))
+
+	deployment := &appsv1.Deployment{}
+	require.NoError(t, ctx.GetClient().Get(ctx, types.NamespacedName{Name: "ledger-worker", Namespace: "stack0"}, deployment))
+	require.Equal(t, appsv1.RecreateDeploymentStrategyType, deployment.Spec.Strategy.Type)
+	require.Equal(t, "ledger-worker-aws", deployment.Spec.Template.Spec.ServiceAccountName)
+	require.Len(t, deployment.Spec.Template.Spec.Containers, 1)
+	container := deployment.Spec.Template.Spec.Containers[0]
+	require.Equal(t, []string{"worker"}, container.Args)
+	envMap := testutil.EnvMap(container.Env)
+	require.Equal(t, "1000", envMap["WORKER_ASYNC_BLOCK_HASHER_MAX_BLOCK_SIZE"])
+	require.Equal(t, "*/5 * * * *", envMap["WORKER_ASYNC_BLOCK_HASHER_SCHEDULE"])
+	require.Equal(t, "1s", envMap["WORKER_PIPELINES_PULL_INTERVAL"])
+	require.Equal(t, "2s", envMap["WORKER_PIPELINES_PUSH_RETRY_PERIOD"])
+	require.Equal(t, "3s", envMap["WORKER_PIPELINES_SYNC_PERIOD"])
+	require.Equal(t, "42", envMap["WORKER_PIPELINES_LOGS_PAGE_SIZE"])
+	require.Equal(t, "720h", envMap["WORKER_BUCKET_CLEANUP_RETENTION_PERIOD"])
+	require.Equal(t, "0 0 * * *", envMap["WORKER_BUCKET_CLEANUP_SCHEDULE"])
+	require.Equal(t, "strict", envMap["SCHEMA_ENFORCEMENT_MODE"])
+	require.Len(t, container.Ports, 1)
+	require.Equal(t, int32(8081), container.Ports[0].ContainerPort)
+
+	service := &corev1.Service{}
+	require.NoError(t, ctx.GetClient().Get(ctx, types.NamespacedName{Name: "ledger-worker", Namespace: "stack0"}, service))
+	require.Len(t, service.Spec.Ports, 1)
+	require.Equal(t, int32(8081), service.Spec.Ports[0].Port)
+	require.Equal(t, "grpc", service.Spec.Ports[0].TargetPort.String())
+}
+
+func TestLedgerSettingsRejectInvalidValues(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name    string
+		setting client.Object
+		run     func(ctx *testutil.Context, stack *v1beta1.Stack, ledger *v1beta1.Ledger, database *v1beta1.Database, image *registries.ImageConfiguration) error
+	}{
+		{
+			name:    "invalid api page size",
+			setting: settingspkg.New("invalid-page-size", "ledger.api.default-page-size", "not-an-int", "stack0"),
+			run: func(ctx *testutil.Context, stack *v1beta1.Stack, ledger *v1beta1.Ledger, database *v1beta1.Database, image *registries.ImageConfiguration) error {
+				return installLedgerStateless(ctx, stack, ledger, database, image)
+			},
+		},
+		{
+			name:    "invalid worker structured setting",
+			setting: settingspkg.New("invalid-pipelines", "ledger.worker.pipelines", `pull-interval="unterminated`, "stack0"),
+			run: func(ctx *testutil.Context, stack *v1beta1.Stack, ledger *v1beta1.Ledger, database *v1beta1.Database, image *registries.ImageConfiguration) error {
+				return installLedgerWorker(ctx, stack, ledger, database, image)
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			stack, ledger, database, image := ledgerSettingsFixtures()
+			ctx := newLedgerContextWithDependencyIndexes(ledger, tc.setting)
+
+			require.Error(t, tc.run(ctx, stack, ledger, database, image))
+		})
+	}
+}
+
+func ledgerSettingsFixtures() (*v1beta1.Stack, *v1beta1.Ledger, *v1beta1.Database, *registries.ImageConfiguration) {
+	stack := &v1beta1.Stack{ObjectMeta: testutil.ObjectMeta("stack0")}
+	ledger := &v1beta1.Ledger{
+		TypeMeta: metav1.TypeMeta{APIVersion: "formance.com/v1beta1", Kind: "Ledger"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "ledger",
+			UID:  types.UID("ledger-uid"),
+		},
+		Spec: v1beta1.LedgerSpec{
+			StackDependency: v1beta1.StackDependency{Stack: "stack0"},
+		},
+	}
+	database := &v1beta1.Database{
+		Spec: v1beta1.DatabaseSpec{
+			StackDependency: v1beta1.StackDependency{Stack: "stack0"},
+			Service:         "ledger",
+		},
+		Status: v1beta1.DatabaseStatus{
+			URI:      testutil.MustParseURI("postgresql://ledger:secret@postgres.stack0:5432/ledger"),
+			Database: "ledger",
+		},
+	}
+	image := &registries.ImageConfiguration{
+		Registry: "ghcr.io",
+		Image:    "formancehq/ledger",
+		Version:  "v2.0.0",
+	}
+	return stack, ledger, database, image
+}
+
+func newLedgerContextWithDependencyIndexes(objects ...client.Object) *testutil.Context {
+	scheme := testutil.NewScheme()
+	builder := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(objects...)
+
+	builder.WithIndex(&v1beta1.Settings{}, "stack", func(obj client.Object) []string {
+		return obj.(*v1beta1.Settings).GetStacks()
+	})
+	builder.WithIndex(&v1beta1.Settings{}, "keylen", func(obj client.Object) []string {
+		keyParts := settingspkg.SplitKeywordWithDot(obj.(*v1beta1.Settings).Spec.Key)
+		return []string{fmt.Sprintf("%d", len(keyParts))}
+	})
+	builder.WithIndex(&v1beta1.BrokerTopic{}, "stack", func(obj client.Object) []string {
+		topic := obj.(*v1beta1.BrokerTopic)
+		if topic.Spec.Stack == "" {
+			return nil
+		}
+		return []string{topic.Spec.Stack}
+	})
+	builder.WithIndex(&v1beta1.BrokerTopic{}, ".spec.service", func(obj client.Object) []string {
+		topic := obj.(*v1beta1.BrokerTopic)
+		if topic.Spec.Service == "" {
+			return nil
+		}
+		return []string{topic.Spec.Service}
+	})
+	withLedgerUnstructuredStackIndex(builder, "Auth")
+	withLedgerUnstructuredStackIndex(builder, "Gateway")
+
+	return &testutil.Context{
+		Context: context.Background(),
+		Client:  builder.Build(),
+		Scheme:  scheme,
+	}
+}
+
+func withLedgerUnstructuredStackIndex(builder *fake.ClientBuilder, kind string) {
+	object := &unstructured.Unstructured{}
+	object.SetAPIVersion("formance.com/v1beta1")
+	object.SetKind(kind)
+	builder.WithIndex(object, "stack", func(obj client.Object) []string {
+		u, ok := obj.(*unstructured.Unstructured)
+		if !ok {
+			return nil
+		}
+		spec, ok := u.Object["spec"].(map[string]any)
+		if !ok {
+			return nil
+		}
+		stack, ok := spec["stack"].(string)
+		if !ok || stack == "" {
+			return nil
+		}
+		return []string{stack}
+	})
+}

--- a/internal/resources/payments/deployments.go
+++ b/internal/resources/payments/deployments.go
@@ -51,6 +51,9 @@ func temporalEnvVars(ctx core.Context, stack *v1beta1.Stack, payments *v1beta1.P
 
 	if secret := temporalURI.Query().Get("secret"); secret != "" {
 		ref, err = resourcereferences.Create(ctx, payments, "payments-temporal", secret, &corev1.Secret{})
+		if err != nil {
+			return
+		}
 		hash[ref.Name] = ref.Status.Hash
 	} else {
 		err = resourcereferences.Delete(ctx, payments, "payments-temporal")
@@ -61,6 +64,9 @@ func temporalEnvVars(ctx core.Context, stack *v1beta1.Stack, payments *v1beta1.P
 
 	if secret := temporalURI.Query().Get("encryptionKeySecret"); secret != "" {
 		ref, err = resourcereferences.Create(ctx, payments, "payments-temporal-encryption-key", secret, &corev1.Secret{})
+		if err != nil {
+			return
+		}
 		hash[ref.Name] = ref.Status.Hash
 	} else {
 		err = resourcereferences.Delete(ctx, payments, "payments-temporal-encryption-key")

--- a/internal/resources/payments/deployments_test.go
+++ b/internal/resources/payments/deployments_test.go
@@ -1,0 +1,495 @@
+package payments
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/formancehq/operator/v3/api/formance.com/v1beta1"
+	"github.com/formancehq/operator/v3/internal/core"
+	"github.com/formancehq/operator/v3/internal/resources/registries"
+	settingspkg "github.com/formancehq/operator/v3/internal/resources/settings"
+	"github.com/formancehq/operator/v3/internal/testutil"
+)
+
+func TestGetEncryptionKeyUsesSettingsWhenSpecIsEmpty(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.NewContext(
+		settingspkg.New("encryption-key", "payments.encryption-key", "from-settings", "stack0"),
+	)
+
+	key, err := getEncryptionKey(ctx, &v1beta1.Payments{Spec: v1beta1.PaymentsSpec{
+		StackDependency: v1beta1.StackDependency{Stack: "stack0"},
+	}})
+	require.NoError(t, err)
+	require.Equal(t, "from-settings", key)
+}
+
+func TestGetEncryptionKeyReturnsEmptyWhenSpecIsSet(t *testing.T) {
+	t.Parallel()
+
+	key, err := getEncryptionKey(testutil.NewContext(), &v1beta1.Payments{Spec: v1beta1.PaymentsSpec{
+		StackDependency: v1beta1.StackDependency{Stack: "stack0"},
+		EncryptionKey:   "from-spec",
+	}})
+	require.NoError(t, err)
+	require.Empty(t, key)
+}
+
+func TestTemporalEnvVarsWithoutReferencedSecrets(t *testing.T) {
+	t.Parallel()
+
+	stack := &v1beta1.Stack{ObjectMeta: testutil.ObjectMeta("stack0")}
+	payments := &v1beta1.Payments{
+		ObjectMeta: testutil.ObjectMeta("payments0"),
+		Spec: v1beta1.PaymentsSpec{
+			StackDependency: v1beta1.StackDependency{Stack: "stack0"},
+		},
+	}
+	ctx := testutil.NewContext(
+		settingspkg.New("temporal-dsn", "temporal.dsn", "temporal://temporal.stack0:7233/payments?initSearchAttributes=true", "stack0"),
+		settingspkg.New("temporal-crt", "temporal.tls.crt", "crt", "stack0"),
+		settingspkg.New("temporal-key", "temporal.tls.key", "key", "stack0"),
+		settingspkg.New("workflow-pollers", "payments.worker.temporal-max-concurrent-workflow-task-pollers", "8", "stack0"),
+		settingspkg.New("activity-pollers", "payments.worker.temporal-max-concurrent-activity-task-pollers", "9", "stack0"),
+		settingspkg.New("slots", "payments.worker.temporal-max-slots-per-poller", "12", "stack0"),
+		settingspkg.New("local-slots", "payments.worker.temporal-max-local-activity-slots", "34", "stack0"),
+	)
+
+	hash, env, err := temporalEnvVars(ctx, stack, payments)
+	require.NoError(t, err)
+	require.Empty(t, hash)
+
+	envMap := testutil.EnvMap(env)
+	require.Equal(t, "temporal.stack0:7233", envMap["TEMPORAL_ADDRESS"])
+	require.Equal(t, "payments", envMap["TEMPORAL_NAMESPACE"])
+	require.Equal(t, "crt", envMap["TEMPORAL_SSL_CLIENT_CERT"])
+	require.Equal(t, "key", envMap["TEMPORAL_SSL_CLIENT_KEY"])
+	require.Equal(t, "true", envMap["TEMPORAL_INIT_SEARCH_ATTRIBUTES"])
+	require.Equal(t, "8", envMap["TEMPORAL_MAX_CONCURRENT_WORKFLOW_TASK_POLLERS"])
+	require.Equal(t, "9", envMap["TEMPORAL_MAX_CONCURRENT_ACTIVITY_TASK_POLLERS"])
+	require.Equal(t, "12", envMap["TEMPORAL_MAX_SLOTS_PER_POLLER"])
+	require.Equal(t, "34", envMap["TEMPORAL_MAX_LOCAL_ACTIVITY_SLOTS"])
+}
+
+func TestTemporalEnvVarsWithReferencedSecretWaitsForResourceReference(t *testing.T) {
+	t.Parallel()
+
+	stack := &v1beta1.Stack{ObjectMeta: testutil.ObjectMeta("stack0")}
+	payments := &v1beta1.Payments{
+		ObjectMeta: testutil.ObjectMeta("payments0"),
+		Spec: v1beta1.PaymentsSpec{
+			StackDependency: v1beta1.StackDependency{Stack: "stack0"},
+		},
+	}
+	ctx := testutil.NewContext(
+		settingspkg.New("temporal-dsn", "temporal.dsn", "temporal://temporal.stack0:7233/payments?secret=temporal-tls", "stack0"),
+	)
+
+	_, _, err := temporalEnvVars(ctx, stack, payments)
+	require.True(t, core.IsApplicationError(err))
+}
+
+func TestTemporalEnvVarsWithReadyReferencedSecrets(t *testing.T) {
+	t.Parallel()
+
+	stack := &v1beta1.Stack{ObjectMeta: testutil.ObjectMeta("stack0")}
+	payments := &v1beta1.Payments{
+		TypeMeta:   metav1.TypeMeta{APIVersion: "formance.com/v1beta1", Kind: "Payments"},
+		ObjectMeta: testutil.ObjectMeta("payments0"),
+		Spec: v1beta1.PaymentsSpec{
+			StackDependency: v1beta1.StackDependency{Stack: "stack0"},
+		},
+	}
+	tlsRef := readyResourceReference("payments0-payments-temporal", "tls-hash")
+	encryptionRef := readyResourceReference("payments0-payments-temporal-encryption-key", "encryption-hash")
+	ctx := testutil.NewContext(
+		payments,
+		tlsRef,
+		encryptionRef,
+		settingspkg.New("temporal-dsn", "temporal.dsn", "temporal://temporal.stack0:7233/payments?secret=temporal-tls&encryptionKeySecret=temporal-encryption", "stack0"),
+	)
+
+	hash, env, err := temporalEnvVars(ctx, stack, payments)
+	require.NoError(t, err)
+	require.Equal(t, map[string]string{
+		"payments0-payments-temporal":                "tls-hash",
+		"payments0-payments-temporal-encryption-key": "encryption-hash",
+	}, hash)
+
+	envByName := envVarsByName(env)
+	require.Equal(t, "temporal.stack0:7233", envByName["TEMPORAL_ADDRESS"].Value)
+	require.Equal(t, "payments", envByName["TEMPORAL_NAMESPACE"].Value)
+	requireSecretEnv(t, envByName["TEMPORAL_SSL_CLIENT_KEY"], "temporal-tls", "tls.key")
+	requireSecretEnv(t, envByName["TEMPORAL_SSL_CLIENT_CERT"], "temporal-tls", "tls.crt")
+	require.Equal(t, "true", envByName["TEMPORAL_ENCRYPTION_ENABLED"].Value)
+	requireSecretEnv(t, envByName["TEMPORAL_ENCRYPTION_KEY"], "temporal-encryption", "key")
+}
+
+func TestTemporalEnvVarsUsesWorkerDefaultsAndRejectsInvalidWorkerSettings(t *testing.T) {
+	t.Parallel()
+
+	stack := &v1beta1.Stack{ObjectMeta: testutil.ObjectMeta("stack0")}
+	payments := &v1beta1.Payments{
+		ObjectMeta: testutil.ObjectMeta("payments0"),
+		Spec: v1beta1.PaymentsSpec{
+			StackDependency: v1beta1.StackDependency{Stack: "stack0"},
+		},
+	}
+	ctx := testutil.NewContext(
+		settingspkg.New("temporal-dsn", "temporal.dsn", "temporal://temporal.stack0:7233/payments", "stack0"),
+	)
+
+	_, env, err := temporalEnvVars(ctx, stack, payments)
+	require.NoError(t, err)
+	envMap := testutil.EnvMap(env)
+	require.Equal(t, "4", envMap["TEMPORAL_MAX_CONCURRENT_WORKFLOW_TASK_POLLERS"])
+	require.Equal(t, "4", envMap["TEMPORAL_MAX_CONCURRENT_ACTIVITY_TASK_POLLERS"])
+	require.Equal(t, "10", envMap["TEMPORAL_MAX_SLOTS_PER_POLLER"])
+	require.Equal(t, "50", envMap["TEMPORAL_MAX_LOCAL_ACTIVITY_SLOTS"])
+
+	invalidSettings := []string{
+		"payments.worker.temporal-max-concurrent-workflow-task-pollers",
+		"payments.worker.temporal-max-concurrent-activity-task-pollers",
+		"payments.worker.temporal-max-slots-per-poller",
+		"payments.worker.temporal-max-local-activity-slots",
+	}
+	for _, key := range invalidSettings {
+		t.Run(key, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := testutil.NewContext(
+				settingspkg.New("temporal-dsn", "temporal.dsn", "temporal://temporal.stack0:7233/payments", "stack0"),
+				settingspkg.New("invalid-worker-setting", key, "not-an-int", "stack0"),
+			)
+			_, _, err := temporalEnvVars(ctx, stack, payments)
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestCommonEnvVarsBuildsPostgresAndModuleEnv(t *testing.T) {
+	t.Parallel()
+
+	stack := &v1beta1.Stack{ObjectMeta: testutil.ObjectMeta("stack0")}
+	payments := &v1beta1.Payments{
+		ObjectMeta: testutil.ObjectMeta("payments0"),
+		Spec: v1beta1.PaymentsSpec{
+			StackDependency: v1beta1.StackDependency{Stack: "stack0"},
+			ModuleProperties: v1beta1.ModuleProperties{
+				DevProperties: v1beta1.DevProperties{Debug: true, Dev: true},
+			},
+		},
+	}
+	database := &v1beta1.Database{
+		Spec: v1beta1.DatabaseSpec{
+			StackDependency: v1beta1.StackDependency{Stack: "stack0"},
+			Service:         "payments",
+		},
+		Status: v1beta1.DatabaseStatus{
+			URI:      testutil.MustParseURI("postgresql://user:p%40ss@postgres.stack0:5432/payments?sslmode=disable"),
+			Database: "payments",
+		},
+	}
+	ctx := testutil.NewContext(
+		settingspkg.New("encryption-key", "payments.encryption-key", "secret-key", "stack0"),
+		settingspkg.New("connection-pool", "modules.payments.database.connection-pool", "max-idle=3,max-lifetime=10m", "stack0"),
+	)
+
+	env, err := commonEnvVars(ctx, stack, payments, database)
+	require.NoError(t, err)
+
+	envMap := testutil.EnvMap(env)
+	require.Equal(t, "postgres.stack0", envMap["POSTGRES_HOST"])
+	require.Equal(t, "5432", envMap["POSTGRES_PORT"])
+	require.Equal(t, "payments", envMap["POSTGRES_DATABASE"])
+	require.Equal(t, "secret-key", envMap["CONFIG_ENCRYPTION_KEY"])
+	require.Equal(t, "true", envMap["DEBUG"])
+	require.Equal(t, "true", envMap["DEV"])
+	require.Equal(t, "3", envMap["POSTGRES_MAX_IDLE_CONNS"])
+	require.Equal(t, "10m", envMap["POSTGRES_CONN_MAX_LIFETIME"])
+}
+
+func TestCreateV2ReadDeployment(t *testing.T) {
+	t.Parallel()
+
+	stack, payments, database := paymentsFixtures()
+	image := &registries.ImageConfiguration{
+		Registry: "ghcr.io",
+		Image:    "formancehq/payments",
+		Version:  "v2.0.0",
+	}
+	ctx := testutil.NewContext(
+		payments,
+		settingspkg.New("encryption-key", "payments.encryption-key", "secret-key", "stack0"),
+	)
+
+	require.NoError(t, createV2ReadDeployment(ctx, stack, payments, database, image))
+
+	deployment := &appsv1.Deployment{}
+	require.NoError(t, ctx.GetClient().Get(ctx, types.NamespacedName{Name: "payments-read", Namespace: "stack0"}, deployment))
+	require.Len(t, deployment.Spec.Template.Spec.Containers, 1)
+
+	container := deployment.Spec.Template.Spec.Containers[0]
+	envMap := testutil.EnvMap(container.Env)
+	require.Equal(t, "api", container.Name)
+	require.Equal(t, []string{"api", "serve"}, container.Args)
+	require.Equal(t, "ghcr.io/formancehq/payments:v2.0.0", container.Image)
+	require.Equal(t, "secret-key", envMap["CONFIG_ENCRYPTION_KEY"])
+	require.Equal(t, "$(POSTGRES_DATABASE)", envMap["POSTGRES_DATABASE_NAME"])
+	require.NotNil(t, container.LivenessProbe)
+
+	service := &corev1.Service{}
+	require.NoError(t, ctx.GetClient().Get(ctx, types.NamespacedName{Name: "payments-read", Namespace: "stack0"}, service))
+	require.Equal(t, int32(8080), service.Spec.Ports[0].Port)
+	require.Equal(t, "payments-read", service.Labels["app.kubernetes.io/service-name"])
+}
+
+func TestCreateV2ConnectorsDeploymentAppliesBrokerAndServiceSettings(t *testing.T) {
+	t.Parallel()
+
+	stack, payments, database := paymentsFixtures()
+	image := &registries.ImageConfiguration{
+		Registry: "ghcr.io",
+		Image:    "formancehq/payments",
+		Version:  "v2.0.0",
+	}
+	topic := &v1beta1.BrokerTopic{
+		ObjectMeta: testutil.ObjectMeta("payments-topic"),
+		Spec: v1beta1.BrokerTopicSpec{
+			StackDependency: v1beta1.StackDependency{Stack: "stack0"},
+			Service:         "payments",
+		},
+		Status: v1beta1.BrokerTopicStatus{Status: v1beta1.Status{Ready: true}},
+	}
+	broker := &v1beta1.Broker{
+		ObjectMeta: testutil.ObjectMeta("stack0"),
+		Spec: v1beta1.BrokerSpec{
+			StackDependency: v1beta1.StackDependency{Stack: "stack0"},
+		},
+		Status: v1beta1.BrokerStatus{
+			Status: v1beta1.Status{Ready: true},
+			URI:    testutil.MustParseURI("nats://nats.stack0:4222?circuitBreakerEnabled=true&circuitBreakerOpenInterval=5s"),
+			Mode:   v1beta1.ModeOneStreamByStack,
+		},
+	}
+	ctx := newPaymentsContextWithBrokerTopicIndexes(
+		payments,
+		topic,
+		broker,
+		settingspkg.New("encryption-key", "payments.encryption-key", "secret-key", "stack0"),
+		settingspkg.New("aws-sa", "aws.service-account", "payments-connectors-aws", "stack0"),
+		settingspkg.New("service-annotations", "services.payments-connectors.annotations", "owner=payments", "stack0"),
+		settingspkg.New("service-traffic", "services.payments-connectors.traffic-distribution", "PreferClose", "stack0"),
+	)
+
+	require.NoError(t, createV2ConnectorsDeployment(ctx, stack, payments, database, image))
+
+	deployment := &appsv1.Deployment{}
+	require.NoError(t, ctx.GetClient().Get(ctx, types.NamespacedName{Name: "payments-connectors", Namespace: "stack0"}, deployment))
+	require.Equal(t, appsv1.RecreateDeploymentStrategyType, deployment.Spec.Strategy.Type)
+	require.Equal(t, "payments-connectors-aws", deployment.Spec.Template.Spec.ServiceAccountName)
+	require.Len(t, deployment.Spec.Template.Spec.Containers, 1)
+	container := deployment.Spec.Template.Spec.Containers[0]
+	require.Equal(t, "connectors", container.Name)
+	require.Equal(t, []string{"connectors", "serve"}, container.Args)
+	envMap := testutil.EnvMap(container.Env)
+	require.Equal(t, "secret-key", envMap["CONFIG_ENCRYPTION_KEY"])
+	require.Equal(t, "nats", envMap["BROKER"])
+	require.Equal(t, "true", envMap["PUBLISHER_NATS_ENABLED"])
+	require.Equal(t, "nats.stack0:4222", envMap["PUBLISHER_NATS_URL"])
+	require.Equal(t, "stack0-payments", envMap["PUBLISHER_NATS_CLIENT_ID"])
+	require.Equal(t, "*:stack0.payments", envMap["PUBLISHER_TOPIC_MAPPING"])
+	require.Equal(t, "false", envMap["PUBLISHER_NATS_AUTO_PROVISION"])
+	require.Equal(t, "true", envMap["PUBLISHER_CIRCUIT_BREAKER_ENABLED"])
+	require.Equal(t, "5s", envMap["PUBLISHER_CIRCUIT_BREAKER_OPEN_INTERVAL_DURATION"])
+
+	service := &corev1.Service{}
+	require.NoError(t, ctx.GetClient().Get(ctx, types.NamespacedName{Name: "payments-connectors", Namespace: "stack0"}, service))
+	require.Equal(t, "payments", service.Annotations["owner"])
+	require.NotNil(t, service.Spec.TrafficDistribution)
+	require.Equal(t, "PreferClose", *service.Spec.TrafficDistribution)
+}
+
+func TestCreateGateway(t *testing.T) {
+	t.Parallel()
+
+	stack, payments, _ := paymentsFixtures()
+	ctx := testutil.NewContext(
+		payments,
+		settingspkg.New("caddy-image", "caddy.image", "caddy:2.7.6-alpine", "stack0"),
+	)
+
+	require.NoError(t, createGateway(ctx, stack, payments))
+
+	configMap := &corev1.ConfigMap{}
+	require.NoError(t, ctx.GetClient().Get(ctx, types.NamespacedName{Name: "payments", Namespace: "stack0"}, configMap))
+	require.Contains(t, configMap.Data["Caddyfile"], ":8080")
+
+	deployment := &appsv1.Deployment{}
+	require.NoError(t, ctx.GetClient().Get(ctx, types.NamespacedName{Name: "payments", Namespace: "stack0"}, deployment))
+	require.Len(t, deployment.Spec.Template.Spec.Containers, 1)
+	require.Empty(t, deployment.Spec.Template.Spec.InitContainers)
+	require.Equal(t, "gateway", deployment.Spec.Template.Spec.Containers[0].Name)
+	require.Equal(t, "docker.io/caddy:2.7.6-alpine", deployment.Spec.Template.Spec.Containers[0].Image)
+	require.Equal(t, "payments", deployment.Spec.Template.Labels["app.kubernetes.io/name"])
+}
+
+func TestCreateV3DeploymentAppliesTemporalAndAWSSettings(t *testing.T) {
+	t.Parallel()
+
+	stack, payments, database := paymentsFixtures()
+	image := &registries.ImageConfiguration{
+		Registry: "ghcr.io",
+		Image:    "formancehq/payments",
+		Version:  "v3.0.0",
+	}
+	ctx := newPaymentsContextWithBrokerTopicIndexes(
+		payments,
+		settingspkg.New("temporal-dsn", "temporal.dsn", "temporal://temporal.stack0:7233/payments?initSearchAttributes=true", "stack0"),
+		settingspkg.New("aws-sa", "aws.service-account", "payments-aws", "stack0"),
+		settingspkg.New("workflow-pollers", "payments.worker.temporal-max-concurrent-workflow-task-pollers", "6", "stack0"),
+		settingspkg.New("deployment-env", "deployments.payments-worker.containers.payments-worker.env-vars", "FROM_DEPLOYMENT_SETTINGS=true", "stack0"),
+	)
+
+	require.NoError(t, createV3Deployment(ctx, stack, payments, database, image, DeploymentTypeWorker))
+
+	deployment := &appsv1.Deployment{}
+	require.NoError(t, ctx.GetClient().Get(ctx, types.NamespacedName{Name: "payments-worker", Namespace: "stack0"}, deployment))
+	require.Equal(t, "payments-aws", deployment.Spec.Template.Spec.ServiceAccountName)
+	require.Len(t, deployment.Spec.Template.Spec.Containers, 1)
+	container := deployment.Spec.Template.Spec.Containers[0]
+	require.Equal(t, "payments-worker", container.Name)
+	require.Equal(t, []string{"worker"}, container.Args)
+	envMap := testutil.EnvMap(container.Env)
+	require.Equal(t, "temporal.stack0:7233", envMap["TEMPORAL_ADDRESS"])
+	require.Equal(t, "payments", envMap["TEMPORAL_NAMESPACE"])
+	require.Equal(t, "true", envMap["TEMPORAL_INIT_SEARCH_ATTRIBUTES"])
+	require.Equal(t, "6", envMap["TEMPORAL_MAX_CONCURRENT_WORKFLOW_TASK_POLLERS"])
+	require.Equal(t, "true", envMap["FROM_DEPLOYMENT_SETTINGS"])
+}
+
+func TestValidateTemporalURI(t *testing.T) {
+	t.Parallel()
+
+	require.NoError(t, validateTemporalURI(testutil.MustParseURI("temporal://temporal.stack0:7233/payments")))
+	require.Error(t, validateTemporalURI(testutil.MustParseURI("http://temporal.stack0:7233/payments")))
+	require.Error(t, validateTemporalURI(testutil.MustParseURI("temporal://temporal.stack0:7233")))
+}
+
+func readyResourceReference(name, hash string) *v1beta1.ResourceReference {
+	return &v1beta1.ResourceReference{
+		TypeMeta:   metav1.TypeMeta{APIVersion: "formance.com/v1beta1", Kind: "ResourceReference"},
+		ObjectMeta: testutil.ObjectMeta(name),
+		Status: v1beta1.ResourceReferenceStatus{
+			Status: v1beta1.Status{Ready: true},
+			Hash:   hash,
+		},
+	}
+}
+
+func envVarsByName(env []corev1.EnvVar) map[string]corev1.EnvVar {
+	ret := make(map[string]corev1.EnvVar, len(env))
+	for _, item := range env {
+		ret[item.Name] = item
+	}
+	return ret
+}
+
+func requireSecretEnv(t *testing.T, env corev1.EnvVar, secretName, key string) {
+	t.Helper()
+
+	require.NotNil(t, env.ValueFrom)
+	require.NotNil(t, env.ValueFrom.SecretKeyRef)
+	require.Equal(t, secretName, env.ValueFrom.SecretKeyRef.Name)
+	require.Equal(t, key, env.ValueFrom.SecretKeyRef.Key)
+}
+
+func newPaymentsContextWithBrokerTopicIndexes(objects ...client.Object) *testutil.Context {
+	scheme := testutil.NewScheme()
+	builder := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(objects...)
+
+	builder.WithIndex(&v1beta1.Settings{}, "stack", func(obj client.Object) []string {
+		return obj.(*v1beta1.Settings).GetStacks()
+	})
+	builder.WithIndex(&v1beta1.Settings{}, "keylen", func(obj client.Object) []string {
+		keyParts := settingspkg.SplitKeywordWithDot(obj.(*v1beta1.Settings).Spec.Key)
+		return []string{fmt.Sprintf("%d", len(keyParts))}
+	})
+	builder.WithIndex(&v1beta1.BrokerTopic{}, "stack", func(obj client.Object) []string {
+		topic := obj.(*v1beta1.BrokerTopic)
+		if topic.Spec.Stack == "" {
+			return nil
+		}
+		return []string{topic.Spec.Stack}
+	})
+	builder.WithIndex(&v1beta1.BrokerTopic{}, ".spec.service", func(obj client.Object) []string {
+		topic := obj.(*v1beta1.BrokerTopic)
+		if topic.Spec.Service == "" {
+			return nil
+		}
+		return []string{topic.Spec.Service}
+	})
+	withPaymentsUnstructuredStackIndex(builder, "Auth")
+	withPaymentsUnstructuredStackIndex(builder, "Gateway")
+
+	return &testutil.Context{
+		Context: context.Background(),
+		Client:  builder.Build(),
+		Scheme:  scheme,
+	}
+}
+
+func withPaymentsUnstructuredStackIndex(builder *fake.ClientBuilder, kind string) {
+	object := &unstructured.Unstructured{}
+	object.SetAPIVersion("formance.com/v1beta1")
+	object.SetKind(kind)
+	builder.WithIndex(object, "stack", func(obj client.Object) []string {
+		u, ok := obj.(*unstructured.Unstructured)
+		if !ok {
+			return nil
+		}
+		spec, ok := u.Object["spec"].(map[string]any)
+		if !ok {
+			return nil
+		}
+		stack, ok := spec["stack"].(string)
+		if !ok || stack == "" {
+			return nil
+		}
+		return []string{stack}
+	})
+}
+
+func paymentsFixtures() (*v1beta1.Stack, *v1beta1.Payments, *v1beta1.Database) {
+	stack := &v1beta1.Stack{ObjectMeta: testutil.ObjectMeta("stack0")}
+	payments := &v1beta1.Payments{
+		ObjectMeta: testutil.ObjectMeta("payments0"),
+		Spec: v1beta1.PaymentsSpec{
+			StackDependency: v1beta1.StackDependency{Stack: "stack0"},
+		},
+	}
+	database := &v1beta1.Database{
+		Spec: v1beta1.DatabaseSpec{
+			StackDependency: v1beta1.StackDependency{Stack: "stack0"},
+			Service:         "payments",
+		},
+		Status: v1beta1.DatabaseStatus{
+			URI:      testutil.MustParseURI("postgresql://payments:secret@postgres.stack0:5432/payments"),
+			Database: "payments",
+		},
+	}
+	return stack, payments, database
+}

--- a/internal/resources/payments/finalizer_settings_test.go
+++ b/internal/resources/payments/finalizer_settings_test.go
@@ -1,0 +1,44 @@
+package payments
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	batchv1 "k8s.io/api/batch/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/formancehq/operator/v3/api/formance.com/v1beta1"
+	settingspkg "github.com/formancehq/operator/v3/internal/resources/settings"
+	"github.com/formancehq/operator/v3/internal/testutil"
+)
+
+func TestCleanSkipsTemporalCleanupWhenSettingIsFalse(t *testing.T) {
+	t.Parallel()
+
+	stack := &v1beta1.Stack{
+		ObjectMeta: testutil.ObjectMeta("stack0"),
+		Spec:       v1beta1.StackSpec{Version: "v3.0.0"},
+	}
+	payments := &v1beta1.Payments{
+		TypeMeta: metav1.TypeMeta{APIVersion: "formance.com/v1beta1", Kind: "Payments"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "payments0",
+			UID:  types.UID("payments-uid"),
+		},
+		Spec: v1beta1.PaymentsSpec{
+			StackDependency: v1beta1.StackDependency{Stack: "stack0"},
+		},
+	}
+	ctx := testutil.NewContext(
+		stack,
+		payments,
+		settingspkg.New("clear-temporal", "payments.clear-temporal", "false", "stack0"),
+	)
+
+	require.NoError(t, Clean(ctx, payments))
+
+	job := &batchv1.Job{}
+	err := ctx.GetClient().Get(ctx, types.NamespacedName{Name: "payments-uid-clean-payments-temporal", Namespace: "stack0"}, job)
+	require.Error(t, err)
+}

--- a/internal/resources/registries/registries_test.go
+++ b/internal/resources/registries/registries_test.go
@@ -1,0 +1,76 @@
+package registries
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/formancehq/operator/v3/api/formance.com/v1beta1"
+	"github.com/formancehq/operator/v3/internal/resources/settings"
+	"github.com/formancehq/operator/v3/internal/testutil"
+)
+
+func TestImageConfigurationNames(t *testing.T) {
+	t.Parallel()
+
+	cfg := &ImageConfiguration{Registry: "registry.example.com", Image: "formance/payments", Version: "v1"}
+	require.Equal(t, "registry.example.com/formance/payments:v1", cfg.GetFullImageName())
+	require.Equal(t, "registry.example.com/formance/payments:v1", cfg.String())
+
+	cfg.Registry = ""
+	require.Equal(t, "formance/payments:v1", cfg.GetFullImageName())
+}
+
+func TestGetImageConfigurationAppliesSettings(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.NewContext(
+		settings.New("rewrite", `registries."ghcr.io".images.formancehq/payments.rewrite`, "mirror/payments", "stack0"),
+		settings.New("endpoint", `registries."ghcr.io".endpoint`, "mirror.example.com?pullSecret=registry-creds", "stack0"),
+	)
+
+	cfg, err := GetImageConfiguration(ctx, "stack0", "ghcr.io/formancehq/payments:v3.0.0")
+	require.NoError(t, err)
+	require.Equal(t, "mirror.example.com", cfg.Registry)
+	require.Equal(t, "mirror/payments", cfg.Image)
+	require.Equal(t, "v3.0.0", cfg.Version)
+	require.Len(t, cfg.PullSecrets, 1)
+	require.Equal(t, "registry-creds", cfg.PullSecrets[0].Name)
+}
+
+func TestGetImageConfigurationDefaultsAndErrors(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.NewContext()
+
+	cfg, err := GetImageConfiguration(ctx, "stack0", "payments:latest")
+	require.NoError(t, err)
+	require.Equal(t, "docker.io", cfg.Registry)
+	require.Equal(t, "payments", cfg.Image)
+
+	_, err = GetImageConfiguration(ctx, "stack0", "invalid")
+	require.Error(t, err)
+
+	ctx = testutil.NewContext(settings.New("endpoint", `registries."docker.io".endpoint`, "mirror.example.com?bad=value", "stack0"))
+	_, err = GetImageConfiguration(ctx, "stack0", "payments:latest")
+	require.Error(t, err)
+}
+
+func TestGetFormanceImages(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.NewContext()
+	stack := &v1beta1.Stack{ObjectMeta: testutil.ObjectMeta("stack0")}
+
+	cfg, err := GetFormanceImage(ctx, stack, "ledger", "")
+	require.NoError(t, err)
+	require.Equal(t, "ghcr.io/formancehq/ledger:latest", cfg.GetFullImageName())
+
+	cfg, err = GetBenthosImage(ctx, stack, "v1")
+	require.NoError(t, err)
+	require.Equal(t, "public.ecr.aws/formance-internal/jeffail/benthos:v1", cfg.GetFullImageName())
+
+	cfg, err = GetNatsBoxImage(ctx, stack, "v2")
+	require.NoError(t, err)
+	require.Equal(t, "docker.io/natsio/nats-box:v2", cfg.GetFullImageName())
+}

--- a/internal/resources/services/services_settings_test.go
+++ b/internal/resources/services/services_settings_test.go
@@ -1,0 +1,86 @@
+package services
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/formancehq/operator/v3/api/formance.com/v1beta1"
+	settingspkg "github.com/formancehq/operator/v3/internal/resources/settings"
+	"github.com/formancehq/operator/v3/internal/testutil"
+)
+
+func TestCreateAppliesServiceSettings(t *testing.T) {
+	t.Parallel()
+
+	owner := serviceSettingsOwner()
+	ctx := testutil.NewContext(
+		owner,
+		settingspkg.New("wildcard-annotations", "services.*.annotations", "team=platform,checksum=wildcard", "stack0"),
+		settingspkg.New("specific-annotations", "services.ledger.annotations", "checksum=specific", "stack0"),
+		settingspkg.New("traffic", "services.ledger.traffic-distribution", "PreferClose", "stack0"),
+	)
+
+	service, err := Create(ctx, owner, "ledger", WithDefault("ledger"))
+	require.NoError(t, err)
+
+	stored := &corev1.Service{}
+	require.NoError(t, ctx.GetClient().Get(ctx, types.NamespacedName{Name: "ledger", Namespace: "stack0"}, stored))
+	require.Equal(t, service.Name, stored.Name)
+
+	require.Equal(t, map[string]string{"app.kubernetes.io/service-name": "ledger"}, stored.Labels)
+	require.Equal(t, map[string]string{"app.kubernetes.io/name": "ledger"}, stored.Spec.Selector)
+	require.Len(t, stored.Spec.Ports, 1)
+	require.Equal(t, int32(8080), stored.Spec.Ports[0].Port)
+	require.Equal(t, "http", stored.Spec.Ports[0].TargetPort.String())
+
+	require.Equal(t, "specific", stored.Annotations["checksum"])
+	require.NotContains(t, stored.Annotations, "team")
+	require.NotNil(t, stored.Spec.TrafficDistribution)
+	require.Equal(t, "PreferClose", *stored.Spec.TrafficDistribution)
+	require.Len(t, stored.OwnerReferences, 1)
+	require.Equal(t, "Ledger", stored.OwnerReferences[0].Kind)
+}
+
+func TestCreateUsesWildcardServiceSettingsWhenNoSpecificSettingExists(t *testing.T) {
+	t.Parallel()
+
+	owner := serviceSettingsOwner()
+	ctx := testutil.NewContext(
+		owner,
+		settingspkg.New("wildcard-annotations", "services.*.annotations", "team=platform", "stack0"),
+	)
+
+	service, err := Create(ctx, owner, "ledger", WithDefault("ledger"))
+	require.NoError(t, err)
+	require.Equal(t, "platform", service.Annotations["team"])
+}
+
+func TestCreateReturnsInvalidServiceAnnotationSettingError(t *testing.T) {
+	t.Parallel()
+
+	owner := serviceSettingsOwner()
+	ctx := testutil.NewContext(
+		owner,
+		settingspkg.New("invalid-annotations", "services.ledger.annotations", `team="unterminated`, "stack0"),
+	)
+
+	_, err := Create(ctx, owner, "ledger", WithDefault("ledger"))
+	require.Error(t, err)
+}
+
+func serviceSettingsOwner() *v1beta1.Ledger {
+	return &v1beta1.Ledger{
+		TypeMeta: metav1.TypeMeta{APIVersion: "formance.com/v1beta1", Kind: "Ledger"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "ledger",
+			UID:  types.UID("ledger-uid"),
+		},
+		Spec: v1beta1.LedgerSpec{
+			StackDependency: v1beta1.StackDependency{Stack: "stack0"},
+		},
+	}
+}

--- a/internal/resources/settings/getters_test.go
+++ b/internal/resources/settings/getters_test.go
@@ -1,0 +1,160 @@
+package settings
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/formancehq/operator/v3/internal/testutil"
+)
+
+type typedSetting struct {
+	MaxIdle     string `json:"max-idle,omitempty"`
+	MaxLifetime string `json:"max-lifetime,omitempty"`
+}
+
+func TestGetTypedSettingsFromFakeClient(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.NewContext(
+		New("wildcard", "modules.*.database.connection-pool", "max-idle=5,max-lifetime=30m", "*"),
+		New("stack-specific", "modules.ledger.database.connection-pool", "max-idle=10,max-lifetime=1h", "stack0"),
+		New("slice", "ledger.experimental-numscript-flags", " a, b ,,c ", "stack0"),
+		New("env", "jobs.payments.containers.migrate.env-vars", `FOO=bar,QUOTED="a,b"`, "stack0"),
+		New("bool", "auth.payments.check-scopes", "true", "stack0"),
+		New("int", "payments.worker.temporal-max-slots-per-poller", "12", "stack0"),
+	)
+
+	value, err := GetStringOrEmpty(ctx, "stack0", "modules", "ledger", "database", "connection-pool")
+	require.NoError(t, err)
+	require.Equal(t, "max-idle=10,max-lifetime=1h", value)
+
+	value, err = GetStringOrEmpty(ctx, "stack1", "modules", "payments", "database", "connection-pool")
+	require.NoError(t, err)
+	require.Equal(t, "max-idle=5,max-lifetime=30m", value)
+
+	flags, err := GetTrimmedStringSlice(ctx, "stack0", "ledger", "experimental-numscript-flags")
+	require.NoError(t, err)
+	require.Equal(t, []string{"a", "b", "c"}, flags)
+
+	env, err := GetEnvVars(ctx, "stack0", "jobs", "payments", "containers", "migrate")
+	require.NoError(t, err)
+	require.Equal(t, map[string]string{"FOO": "bar", "QUOTED": "a,b"}, testutil.EnvMap(env))
+
+	checkScopes, err := GetBoolOrFalse(ctx, "stack0", "auth", "payments", "check-scopes")
+	require.NoError(t, err)
+	require.True(t, checkScopes)
+
+	slots, err := GetIntOrDefault(ctx, "stack0", 4, "payments", "worker", "temporal-max-slots-per-poller")
+	require.NoError(t, err)
+	require.Equal(t, 12, slots)
+
+	cfg, err := GetAs[typedSetting](ctx, "stack0", "modules", "ledger", "database", "connection-pool")
+	require.NoError(t, err)
+	require.Equal(t, &typedSetting{MaxIdle: "10", MaxLifetime: "1h"}, cfg)
+}
+
+func TestSettingsErrors(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.NewContext(
+		New("invalid-int", "payments.worker.count", "not-an-int", "stack0"),
+		New("invalid-map", "jobs.payments.env-vars", `BROKEN="unterminated`, "stack0"),
+	)
+
+	_, err := RequireString(ctx, "stack0", "missing", "setting")
+	require.Error(t, err)
+
+	_, err = GetInt(ctx, "stack0", "payments", "worker", "count")
+	require.Error(t, err)
+
+	_, err = GetMap(ctx, "stack0", "jobs", "payments", "env-vars")
+	require.Error(t, err)
+}
+
+func TestNumericURLAndBoolGetters(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.NewContext(
+		New("int64", "numbers.int64", "922337203685477580", "stack0"),
+		New("int32", "numbers.int32", "214748364", "stack0"),
+		New("uint64", "numbers.uint64", "1844674407370955161", "stack0"),
+		New("uint16", "numbers.uint16", "65535", "stack0"),
+		New("uint", "numbers.uint", "42", "stack0"),
+		New("bool-true", "flags.enabled", "true", "stack0"),
+		New("bool-false", "flags.disabled", "false", "stack0"),
+		New("url", "temporal.dsn", "temporal://temporal.stack0:7233/payments", "stack0"),
+	)
+
+	int64Value, err := GetInt64(ctx, "stack0", "numbers", "int64")
+	require.NoError(t, err)
+	require.Equal(t, int64(922337203685477580), *int64Value)
+
+	int32Value, err := GetInt32(ctx, "stack0", "numbers", "int32")
+	require.NoError(t, err)
+	require.Equal(t, int32(214748364), *int32Value)
+
+	uint64Value, err := GetUInt64(ctx, "stack0", "numbers", "uint64")
+	require.NoError(t, err)
+	require.Equal(t, uint64(1844674407370955161), *uint64Value)
+
+	uint16Value, err := GetUInt16(ctx, "stack0", "numbers", "uint16")
+	require.NoError(t, err)
+	require.Equal(t, uint16(65535), *uint16Value)
+
+	uintValue, err := GetUInt(ctx, "stack0", "numbers", "uint")
+	require.NoError(t, err)
+	require.Equal(t, uint(42), *uintValue)
+
+	uint16Default, err := GetUInt16OrDefault(ctx, "stack0", 7, "missing", "uint16")
+	require.NoError(t, err)
+	require.Equal(t, uint16(7), uint16Default)
+
+	int32Default, err := GetInt32OrDefault(ctx, "stack0", 9, "missing", "int32")
+	require.NoError(t, err)
+	require.Equal(t, int32(9), int32Default)
+
+	enabled, err := GetBool(ctx, "stack0", "flags", "enabled")
+	require.NoError(t, err)
+	require.True(t, *enabled)
+
+	disabled, err := GetBool(ctx, "stack0", "flags", "disabled")
+	require.NoError(t, err)
+	require.False(t, *disabled)
+
+	enabledDefault, err := GetBoolOrDefault(ctx, "stack0", true, "missing", "flag")
+	require.NoError(t, err)
+	require.True(t, enabledDefault)
+
+	uri, err := GetURL(ctx, "stack0", "temporal", "dsn")
+	require.NoError(t, err)
+	require.Equal(t, "temporal", uri.Scheme)
+	require.Equal(t, "temporal.stack0:7233", uri.Host)
+	require.Equal(t, "/payments", uri.Path)
+
+	requiredURI, err := RequireURL(ctx, "stack0", "temporal", "dsn")
+	require.NoError(t, err)
+	require.Equal(t, uri.String(), requiredURI.String())
+}
+
+func TestGetterParsingErrors(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.NewContext(
+		New("invalid-int32", "numbers.int32", "999999999999999999999", "stack0"),
+		New("invalid-uint", "numbers.uint", "-1", "stack0"),
+		New("invalid-url", "temporal.dsn", "%", "stack0"),
+	)
+
+	_, err := GetInt32(ctx, "stack0", "numbers", "int32")
+	require.Error(t, err)
+
+	_, err = GetUInt(ctx, "stack0", "numbers", "uint")
+	require.Error(t, err)
+
+	_, err = GetURL(ctx, "stack0", "temporal", "dsn")
+	require.Error(t, err)
+
+	_, err = RequireURL(ctx, "stack0", "missing", "dsn")
+	require.Error(t, err)
+}

--- a/internal/resources/settings/helpers_test.go
+++ b/internal/resources/settings/helpers_test.go
@@ -271,3 +271,38 @@ func TestParseKeyValuePair(t *testing.T) {
 		"h": "i,j",
 	}, ret)
 }
+
+func TestParseKeyValueListErrors(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name  string
+		input string
+	}{
+		{
+			name:  "quotes in key",
+			input: `"bad"=value`,
+		},
+		{
+			name:  "unterminated quoted value",
+			input: `key="value`,
+		},
+		{
+			name:  "missing comma after quoted value",
+			input: `key="value"next=value`,
+		},
+		{
+			name:  "missing value separator",
+			input: `key`,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := parseKeyValueList(tc.input)
+			require.Error(t, err)
+		})
+	}
+}

--- a/internal/resources/settings/opentelemetry_test.go
+++ b/internal/resources/settings/opentelemetry_test.go
@@ -1,0 +1,90 @@
+package settings
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/formancehq/operator/v3/internal/testutil"
+)
+
+func TestGetOTELEnvVars(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.NewContext(
+		New("traces-dsn", "opentelemetry.traces.dsn", "grpc://otel-collector:4317?insecure=true", "stack0"),
+		New("traces-attrs", "opentelemetry.traces.resource-attributes", "service.namespace=formance,region=eu", "stack0"),
+		New("metrics-dsn", "opentelemetry.metrics.dsn", "http://otel-collector:4318/v1/metrics", "stack0"),
+	)
+
+	env, err := GetOTELEnvVars(ctx, "stack0", "payments", " ")
+	require.NoError(t, err)
+	envMap := testutil.EnvMap(env)
+
+	require.Equal(t, "true", envMap["OTEL_TRACES"])
+	require.Equal(t, "true", envMap["OTEL_TRACES_BATCH"])
+	require.Equal(t, "otlp", envMap["OTEL_TRACES_EXPORTER"])
+	require.Equal(t, "true", envMap["OTEL_TRACES_EXPORTER_OTLP_INSECURE"])
+	require.Equal(t, "4317", envMap["OTEL_TRACES_PORT"])
+	require.Equal(t, "otel-collector", envMap["OTEL_TRACES_ENDPOINT"])
+	require.Equal(t, "$(OTEL_TRACES_ENDPOINT):$(OTEL_TRACES_PORT)", envMap["OTEL_TRACES_EXPORTER_OTLP_ENDPOINT"])
+	require.Equal(t, "pod-name=$(POD_NAME) stack=stack0", envMap["OTEL_RESOURCE_ATTRIBUTES"])
+
+	require.Equal(t, "true", envMap["OTEL_METRICS"])
+	require.Equal(t, "true", envMap["OTEL_METRICS_RUNTIME"])
+	require.Equal(t, "http://otel-collector:4318/v1/metrics", envMap["OTEL_METRICS_EXPORTER_OTLP_ENDPOINT"])
+	require.Equal(t, "payments", envMap["OTEL_SERVICE_NAME"])
+
+	var podName corev1.EnvVar
+	for _, item := range env {
+		if item.Name == "POD_NAME" {
+			podName = item
+			break
+		}
+	}
+	require.Equal(t, "metadata.name", podName.ValueFrom.FieldRef.FieldPath)
+
+	tracesEnv, err := otelEnvVars(ctx, "stack0", MonitoringTypeTraces, "payments", " ")
+	require.NoError(t, err)
+	require.Equal(t, "pod-name=$(POD_NAME) region=eu service.namespace=formance stack=stack0", testutil.EnvMap(tracesEnv)["OTEL_RESOURCE_ATTRIBUTES"])
+}
+
+func TestHasOpenTelemetryTracesEnabled(t *testing.T) {
+	t.Parallel()
+
+	enabled, err := HasOpenTelemetryTracesEnabled(testutil.NewContext(), "stack0")
+	require.NoError(t, err)
+	require.False(t, enabled)
+
+	enabled, err = HasOpenTelemetryTracesEnabled(testutil.NewContext(
+		New("traces-dsn", "opentelemetry.traces.dsn", "grpc://otel-collector:4317", "stack0"),
+	), "stack0")
+	require.NoError(t, err)
+	require.True(t, enabled)
+}
+
+func TestGetResourceRequirements(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.NewContext(
+		New("limits", "jobs.payments.resources.limits", "cpu=500m,memory=256Mi", "stack0"),
+		New("requests", "jobs.payments.resources.requests", "cpu=250m,memory=128Mi", "stack0"),
+		New("claims", "jobs.payments.resources.claims", "cache,tmp", "stack0"),
+	)
+
+	requirements, err := GetResourceRequirements(ctx, "stack0", "jobs", "payments", "resources")
+	require.NoError(t, err)
+	require.Equal(t, "500m", requirements.Limits.Cpu().String())
+	require.Equal(t, "256Mi", requirements.Limits.Memory().String())
+	require.Equal(t, "250m", requirements.Requests.Cpu().String())
+	require.Equal(t, "128Mi", requirements.Requests.Memory().String())
+	require.Len(t, requirements.Claims, 2)
+	require.Equal(t, "cache", requirements.Claims[0].Name)
+	require.Equal(t, "tmp", requirements.Claims[1].Name)
+
+	_, err = GetResourceList(testutil.NewContext(
+		New("invalid", "jobs.payments.resources.limits", "cpu=not-a-quantity", "stack0"),
+	), "stack0", "jobs", "payments", "resources", "limits")
+	require.Error(t, err)
+}

--- a/internal/resources/stacks/init_test.go
+++ b/internal/resources/stacks/init_test.go
@@ -1,0 +1,107 @@
+package stacks
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/formancehq/operator/v3/api/formance.com/v1beta1"
+	"github.com/formancehq/operator/v3/internal/core"
+	"github.com/formancehq/operator/v3/internal/resources/settings"
+	"github.com/formancehq/operator/v3/internal/testutil"
+)
+
+func TestSetModulesConditionMarksReadyModules(t *testing.T) {
+	t.Parallel()
+
+	stack := &v1beta1.Stack{ObjectMeta: metav1.ObjectMeta{Name: "stack0", Generation: 7}}
+	ctx := testutil.NewContext(moduleObject("Auth", "auth0", "stack0", metav1.ConditionTrue, "Spec", 7))
+
+	require.NoError(t, setModulesCondition(ctx, stack))
+	require.Equal(t, []string{"Auth"}, stack.Status.Modules)
+	condition := stack.GetConditions().Get(ModuleReconciliation)
+	require.NotNil(t, condition)
+	require.Equal(t, "Auth", condition.Reason)
+	require.Equal(t, metav1.ConditionTrue, condition.Status)
+	require.Equal(t, "All checks passed", condition.Message)
+	require.Equal(t, int64(7), condition.ObservedGeneration)
+}
+
+func TestSetModulesConditionDetectsPendingModule(t *testing.T) {
+	t.Parallel()
+
+	stack := &v1beta1.Stack{ObjectMeta: metav1.ObjectMeta{Name: "stack0", Generation: 7}}
+	ctx := testutil.NewContext(moduleObject("Auth", "auth0", "stack0", metav1.ConditionFalse, "Spec", 7))
+
+	err := setModulesCondition(ctx, stack)
+	require.True(t, core.IsApplicationError(err))
+	require.Contains(t, err.Error(), "Pending modules")
+	condition := stack.GetConditions().Get(ModuleReconciliation)
+	require.NotNil(t, condition)
+	require.Equal(t, "Auth", condition.Reason)
+	require.Equal(t, metav1.ConditionFalse, condition.Status)
+	require.Equal(t, "Module not declared as reconciled for stack", condition.Message)
+}
+
+func TestSetModulesConditionDetectsSkipMismatch(t *testing.T) {
+	t.Parallel()
+
+	stack := &v1beta1.Stack{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "stack0",
+			Generation: 7,
+			Annotations: map[string]string{
+				v1beta1.SkipLabel: "true",
+			},
+		},
+	}
+	ctx := testutil.NewContext(moduleObject("Auth", "auth0", "stack0", metav1.ConditionTrue, "Spec", 7))
+
+	err := setModulesCondition(ctx, stack)
+	require.True(t, core.IsApplicationError(err))
+	condition := stack.GetConditions().Get(ModuleReconciliation)
+	require.NotNil(t, condition)
+	require.Equal(t, metav1.ConditionFalse, condition.Status)
+	require.Equal(t, "Module should be skipped but is not", condition.Message)
+}
+
+func TestNamespaceMutators(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.NewContext(
+		settings.New("labels", "namespace.labels", "team=core,env=dev", "stack0"),
+		settings.New("annotations", "namespace.annotations", "owner=platform", "stack0"),
+	)
+	ns := &corev1.Namespace{}
+
+	require.NoError(t, namespaceLabel(ctx, "stack0")(ns))
+	require.NoError(t, namespaceAnnotations(ctx, "stack0")(ns))
+	require.Equal(t, map[string]string{"team": "core", "env": "dev"}, ns.Labels)
+	require.Equal(t, map[string]string{"owner": "platform"}, ns.Annotations)
+}
+
+func moduleObject(kind, name, stack string, status metav1.ConditionStatus, reason string, observedGeneration int64) *unstructured.Unstructured {
+	return &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "formance.com/v1beta1",
+		"kind":       kind,
+		"metadata": map[string]any{
+			"name": name,
+		},
+		"spec": map[string]any{
+			"stack": stack,
+		},
+		"status": map[string]any{
+			"conditions": []any{
+				map[string]any{
+					"type":               "ReconciledWithStack",
+					"status":             string(status),
+					"reason":             reason,
+					"observedGeneration": observedGeneration,
+				},
+			},
+		},
+	}}
+}

--- a/internal/resources/webhooks/deployment_test.go
+++ b/internal/resources/webhooks/deployment_test.go
@@ -1,0 +1,119 @@
+package webhooks
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/formancehq/operator/v3/api/formance.com/v1beta1"
+	settingspkg "github.com/formancehq/operator/v3/internal/resources/settings"
+	"github.com/formancehq/operator/v3/internal/testutil"
+)
+
+func TestDeploymentEnvVars(t *testing.T) {
+	t.Parallel()
+
+	stack, webhooks, database := webhooksFixtures()
+	ctx := testutil.NewContext(
+		settingspkg.New("broker-dsn", "broker.dsn", "nats://nats.stack0:4222?replicas=3", "stack0"),
+		settingspkg.New("pool", "modules.webhooks.database.connection-pool", "max-idle=5", "stack0"),
+	)
+
+	env, err := deploymentEnvVars(ctx, stack, webhooks, database)
+	require.NoError(t, err)
+
+	envMap := testutil.EnvMap(env)
+	require.Equal(t, "postgres.stack0", envMap["POSTGRES_HOST"])
+	require.Equal(t, "webhooks", envMap["POSTGRES_DATABASE"])
+	require.Equal(t, "$(POSTGRES_URI)", envMap["STORAGE_POSTGRES_CONN_STRING"])
+	require.Equal(t, "nats.stack0:4222", envMap["PUBLISHER_NATS_URL"])
+	require.Equal(t, "stack0-webhooks", envMap["PUBLISHER_NATS_CLIENT_ID"])
+	require.Equal(t, "5", envMap["POSTGRES_MAX_IDLE_CONNS"])
+	require.Equal(t, "true", envMap["DEBUG"])
+	require.Equal(t, "true", envMap["DEV"])
+}
+
+func TestDeploymentEnvVarsRequiresBrokerDSN(t *testing.T) {
+	t.Parallel()
+
+	stack, webhooks, database := webhooksFixtures()
+	_, err := deploymentEnvVars(testutil.NewContext(), stack, webhooks, database)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "settings 'broker.dsn' not found")
+}
+
+func TestCreateSingleDeployment(t *testing.T) {
+	t.Parallel()
+
+	stack, webhooks, database := webhooksFixtures()
+	consumer := &v1beta1.BrokerConsumer{
+		ObjectMeta: testutil.ObjectMeta("webhooks"),
+		Spec: v1beta1.BrokerConsumerSpec{
+			StackDependency: v1beta1.StackDependency{Stack: "stack0"},
+			Services:        []string{"ledger", "payments"},
+		},
+		Status: v1beta1.BrokerConsumerStatus{Status: v1beta1.Status{Ready: true}},
+	}
+	broker := &v1beta1.Broker{
+		ObjectMeta: testutil.ObjectMeta("stack0"),
+		Spec:       v1beta1.BrokerSpec{StackDependency: v1beta1.StackDependency{Stack: "stack0"}},
+		Status: v1beta1.BrokerStatus{
+			Status: v1beta1.Status{Ready: true},
+			Mode:   v1beta1.ModeOneStreamByStack,
+			URI:    testutil.MustParseURI("nats://nats.stack0:4222"),
+		},
+	}
+	ctx := testutil.NewContext(
+		webhooks,
+		broker,
+		settingspkg.New("broker-dsn", "broker.dsn", "nats://nats.stack0:4222", "stack0"),
+	)
+
+	require.NoError(t, createSingleDeployment(ctx, stack, webhooks, database, consumer, "v2.0.0-rc.4"))
+
+	deployment := &appsv1.Deployment{}
+	require.NoError(t, ctx.GetClient().Get(ctx, types.NamespacedName{Name: "webhooks", Namespace: "stack0"}, deployment))
+	require.Len(t, deployment.Spec.Template.Spec.Containers, 1)
+
+	container := deployment.Spec.Template.Spec.Containers[0]
+	envMap := testutil.EnvMap(container.Env)
+	require.Equal(t, "api", container.Name)
+	require.Equal(t, "ghcr.io/formancehq/webhooks:v2.0.0-rc.4", container.Image)
+	require.Equal(t, []string{"serve", "--auto-migrate"}, container.Args)
+	require.Equal(t, "true", envMap["WORKER"])
+	require.Equal(t, "stack0.ledger stack0.payments", envMap["KAFKA_TOPICS"])
+	require.Equal(t, "false", envMap["PUBLISHER_NATS_AUTO_PROVISION"])
+	require.NotNil(t, container.LivenessProbe)
+	require.NotNil(t, container.ReadinessProbe)
+	require.Equal(t, "webhooks", deployment.Spec.Template.Labels["app.kubernetes.io/name"])
+}
+
+func webhooksFixtures() (*v1beta1.Stack, *v1beta1.Webhooks, *v1beta1.Database) {
+	stack := &v1beta1.Stack{
+		ObjectMeta: metav1.ObjectMeta{Name: "stack0"},
+		Spec:       v1beta1.StackSpec{DevProperties: v1beta1.DevProperties{Debug: true}},
+	}
+	webhooks := &v1beta1.Webhooks{
+		ObjectMeta: testutil.ObjectMeta("webhooks"),
+		Spec: v1beta1.WebhooksSpec{
+			StackDependency: v1beta1.StackDependency{Stack: "stack0"},
+			ModuleProperties: v1beta1.ModuleProperties{
+				DevProperties: v1beta1.DevProperties{Dev: true},
+			},
+		},
+	}
+	database := &v1beta1.Database{
+		Spec: v1beta1.DatabaseSpec{
+			StackDependency: v1beta1.StackDependency{Stack: "stack0"},
+			Service:         "webhooks",
+		},
+		Status: v1beta1.DatabaseStatus{
+			URI:      testutil.MustParseURI("postgresql://webhooks:secret@postgres.stack0:5432/webhooks"),
+			Database: "webhooks",
+		},
+	}
+	return stack, webhooks, database
+}

--- a/internal/testutil/context.go
+++ b/internal/testutil/context.go
@@ -120,19 +120,6 @@ func must(err error) {
 	}
 }
 
-type stackGetter interface {
-	GetStack() string
-}
-
-func withStackIndex(builder *fake.ClientBuilder, object client.Object) {
-	builder.WithIndex(object, "stack", func(obj client.Object) []string {
-		if dep, ok := obj.(stackGetter); ok && dep.GetStack() != "" {
-			return []string{dep.GetStack()}
-		}
-		return nil
-	})
-}
-
 func withUnstructuredStackIndex(builder *fake.ClientBuilder, kind string) {
 	object := &unstructured.Unstructured{}
 	object.SetAPIVersion("formance.com/v1beta1")

--- a/internal/testutil/context.go
+++ b/internal/testutil/context.go
@@ -1,0 +1,223 @@
+package testutil
+
+import (
+	"context"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/go-logr/logr"
+	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	policyv1 "k8s.io/api/policy/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/config"
+	"sigs.k8s.io/controller-runtime/pkg/healthz"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+	externaldnsv1alpha1 "sigs.k8s.io/external-dns/apis/v1alpha1"
+
+	"github.com/formancehq/operator/v3/api/formance.com/v1beta1"
+	"github.com/formancehq/operator/v3/internal/core"
+)
+
+type Context struct {
+	context.Context
+	Client   client.Client
+	Scheme   *runtime.Scheme
+	Platform core.Platform
+}
+
+func (c *Context) GetClient() client.Client {
+	return c.Client
+}
+
+func (c *Context) GetScheme() *runtime.Scheme {
+	return c.Scheme
+}
+
+func (c *Context) GetAPIReader() client.Reader {
+	return c.Client
+}
+
+func (c *Context) GetPlatform() core.Platform {
+	return c.Platform
+}
+
+func NewScheme() *runtime.Scheme {
+	scheme := runtime.NewScheme()
+	must(corev1.AddToScheme(scheme))
+	must(appsv1.AddToScheme(scheme))
+	must(batchv1.AddToScheme(scheme))
+	must(networkingv1.AddToScheme(scheme))
+	must(policyv1.AddToScheme(scheme))
+	must(externaldnsv1alpha1.AddToScheme(scheme))
+	must(v1beta1.AddToScheme(scheme))
+	return scheme
+}
+
+func NewContext(objects ...client.Object) *Context {
+	scheme := NewScheme()
+	builder := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(objects...)
+
+	withUnstructuredStackIndex(builder, "Auth")
+	withUnstructuredStackIndex(builder, "Gateway")
+	withUnstructuredStackIndex(builder, "Ledger")
+	withUnstructuredStackIndex(builder, "Orchestration")
+	withUnstructuredStackIndex(builder, "Payments")
+	withUnstructuredStackIndex(builder, "Reconciliation")
+	withUnstructuredStackIndex(builder, "Search")
+	withUnstructuredStackIndex(builder, "Stargate")
+	withUnstructuredStackIndex(builder, "TransactionPlane")
+	withUnstructuredStackIndex(builder, "Wallets")
+	withUnstructuredStackIndex(builder, "Webhooks")
+	withUnstructuredStackIndex(builder, "Database")
+	withUnstructuredStackIndex(builder, "Broker")
+	withUnstructuredStackIndex(builder, "BrokerTopic")
+	withSettingsIndexes(builder)
+
+	return &Context{
+		Context: context.Background(),
+		Client:  builder.Build(),
+		Scheme:  scheme,
+	}
+}
+
+func EnvMap(env []corev1.EnvVar) map[string]string {
+	ret := make(map[string]string, len(env))
+	for _, item := range env {
+		ret[item.Name] = item.Value
+	}
+	return ret
+}
+
+func MustParseURI(raw string) *v1beta1.URI {
+	uri, err := v1beta1.ParseURL(raw)
+	must(err)
+	return uri
+}
+
+func ObjectMeta(name string) metav1.ObjectMeta {
+	return metav1.ObjectMeta{Name: name}
+}
+
+func must(err error) {
+	if err != nil {
+		panic(err)
+	}
+}
+
+type stackGetter interface {
+	GetStack() string
+}
+
+func withStackIndex(builder *fake.ClientBuilder, object client.Object) {
+	builder.WithIndex(object, "stack", func(obj client.Object) []string {
+		if dep, ok := obj.(stackGetter); ok && dep.GetStack() != "" {
+			return []string{dep.GetStack()}
+		}
+		return nil
+	})
+}
+
+func withUnstructuredStackIndex(builder *fake.ClientBuilder, kind string) {
+	object := &unstructured.Unstructured{}
+	object.SetAPIVersion("formance.com/v1beta1")
+	object.SetKind(kind)
+	builder.WithIndex(object, "stack", func(obj client.Object) []string {
+		u, ok := obj.(*unstructured.Unstructured)
+		if !ok {
+			return nil
+		}
+		spec, ok := u.Object["spec"].(map[string]any)
+		if !ok {
+			return nil
+		}
+		stack, ok := spec["stack"].(string)
+		if !ok || stack == "" {
+			return nil
+		}
+		return []string{stack}
+	})
+}
+
+func withSettingsIndexes(builder *fake.ClientBuilder) {
+	builder.WithIndex(&v1beta1.Settings{}, "stack", func(obj client.Object) []string {
+		settings := obj.(*v1beta1.Settings)
+		return settings.Spec.Stacks
+	})
+	builder.WithIndex(&v1beta1.Settings{}, "keylen", func(obj client.Object) []string {
+		settings := obj.(*v1beta1.Settings)
+		return []string{strconv.Itoa(len(splitKeywordWithDot(settings.Spec.Key)))}
+	})
+}
+
+func splitKeywordWithDot(key string) []string {
+	segments := ""
+	inQuote := false
+	for _, item := range key {
+		switch item {
+		case '"':
+			inQuote = !inQuote
+		case '.':
+			if !inQuote {
+				segments += " "
+				continue
+			}
+			segments += string(item)
+		default:
+			segments += string(item)
+		}
+	}
+	return strings.Split(segments, " ")
+}
+
+type Manager struct {
+	Client   client.Client
+	Scheme   *runtime.Scheme
+	Platform core.Platform
+}
+
+var _ core.Manager = (*Manager)(nil)
+
+func (m *Manager) GetClient() client.Client                        { return m.Client }
+func (m *Manager) GetScheme() *runtime.Scheme                      { return m.Scheme }
+func (m *Manager) GetAPIReader() client.Reader                     { return m.Client }
+func (m *Manager) GetPlatform() core.Platform                      { return m.Platform }
+func (m *Manager) GetCache() cache.Cache                           { return nil }
+func (m *Manager) GetConfig() *rest.Config                         { return nil }
+func (m *Manager) GetEventRecorderFor(string) record.EventRecorder { return nil }
+func (m *Manager) GetLogger() logr.Logger                          { return logr.Discard() }
+func (m *Manager) GetRESTMapper() meta.RESTMapper                  { return nil }
+func (m *Manager) GetFieldIndexer() client.FieldIndexer            { return nil }
+func (m *Manager) GetHTTPClient() *http.Client                     { return nil }
+func (m *Manager) GetWebhookServer() webhook.Server                { return nil }
+func (m *Manager) GetMetricsServer() server.Server                 { return nil }
+func (m *Manager) GetControllerOptions() config.Controller         { return config.Controller{} }
+func (m *Manager) Add(manager.Runnable) error                      { return nil }
+func (m *Manager) Elected() <-chan struct{} {
+	ch := make(chan struct{})
+	close(ch)
+	return ch
+}
+func (m *Manager) SetFields(any) error                      { return nil }
+func (m *Manager) AddMetricsExtraHandler(string, any) error { return nil }
+func (m *Manager) AddMetricsServerExtraHandler(string, http.Handler) error {
+	return nil
+}
+func (m *Manager) AddHealthzCheck(string, healthz.Checker) error { return nil }
+func (m *Manager) AddReadyzCheck(string, healthz.Checker) error  { return nil }
+func (m *Manager) Start(context.Context) error                   { return nil }

--- a/pkg/client/formance.com/v1beta1/client_test.go
+++ b/pkg/client/formance.com/v1beta1/client_test.go
@@ -1,0 +1,467 @@
+package v1beta1
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	apiv1beta1 "github.com/formancehq/operator/v3/api/formance.com/v1beta1"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	restfake "k8s.io/client-go/rest/fake"
+)
+
+func TestClientAccessorsShareRESTClient(t *testing.T) {
+	t.Parallel()
+
+	restClient := newRecordingRESTClient(t, "{}")
+	client := NewClient(restClient)
+
+	require.Same(t, restClient, client.Interface)
+	require.IsType(t, &stackClient{}, client.Stacks())
+	require.IsType(t, &AuthClient{}, client.Auths())
+	require.IsType(t, &gatewayClient{}, client.Gateways())
+	require.IsType(t, &LedgerClient{}, client.Ledgers())
+	require.IsType(t, &OrchestrationClient{}, client.Orchestrations())
+	require.IsType(t, &paymentsClient{}, client.Payments())
+	require.IsType(t, &reconciliationClient{}, client.Reconciliations())
+	require.IsType(t, &SearchClient{}, client.Searches())
+	require.IsType(t, &walletsClient{}, client.Wallets())
+	require.IsType(t, &webhooksClient{}, client.Webhooks())
+	require.IsType(t, &VersionsClient{}, client.Versions())
+	require.IsType(t, &databasesClient{}, client.Databases())
+}
+
+func TestStackClientRequests(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	resource := "stacks"
+	t.Run("list", func(t *testing.T) {
+		recorder, client := newStackClient(t, listJSON("Stack"))
+		got, err := client.List(ctx, metav1.ListOptions{LabelSelector: "app=stack"})
+		require.NoError(t, err)
+		require.NotNil(t, got)
+		recorder.requireRequest(t, http.MethodGet, "/stacks", "labelSelector=app%3Dstack")
+	})
+	t.Run("get", func(t *testing.T) {
+		recorder, client := newStackClient(t, objectJSON("Stack", "stack0"))
+		got, err := client.Get(ctx, "stack0", metav1.GetOptions{})
+		require.NoError(t, err)
+		require.Equal(t, "stack0", got.Name)
+		recorder.requireRequest(t, http.MethodGet, "/"+resource+"/stack0", "")
+	})
+	t.Run("create", func(t *testing.T) {
+		recorder, client := newStackClient(t, objectJSON("Stack", "stack0"))
+		got, err := client.Create(ctx, &apiv1beta1.Stack{ObjectMeta: metav1.ObjectMeta{Name: "stack0"}})
+		require.NoError(t, err)
+		require.Equal(t, "stack0", got.Name)
+		recorder.requireRequest(t, http.MethodPost, "/"+resource, "")
+	})
+	t.Run("update", func(t *testing.T) {
+		recorder, client := newStackClient(t, objectJSON("Stack", "stack0"))
+		got, err := client.Update(ctx, &apiv1beta1.Stack{ObjectMeta: metav1.ObjectMeta{Name: "stack0"}})
+		require.NoError(t, err)
+		require.Equal(t, "stack0", got.Name)
+		recorder.requireRequest(t, http.MethodPut, "/"+resource+"/stack0", "")
+	})
+	t.Run("patch", func(t *testing.T) {
+		recorder, client := newStackClient(t, objectJSON("Stack", "stack0"))
+		got, err := client.Patch(ctx, "stack0", types.MergePatchType, []byte(`{"metadata":{"labels":{"a":"b"}}}`))
+		require.NoError(t, err)
+		require.Equal(t, "stack0", got.Name)
+		recorder.requireRequest(t, http.MethodPatch, "/"+resource+"/stack0", "")
+	})
+	t.Run("delete", func(t *testing.T) {
+		recorder, client := newStackClient(t, statusJSON())
+		require.NoError(t, client.Delete(ctx, "stack0"))
+		recorder.requireRequest(t, http.MethodDelete, "/"+resource+"/stack0", "")
+	})
+	t.Run("watch", func(t *testing.T) {
+		recorder, client := newStackClient(t, watchJSON("Stack", "stack0"))
+		watcher, err := client.Watch(ctx, metav1.ListOptions{})
+		require.NoError(t, err)
+		require.NotNil(t, watcher)
+		watcher.Stop()
+		recorder.requireRequest(t, http.MethodGet, "/"+resource, "watch=true")
+	})
+}
+
+func TestGeneratedModuleClientsRequests(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	tests := []struct {
+		name     string
+		resource string
+		kind     string
+		run      func(context.Context, rest.Interface) error
+	}{
+		{
+			name:     "auth",
+			resource: "Auths",
+			kind:     "Auth",
+			run: func(ctx context.Context, restClient rest.Interface) error {
+				client := &AuthClient{restClient: restClient}
+				_, err := client.List(ctx, metav1.ListOptions{})
+				if err != nil {
+					return err
+				}
+				_, err = client.Get(ctx, "auth0", metav1.GetOptions{})
+				if err != nil {
+					return err
+				}
+				_, err = client.Create(ctx, &apiv1beta1.Auth{ObjectMeta: metav1.ObjectMeta{Name: "auth0"}})
+				if err != nil {
+					return err
+				}
+				_, err = client.Update(ctx, &apiv1beta1.Auth{ObjectMeta: metav1.ObjectMeta{Name: "auth0"}})
+				if err != nil {
+					return err
+				}
+				return client.Delete(ctx, "auth0")
+			},
+		},
+		{
+			name:     "gateway",
+			resource: "Gateways",
+			kind:     "Gateway",
+			run: func(ctx context.Context, restClient rest.Interface) error {
+				client := &gatewayClient{restClient: restClient}
+				_, err := client.List(ctx, metav1.ListOptions{})
+				if err != nil {
+					return err
+				}
+				_, err = client.Get(ctx, "gateway0", metav1.GetOptions{})
+				if err != nil {
+					return err
+				}
+				_, err = client.Create(ctx, &apiv1beta1.Gateway{ObjectMeta: metav1.ObjectMeta{Name: "gateway0"}})
+				if err != nil {
+					return err
+				}
+				_, err = client.Update(ctx, &apiv1beta1.Gateway{ObjectMeta: metav1.ObjectMeta{Name: "gateway0"}})
+				if err != nil {
+					return err
+				}
+				return client.Delete(ctx, "gateway0")
+			},
+		},
+		{
+			name:     "ledger",
+			resource: "Ledgers",
+			kind:     "Ledger",
+			run: func(ctx context.Context, restClient rest.Interface) error {
+				client := &LedgerClient{restClient: restClient}
+				_, err := client.List(ctx, metav1.ListOptions{})
+				if err != nil {
+					return err
+				}
+				_, err = client.Get(ctx, "ledger0", metav1.GetOptions{})
+				if err != nil {
+					return err
+				}
+				_, err = client.Create(ctx, &apiv1beta1.Ledger{ObjectMeta: metav1.ObjectMeta{Name: "ledger0"}})
+				if err != nil {
+					return err
+				}
+				_, err = client.Update(ctx, &apiv1beta1.Ledger{ObjectMeta: metav1.ObjectMeta{Name: "ledger0"}})
+				if err != nil {
+					return err
+				}
+				return client.Delete(ctx, "ledger0")
+			},
+		},
+		{
+			name:     "orchestration",
+			resource: "Orchestrations",
+			kind:     "Orchestration",
+			run: func(ctx context.Context, restClient rest.Interface) error {
+				client := &OrchestrationClient{restClient: restClient}
+				_, err := client.List(ctx, metav1.ListOptions{})
+				if err != nil {
+					return err
+				}
+				_, err = client.Get(ctx, "orchestration0", metav1.GetOptions{})
+				if err != nil {
+					return err
+				}
+				_, err = client.Create(ctx, &apiv1beta1.Orchestration{ObjectMeta: metav1.ObjectMeta{Name: "orchestration0"}})
+				if err != nil {
+					return err
+				}
+				_, err = client.Update(ctx, &apiv1beta1.Orchestration{ObjectMeta: metav1.ObjectMeta{Name: "orchestration0"}})
+				if err != nil {
+					return err
+				}
+				return client.Delete(ctx, "orchestration0")
+			},
+		},
+		{
+			name:     "payments",
+			resource: "Payments",
+			kind:     "Payments",
+			run: func(ctx context.Context, restClient rest.Interface) error {
+				client := &paymentsClient{restClient: restClient}
+				_, err := client.List(ctx, metav1.ListOptions{})
+				if err != nil {
+					return err
+				}
+				_, err = client.Get(ctx, "payments0", metav1.GetOptions{})
+				if err != nil {
+					return err
+				}
+				_, err = client.Create(ctx, &apiv1beta1.Payments{ObjectMeta: metav1.ObjectMeta{Name: "payments0"}})
+				if err != nil {
+					return err
+				}
+				_, err = client.Update(ctx, &apiv1beta1.Payments{ObjectMeta: metav1.ObjectMeta{Name: "payments0"}})
+				if err != nil {
+					return err
+				}
+				return client.Delete(ctx, "payments0")
+			},
+		},
+		{
+			name:     "reconciliation",
+			resource: "Reconciliations",
+			kind:     "Reconciliation",
+			run: func(ctx context.Context, restClient rest.Interface) error {
+				client := &reconciliationClient{restClient: restClient}
+				_, err := client.List(ctx, metav1.ListOptions{})
+				if err != nil {
+					return err
+				}
+				_, err = client.Get(ctx, "reconciliation0", metav1.GetOptions{})
+				if err != nil {
+					return err
+				}
+				_, err = client.Create(ctx, &apiv1beta1.Reconciliation{ObjectMeta: metav1.ObjectMeta{Name: "reconciliation0"}})
+				if err != nil {
+					return err
+				}
+				_, err = client.Update(ctx, &apiv1beta1.Reconciliation{ObjectMeta: metav1.ObjectMeta{Name: "reconciliation0"}})
+				if err != nil {
+					return err
+				}
+				return client.Delete(ctx, "reconciliation0")
+			},
+		},
+		{
+			name:     "search",
+			resource: "Searchs",
+			kind:     "Search",
+			run: func(ctx context.Context, restClient rest.Interface) error {
+				client := &SearchClient{restClient: restClient}
+				_, err := client.List(ctx, metav1.ListOptions{})
+				if err != nil {
+					return err
+				}
+				_, err = client.Get(ctx, "search0", metav1.GetOptions{})
+				if err != nil {
+					return err
+				}
+				_, err = client.Create(ctx, &apiv1beta1.Search{ObjectMeta: metav1.ObjectMeta{Name: "search0"}})
+				if err != nil {
+					return err
+				}
+				_, err = client.Update(ctx, &apiv1beta1.Search{ObjectMeta: metav1.ObjectMeta{Name: "search0"}})
+				if err != nil {
+					return err
+				}
+				return client.Delete(ctx, "search0")
+			},
+		},
+		{
+			name:     "wallets",
+			resource: "Wallets",
+			kind:     "Wallets",
+			run: func(ctx context.Context, restClient rest.Interface) error {
+				client := &walletsClient{restClient: restClient}
+				_, err := client.List(ctx, metav1.ListOptions{})
+				if err != nil {
+					return err
+				}
+				_, err = client.Get(ctx, "wallets0", metav1.GetOptions{})
+				if err != nil {
+					return err
+				}
+				_, err = client.Create(ctx, &apiv1beta1.Wallets{ObjectMeta: metav1.ObjectMeta{Name: "wallets0"}})
+				if err != nil {
+					return err
+				}
+				_, err = client.Update(ctx, &apiv1beta1.Wallets{ObjectMeta: metav1.ObjectMeta{Name: "wallets0"}})
+				if err != nil {
+					return err
+				}
+				return client.Delete(ctx, "wallets0")
+			},
+		},
+		{
+			name:     "webhooks",
+			resource: "Webhooks",
+			kind:     "Webhooks",
+			run: func(ctx context.Context, restClient rest.Interface) error {
+				client := &webhooksClient{restClient: restClient}
+				_, err := client.List(ctx, metav1.ListOptions{})
+				if err != nil {
+					return err
+				}
+				_, err = client.Get(ctx, "webhooks0", metav1.GetOptions{})
+				if err != nil {
+					return err
+				}
+				_, err = client.Create(ctx, &apiv1beta1.Webhooks{ObjectMeta: metav1.ObjectMeta{Name: "webhooks0"}})
+				if err != nil {
+					return err
+				}
+				_, err = client.Update(ctx, &apiv1beta1.Webhooks{ObjectMeta: metav1.ObjectMeta{Name: "webhooks0"}})
+				if err != nil {
+					return err
+				}
+				return client.Delete(ctx, "webhooks0")
+			},
+		},
+		{
+			name:     "versions",
+			resource: "Versions",
+			kind:     "Versions",
+			run: func(ctx context.Context, restClient rest.Interface) error {
+				client := &VersionsClient{restClient: restClient}
+				_, err := client.List(ctx, metav1.ListOptions{})
+				if err != nil {
+					return err
+				}
+				_, err = client.Get(ctx, "versions0", metav1.GetOptions{})
+				if err != nil {
+					return err
+				}
+				_, err = client.Create(ctx, &apiv1beta1.Versions{ObjectMeta: metav1.ObjectMeta{Name: "versions0"}})
+				if err != nil {
+					return err
+				}
+				_, err = client.Update(ctx, &apiv1beta1.Versions{ObjectMeta: metav1.ObjectMeta{Name: "versions0"}})
+				if err != nil {
+					return err
+				}
+				return client.Delete(ctx, "versions0")
+			},
+		},
+		{
+			name:     "databases",
+			resource: "Databases",
+			kind:     "Database",
+			run: func(ctx context.Context, restClient rest.Interface) error {
+				client := &databasesClient{restClient: restClient}
+				_, err := client.List(ctx, metav1.ListOptions{})
+				if err != nil {
+					return err
+				}
+				_, err = client.Get(ctx, "databases0", metav1.GetOptions{})
+				return err
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			recorder := &requestRecorder{}
+			restClient := newRecordingRESTClientWithRecorder(t, recorder, func(req *http.Request) string {
+				if req.Method == http.MethodDelete {
+					return statusJSON()
+				}
+				if req.URL.Path == "/"+strings.ToLower(tt.resource) {
+					return listJSON(tt.kind)
+				}
+				return objectJSON(tt.kind, tt.name+"0")
+			})
+
+			require.NoError(t, tt.run(ctx, restClient))
+			require.Equal(t, http.MethodGet, recorder.requests[0].method)
+			require.Equal(t, "/"+strings.ToLower(tt.resource), recorder.requests[0].path)
+			require.Equal(t, http.MethodGet, recorder.requests[1].method)
+			require.Equal(t, "/"+strings.ToLower(tt.resource)+"/"+tt.name+"0", recorder.requests[1].path)
+		})
+	}
+}
+
+type recordedRequest struct {
+	method string
+	path   string
+	query  string
+}
+
+type requestRecorder struct {
+	requests []recordedRequest
+}
+
+func (r *requestRecorder) requireRequest(t *testing.T, method, path, query string) {
+	t.Helper()
+	require.NotEmpty(t, r.requests)
+	last := r.requests[len(r.requests)-1]
+	require.Equal(t, method, last.method)
+	require.Equal(t, path, last.path)
+	require.Equal(t, query, last.query)
+}
+
+func newStackClient(t *testing.T, body string) (*requestRecorder, StackInterface) {
+	t.Helper()
+	recorder := &requestRecorder{}
+	return recorder, &stackClient{restClient: newRecordingRESTClientWithRecorder(t, recorder, func(*http.Request) string {
+		return body
+	})}
+}
+
+func newRecordingRESTClient(t *testing.T, body string) rest.Interface {
+	t.Helper()
+	return newRecordingRESTClientWithRecorder(t, &requestRecorder{}, func(*http.Request) string {
+		return body
+	})
+}
+
+func newRecordingRESTClientWithRecorder(t *testing.T, recorder *requestRecorder, bodyFor func(*http.Request) string) rest.Interface {
+	t.Helper()
+
+	return &restfake.RESTClient{
+		GroupVersion:         schema.GroupVersion{Group: "formance.com", Version: "v1beta1"},
+		NegotiatedSerializer: scheme.Codecs.WithoutConversion(),
+		Client: restfake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
+			recorder.requests = append(recorder.requests, recordedRequest{
+				method: req.Method,
+				path:   req.URL.Path,
+				query:  req.URL.RawQuery,
+			})
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header: http.Header{
+					"Content-Type": []string{runtime.ContentTypeJSON},
+				},
+				Body: io.NopCloser(strings.NewReader(bodyFor(req))),
+			}, nil
+		}),
+	}
+}
+
+func objectJSON(kind, name string) string {
+	return fmt.Sprintf(`{"apiVersion":"formance.com/v1beta1","kind":%q,"metadata":{"name":%q}}`, kind, name)
+}
+
+func listJSON(kind string) string {
+	return fmt.Sprintf(`{"apiVersion":"formance.com/v1beta1","kind":%q,"items":[]}`, kind+"List")
+}
+
+func statusJSON() string {
+	return `{"apiVersion":"v1","kind":"Status","status":"Success"}`
+}
+
+func watchJSON(kind, name string) string {
+	return fmt.Sprintf(`{"type":"ADDED","object":%s}`, objectJSON(kind, name))
+}

--- a/pkg/client/formance.com/v1beta1/client_test.go
+++ b/pkg/client/formance.com/v1beta1/client_test.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 	"testing"
 
-	apiv1beta1 "github.com/formancehq/operator/v3/api/formance.com/v1beta1"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -17,6 +16,8 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	restfake "k8s.io/client-go/rest/fake"
+
+	apiv1beta1 "github.com/formancehq/operator/v3/api/formance.com/v1beta1"
 )
 
 func TestClientAccessorsShareRESTClient(t *testing.T) {


### PR DESCRIPTION
## Summary
- add focused unit coverage for critical settings-driven deployment paths across payments, ledgers, gateways, brokers, jobs, services, applications, and shared helpers
- cover settings parser edge cases and generated client/resource helper behavior
- fix payments Temporal resource-reference error handling before dereferencing pending refs

## Verification
- go test ./internal/resources/gateways ./internal/resources/payments ./internal/resources/ledgers ./internal/resources/settings ./internal/resources/applications ./internal/resources/jobs ./internal/resources/services ./internal/resources/brokers
- go list ./... | grep -v '/internal/tests' | xargs go test
- KUBEBUILDER_ASSETS="/Users/flemzord/Library/Application Support/io.kubebuilder.envtest/k8s/1.32.0-darwin-arm64" go test ./... -coverpkg=./... -coverprofile=/tmp/operator-global-coverpkg.out -covermode=atomic

## Coverage
- fast unit filtered coverage: 48.2%
- global envtest + coverpkg filtered coverage: 78.6%
- global raw coverage including generated deepcopy: 73.3%