### PR TITLE
test: add operator e2e suite

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -76,15 +76,15 @@ jobs:
       fail-fast: false
       matrix:
         kubernetes:
-          - version: "1.30"
-            kind_node_image: kindest/node:v1.30.13
-            cluster_name: formance-operator-e2e-130
           - version: "1.31"
             kind_node_image: kindest/node:v1.31.9
             cluster_name: formance-operator-e2e-131
           - version: "1.32"
             kind_node_image: kindest/node:v1.32.5
             cluster_name: formance-operator-e2e-132
+          - version: "1.33"
+            kind_node_image: kindest/node:v1.33.1
+            cluster_name: formance-operator-e2e-133
     steps:
       - uses: 'namespacelabs/nscloud-checkout-action@v8'
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -68,6 +68,28 @@ jobs:
           nix --extra-experimental-features "nix-command" --extra-experimental-features "flakes" develop --impure --command just tests
         env:
           SPEAKEASY_API_KEY: ${{ secrets.SPEAKEASY_API_KEY }}
+  E2E:
+    runs-on: "namespace-profile-linux-amd64-8vcpu"
+    if: contains(github.event.pull_request.labels.*.name, 'e2e') || github.ref == 'refs/heads/main' || github.event_name == 'merge_group'
+    steps:
+      - uses: 'namespacelabs/nscloud-checkout-action@v8'
+        with:
+          fetch-depth: 0
+      - name: Setup Env
+        uses: ./.github/actions/default
+        with:
+          token: ${{ secrets.NUMARY_GITHUB_TOKEN }}
+      - run: >
+          nix --extra-experimental-features "nix-command" --extra-experimental-features "flakes" develop --impure --command just e2e
+        env:
+          SPEAKEASY_API_KEY: ${{ secrets.SPEAKEASY_API_KEY }}
+      - name: Upload Chainsaw artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: chainsaw-e2e-artifacts
+          path: tests/e2e/artifacts
+          if-no-files-found: ignore
   GoReleaser:
     runs-on: "namespace-profile-linux-amd64-4vcpu"
     if: contains(github.event.pull_request.labels.*.name, 'build-images') || github.ref == 'refs/heads/main' || github.event_name == 'merge_group'
@@ -92,6 +114,7 @@ jobs:
     environment: staging
     needs:
       - Dirty
+      - E2E
       - GoReleaser
       - Tests
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,7 +27,7 @@ jobs:
   Dirty:
     runs-on: "namespace-profile-linux-amd64-4vcpu"
     steps:
-      - uses: 'namespacelabs/nscloud-checkout-action@v8'
+      - uses: "namespacelabs/nscloud-checkout-action@v8"
         with:
           fetch-depth: 0
       - name: Setup Env
@@ -57,7 +57,7 @@ jobs:
   Tests:
     runs-on: "namespace-profile-linux-amd64-8vcpu"
     steps:
-      - uses: 'namespacelabs/nscloud-checkout-action@v8'
+      - uses: "namespacelabs/nscloud-checkout-action@v8"
         with:
           fetch-depth: 0
       - name: Setup Env
@@ -85,8 +85,14 @@ jobs:
           - version: "1.33"
             kind_node_image: kindest/node:v1.33.1
             cluster_name: formance-operator-e2e-133
+          - version: "1.34"
+            kind_node_image: kindest/node:v1.34.3
+            cluster_name: formance-operator-e2e-134
+          - version: "1.35"
+            kind_node_image: kindest/node:v1.35.1
+            cluster_name: formance-operator-e2e-135
     steps:
-      - uses: 'namespacelabs/nscloud-checkout-action@v8'
+      - uses: "namespacelabs/nscloud-checkout-action@v8"
         with:
           fetch-depth: 0
       - name: Setup Env
@@ -110,7 +116,7 @@ jobs:
     runs-on: "namespace-profile-linux-amd64-4vcpu"
     if: contains(github.event.pull_request.labels.*.name, 'build-images') || github.ref == 'refs/heads/main' || github.event_name == 'merge_group'
     steps:
-      - uses: 'namespacelabs/nscloud-checkout-action@v8'
+      - uses: "namespacelabs/nscloud-checkout-action@v8"
         with:
           fetch-depth: 0
       - name: Setup Env
@@ -144,7 +150,7 @@ jobs:
           args: ${{ vars.TS_ARGS }}
           retry: ${{ vars.TS_RETRY }}
           timeout: ${{ vars.TS_TIMEOUT }}
-      - uses: 'namespacelabs/nscloud-checkout-action@v8'
+      - uses: "namespacelabs/nscloud-checkout-action@v8"
         with:
           fetch-depth: 0
       - name: Install Nix

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -69,8 +69,22 @@ jobs:
         env:
           SPEAKEASY_API_KEY: ${{ secrets.SPEAKEASY_API_KEY }}
   E2E:
+    name: E2E (Kubernetes ${{ matrix.kubernetes.version }})
     runs-on: "namespace-profile-linux-amd64-8vcpu"
-    if: contains(github.event.pull_request.labels.*.name, 'e2e') || github.ref == 'refs/heads/main' || github.event_name == 'merge_group'
+    if: github.event_name == 'pull_request' || github.ref == 'refs/heads/main' || github.event_name == 'merge_group'
+    strategy:
+      fail-fast: false
+      matrix:
+        kubernetes:
+          - version: "1.30"
+            kind_node_image: kindest/node:v1.30.13
+            cluster_name: formance-operator-e2e-130
+          - version: "1.31"
+            kind_node_image: kindest/node:v1.31.9
+            cluster_name: formance-operator-e2e-131
+          - version: "1.32"
+            kind_node_image: kindest/node:v1.32.5
+            cluster_name: formance-operator-e2e-132
     steps:
       - uses: 'namespacelabs/nscloud-checkout-action@v8'
         with:
@@ -82,12 +96,14 @@ jobs:
       - run: >
           nix --extra-experimental-features "nix-command" --extra-experimental-features "flakes" develop --impure --command just e2e
         env:
+          KIND_CLUSTER_NAME: ${{ matrix.kubernetes.cluster_name }}
+          KIND_NODE_IMAGE: ${{ matrix.kubernetes.kind_node_image }}
           SPEAKEASY_API_KEY: ${{ secrets.SPEAKEASY_API_KEY }}
       - name: Upload Chainsaw artifacts
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: chainsaw-e2e-artifacts
+          name: chainsaw-e2e-artifacts-k8s-${{ matrix.kubernetes.version }}
           path: tests/e2e/artifacts
           if-no-files-found: ignore
   GoReleaser:

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ Dockerfile.cross
 charts
 
 *.tgz
+
+# E2E test artifacts
+tests/e2e/artifacts/

--- a/Justfile
+++ b/Justfile
@@ -20,6 +20,31 @@ tidy:
 tests args='':
   KUBEBUILDER_ASSETS=$(setup-envtest use 1.32.0 -p path) ginkgo -p ./...
 
+e2e-cluster-up:
+  ./tests/e2e/scripts/cluster-up.sh
+
+e2e-cluster-down:
+  ./tests/e2e/scripts/cluster-down.sh
+
+e2e-build-image:
+  ./tests/e2e/scripts/build-load-image.sh
+
+e2e-install:
+  ./tests/e2e/scripts/install-operator.sh
+
+e2e-install-chainsaw:
+  mkdir -p ./bin
+  GOBIN=$(pwd)/bin go install github.com/kyverno/chainsaw@v0.2.15
+
+e2e-chainsaw args='': e2e-install-chainsaw
+  mkdir -p tests/e2e/artifacts
+  ./bin/chainsaw test tests/e2e/chainsaw --config tests/e2e/chainsaw/.chainsaw.yaml --report-path tests/e2e/artifacts {{args}}
+
+e2e-diagnostics name='manual':
+  ./tests/e2e/scripts/dump-diagnostics.sh {{name}}
+
+e2e: e2e-cluster-up e2e-build-image e2e-install e2e-chainsaw
+
 release-local:
   goreleaser release --nightly --skip=publish --clean
 

--- a/flake.nix
+++ b/flake.nix
@@ -47,6 +47,7 @@
             gotools
             just
             kind
+            kubectl
             kubernetes-helm
             kustomize_4
             setup-envtest

--- a/flake.nix
+++ b/flake.nix
@@ -46,6 +46,7 @@
             go_1_26
             gotools
             just
+            kind
             kubernetes-helm
             kustomize_4
             setup-envtest

--- a/internal/resources/brokerconsumers/controller.go
+++ b/internal/resources/brokerconsumers/controller.go
@@ -170,18 +170,17 @@ func Reconcile(ctx core.Context, stack *v1beta1.Stack, consumer *v1beta1.BrokerC
 
 func createServiceNatsConsumer(ctx core.Context, stack *v1beta1.Stack, consumer *v1beta1.BrokerConsumer, broker *v1beta1.Broker, service string) error {
 	const script = `
-	exists=$(nats consumer ls $STACK-$SERVICE -n | grep $NAME)
-	[[ -z "$exists" ]] || {
-		nats --server $NATS_URI consumer add $STACK-$SERVICE $NAME \
-			--deliver-group $NAME \
+	if ! nats --server "$NATS_URI" consumer info "$STACK-$SERVICE" "$NAME" --no-select >/dev/null 2>&1; then
+		nats --server "$NATS_URI" consumer add "$STACK-$SERVICE" "$NAME" \
+			--deliver-group "$NAME" \
 			--deliver all \
 			--max-pending 1024 \
 			--ack explicit \
-			--target $STACK-$NAME \
+			--target "$STACK-$NAME" \
 			--replay instant \
-			--filter $STACK-$SERVICE \
+			--filter "$STACK-$SERVICE" \
 			--defaults
-	}`
+	fi`
 
 	natsBoxImage, err := registries.GetNatsBoxImage(ctx, stack, "0.19.2")
 	if err != nil {

--- a/internal/resources/brokers/reconcile.go
+++ b/internal/resources/brokers/reconcile.go
@@ -110,9 +110,10 @@ func hasAllVersionsGreaterThan(ctx core.Context, stack *v1beta1.Stack, ref strin
 func detectBrokerModeByCheckingExistentStreams(ctx core.Context, stack *v1beta1.Stack, broker *v1beta1.Broker, uri *v1beta1.URI) (bool, error) {
 	const script = `
 	# notes(gfyrag): Check if we have any stream named "$STACK-xxx"
-	v=$(nats stream ls -n --server $NATS_URI | grep "$STACK-")
-	# exit with code 12 if we detect any streams
-	[[ -z "$v" ]] || exit 12;
+	if nats --server "$NATS_URI" stream ls -n | grep -q "$STACK-"; then
+		# exit with code 12 if we detect any streams
+		exit 12
+	fi
 `
 
 	natsBoxImage, err := registries.GetNatsBoxImage(ctx, stack, "0.19.2")
@@ -219,17 +220,16 @@ func createOneStreamByStack(ctx core.Context, stack *v1beta1.Stack, broker *v1be
 	}
 
 	const script = `
-	index=$(nats --server $NATS_URI stream ls -n | grep "$STREAM")
-	[[ -z "$index" ]] && {
+	if ! nats --server "$NATS_URI" stream info "$STREAM" --no-select >/dev/null 2>&1; then
 		nats stream add \
-			--server $NATS_URI \
+			--server "$NATS_URI" \
 			--retention interest \
-			--subjects $STREAM.* \
+			--subjects "$STREAM.*" \
 			--defaults \
-			--replicas $REPLICAS \
+			--replicas "$REPLICAS" \
 			--no-allow-direct \
-			$STREAM
-	} || true`
+			"$STREAM"
+	fi`
 
 	natsBoxImage, err := registries.GetNatsBoxImage(ctx, stack, "0.19.2")
 	if err != nil {

--- a/tests/e2e/chainsaw/.chainsaw.yaml
+++ b/tests/e2e/chainsaw/.chainsaw.yaml
@@ -1,0 +1,21 @@
+apiVersion: chainsaw.kyverno.io/v1alpha2
+kind: Configuration
+metadata:
+  name: formance-operator-e2e
+spec:
+  timeouts:
+    apply: 2m
+    assert: 5m
+    cleanup: 5m
+    delete: 2m
+    error: 2m
+    exec: 5m
+  cleanup:
+    skipDelete: false
+  execution:
+    failFast: true
+    parallel: 1
+  report:
+    format: JUNIT-TEST
+    name: chainsaw-report
+    path: tests/e2e/artifacts

--- a/tests/e2e/chainsaw/00-install/asserts/core-crds.yaml
+++ b/tests/e2e/chainsaw/00-install/asserts/core-crds.yaml
@@ -1,0 +1,114 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: authclients.formance.com
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: auths.formance.com
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: benthos.formance.com
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: benthosstreams.formance.com
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: brokerconsumers.formance.com
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: brokers.formance.com
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: brokertopics.formance.com
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: databases.formance.com
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: gatewayhttpapis.formance.com
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: gateways.formance.com
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: ledgers.formance.com
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: orchestrations.formance.com
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: payments.formance.com
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: reconciliations.formance.com
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: resourcereferences.formance.com
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: searches.formance.com
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: settings.formance.com
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: stacks.formance.com
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: stargates.formance.com
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: transactionplanes.formance.com
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: versions.formance.com
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: wallets.formance.com
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: webhooks.formance.com

--- a/tests/e2e/chainsaw/00-install/asserts/operator-deployment.yaml
+++ b/tests/e2e/chainsaw/00-install/asserts/operator-deployment.yaml
@@ -1,0 +1,24 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: formance-operator
+  namespace: formance-system
+status:
+  (conditions[?type == 'Available']):
+    - status: "True"
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: formance-controller-manager
+  namespace: formance-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: formance-manager-role
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: formance-manager-rolebinding

--- a/tests/e2e/chainsaw/00-install/asserts/smoke-namespace.yaml
+++ b/tests/e2e/chainsaw/00-install/asserts/smoke-namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: chainsaw-smoke

--- a/tests/e2e/chainsaw/00-install/chainsaw-test.yaml
+++ b/tests/e2e/chainsaw/00-install/chainsaw-test.yaml
@@ -1,0 +1,29 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: install-smoke
+  labels:
+    suite: smoke
+spec:
+  concurrent: false
+  steps:
+    - name: operator-installed
+      try:
+        - assert:
+            file: asserts/operator-deployment.yaml
+        - assert:
+            file: asserts/core-crds.yaml
+      catch:
+        - script:
+            timeout: 2m
+            content: ../../scripts/dump-diagnostics.sh install-smoke-operator-installed
+    - name: stack-namespace
+      try:
+        - apply:
+            file: resources/smoke-stack.yaml
+        - assert:
+            file: asserts/smoke-namespace.yaml
+      catch:
+        - script:
+            timeout: 2m
+            content: ../../scripts/dump-diagnostics.sh install-smoke-stack-namespace

--- a/tests/e2e/chainsaw/00-install/resources/smoke-stack.yaml
+++ b/tests/e2e/chainsaw/00-install/resources/smoke-stack.yaml
@@ -1,0 +1,6 @@
+apiVersion: formance.com/v1beta1
+kind: Stack
+metadata:
+  name: chainsaw-smoke
+spec:
+  version: v0.0.0-e2e

--- a/tests/e2e/chainsaw/01-settings-resolution/asserts/namespaces.yaml
+++ b/tests/e2e/chainsaw/01-settings-resolution/asserts/namespaces.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: chainsaw-settings-wildcard
+  labels:
+    chainsaw-scope: wildcard
+    chainsaw-shared: wildcard
+  annotations:
+    chainsaw-annotation: wildcard
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: chainsaw-settings-specific
+  labels:
+    chainsaw-scope: specific
+    chainsaw-shared: specific
+  annotations:
+    chainsaw-annotation: specific

--- a/tests/e2e/chainsaw/01-settings-resolution/chainsaw-test.yaml
+++ b/tests/e2e/chainsaw/01-settings-resolution/chainsaw-test.yaml
@@ -1,0 +1,21 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: settings-resolution
+  labels:
+    suite: settings
+spec:
+  concurrent: false
+  steps:
+    - name: wildcard-and-stack-specific-settings
+      try:
+        - apply:
+            file: resources/settings.yaml
+        - apply:
+            file: resources/stacks.yaml
+        - assert:
+            file: asserts/namespaces.yaml
+      catch:
+        - script:
+            timeout: 2m
+            content: ../../scripts/dump-diagnostics.sh settings-resolution

--- a/tests/e2e/chainsaw/01-settings-resolution/resources/settings.yaml
+++ b/tests/e2e/chainsaw/01-settings-resolution/resources/settings.yaml
@@ -1,0 +1,39 @@
+apiVersion: formance.com/v1beta1
+kind: Settings
+metadata:
+  name: chainsaw-wildcard-namespace-labels
+spec:
+  stacks:
+    - "*"
+  key: namespace.labels
+  value: chainsaw-scope=wildcard,chainsaw-shared=wildcard
+---
+apiVersion: formance.com/v1beta1
+kind: Settings
+metadata:
+  name: chainsaw-specific-namespace-labels
+spec:
+  stacks:
+    - chainsaw-settings-specific
+  key: namespace.labels
+  value: chainsaw-scope=specific,chainsaw-shared=specific
+---
+apiVersion: formance.com/v1beta1
+kind: Settings
+metadata:
+  name: chainsaw-wildcard-namespace-annotations
+spec:
+  stacks:
+    - "*"
+  key: namespace.annotations
+  value: chainsaw-annotation=wildcard
+---
+apiVersion: formance.com/v1beta1
+kind: Settings
+metadata:
+  name: chainsaw-specific-namespace-annotations
+spec:
+  stacks:
+    - chainsaw-settings-specific
+  key: namespace.annotations
+  value: chainsaw-annotation=specific

--- a/tests/e2e/chainsaw/01-settings-resolution/resources/stacks.yaml
+++ b/tests/e2e/chainsaw/01-settings-resolution/resources/stacks.yaml
@@ -1,0 +1,13 @@
+apiVersion: formance.com/v1beta1
+kind: Stack
+metadata:
+  name: chainsaw-settings-wildcard
+spec:
+  version: v0.0.0-e2e
+---
+apiVersion: formance.com/v1beta1
+kind: Stack
+metadata:
+  name: chainsaw-settings-specific
+spec:
+  version: v0.0.0-e2e

--- a/tests/e2e/chainsaw/02-stack-lifecycle/asserts/networkpolicies.yaml
+++ b/tests/e2e/chainsaw/02-stack-lifecycle/asserts/networkpolicies.yaml
@@ -1,0 +1,50 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny-ingress
+  namespace: chainsaw-networkpolicies
+  ownerReferences:
+    - apiVersion: formance.com/v1beta1
+      kind: Stack
+      name: chainsaw-networkpolicies
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-gateway-ingress
+  namespace: chainsaw-networkpolicies
+  ownerReferences:
+    - apiVersion: formance.com/v1beta1
+      kind: Stack
+      name: chainsaw-networkpolicies
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: gateway
+  ingress:
+    - {}
+  policyTypes:
+    - Ingress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-from-gateway
+  namespace: chainsaw-networkpolicies
+  ownerReferences:
+    - apiVersion: formance.com/v1beta1
+      kind: Stack
+      name: chainsaw-networkpolicies
+spec:
+  podSelector: {}
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: gateway
+  policyTypes:
+    - Ingress

--- a/tests/e2e/chainsaw/02-stack-lifecycle/chainsaw-test.yaml
+++ b/tests/e2e/chainsaw/02-stack-lifecycle/chainsaw-test.yaml
@@ -1,0 +1,36 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: stack-lifecycle
+  labels:
+    suite: stack
+spec:
+  concurrent: false
+  steps:
+    - name: networkpolicies-enabled
+      try:
+        - apply:
+            file: resources/networkpolicies-enabled.yaml
+        - apply:
+            file: resources/stack.yaml
+        - assert:
+            file: asserts/networkpolicies.yaml
+      catch:
+        - script:
+            timeout: 2m
+            content: ../../scripts/dump-diagnostics.sh stack-networkpolicies-enabled
+    - name: networkpolicies-disabled
+      try:
+        - apply:
+            file: resources/networkpolicies-disabled.yaml
+        - script:
+            timeout: 2m
+            content: |
+              set -eu
+              kubectl wait --for=delete networkpolicy/default-deny-ingress -n chainsaw-networkpolicies --timeout=2m
+              kubectl wait --for=delete networkpolicy/allow-gateway-ingress -n chainsaw-networkpolicies --timeout=2m
+              kubectl wait --for=delete networkpolicy/allow-from-gateway -n chainsaw-networkpolicies --timeout=2m
+      catch:
+        - script:
+            timeout: 2m
+            content: ../../scripts/dump-diagnostics.sh stack-networkpolicies-disabled

--- a/tests/e2e/chainsaw/02-stack-lifecycle/resources/networkpolicies-disabled.yaml
+++ b/tests/e2e/chainsaw/02-stack-lifecycle/resources/networkpolicies-disabled.yaml
@@ -1,0 +1,9 @@
+apiVersion: formance.com/v1beta1
+kind: Settings
+metadata:
+  name: chainsaw-networkpolicies-enabled
+spec:
+  stacks:
+    - chainsaw-networkpolicies
+  key: networkpolicies.enabled
+  value: "false"

--- a/tests/e2e/chainsaw/02-stack-lifecycle/resources/networkpolicies-enabled.yaml
+++ b/tests/e2e/chainsaw/02-stack-lifecycle/resources/networkpolicies-enabled.yaml
@@ -1,0 +1,9 @@
+apiVersion: formance.com/v1beta1
+kind: Settings
+metadata:
+  name: chainsaw-networkpolicies-enabled
+spec:
+  stacks:
+    - chainsaw-networkpolicies
+  key: networkpolicies.enabled
+  value: "true"

--- a/tests/e2e/chainsaw/02-stack-lifecycle/resources/stack.yaml
+++ b/tests/e2e/chainsaw/02-stack-lifecycle/resources/stack.yaml
@@ -1,0 +1,6 @@
+apiVersion: formance.com/v1beta1
+kind: Stack
+metadata:
+  name: chainsaw-networkpolicies
+spec:
+  version: v0.0.0-e2e

--- a/tests/e2e/chainsaw/03-resource-reference/asserts/initial-replication.yaml
+++ b/tests/e2e/chainsaw/03-resource-reference/asserts/initial-replication.yaml
@@ -1,0 +1,23 @@
+apiVersion: formance.com/v1beta1
+kind: ResourceReference
+metadata:
+  name: chainsaw-secret-reference
+status:
+  ready: true
+  syncedResource: chainsaw-external-secret
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: chainsaw-external-secret
+  namespace: chainsaw-resource-reference
+  annotations:
+    chainsaw.formance.com/source: initial
+  ownerReferences:
+    - apiVersion: formance.com/v1beta1
+      kind: ResourceReference
+      name: chainsaw-secret-reference
+type: Opaque
+data:
+  username: Y2hhaW5zYXc=
+  password: aW5pdGlhbA==

--- a/tests/e2e/chainsaw/03-resource-reference/asserts/retargeted-replication.yaml
+++ b/tests/e2e/chainsaw/03-resource-reference/asserts/retargeted-replication.yaml
@@ -1,0 +1,23 @@
+apiVersion: formance.com/v1beta1
+kind: ResourceReference
+metadata:
+  name: chainsaw-secret-reference
+status:
+  ready: true
+  syncedResource: chainsaw-external-secret-replacement
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: chainsaw-external-secret-replacement
+  namespace: chainsaw-resource-reference
+  annotations:
+    chainsaw.formance.com/source: replacement
+  ownerReferences:
+    - apiVersion: formance.com/v1beta1
+      kind: ResourceReference
+      name: chainsaw-secret-reference
+type: Opaque
+data:
+  username: Y2hhaW5zYXc=
+  password: cmVwbGFjZW1lbnQ=

--- a/tests/e2e/chainsaw/03-resource-reference/asserts/updated-replication.yaml
+++ b/tests/e2e/chainsaw/03-resource-reference/asserts/updated-replication.yaml
@@ -1,0 +1,24 @@
+apiVersion: formance.com/v1beta1
+kind: ResourceReference
+metadata:
+  name: chainsaw-secret-reference
+status:
+  ready: true
+  syncedResource: chainsaw-external-secret
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: chainsaw-external-secret
+  namespace: chainsaw-resource-reference
+  annotations:
+    chainsaw.formance.com/source: updated
+  ownerReferences:
+    - apiVersion: formance.com/v1beta1
+      kind: ResourceReference
+      name: chainsaw-secret-reference
+type: Opaque
+data:
+  username: Y2hhaW5zYXc=
+  password: dXBkYXRlZA==
+  token: cHJvcGFnYXRlZA==

--- a/tests/e2e/chainsaw/03-resource-reference/chainsaw-test.yaml
+++ b/tests/e2e/chainsaw/03-resource-reference/chainsaw-test.yaml
@@ -1,0 +1,50 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: resource-reference
+  labels:
+    suite: core
+    feature: resource-reference
+spec:
+  concurrent: false
+  steps:
+    - name: create-stack-and-reference
+      try:
+        - apply:
+            file: resources/stack.yaml
+        - apply:
+            file: resources/source-secret.yaml
+        - apply:
+            file: resources/resource-reference.yaml
+        - assert:
+            file: asserts/initial-replication.yaml
+      catch:
+        - script:
+            timeout: 2m
+            content: ../../scripts/dump-diagnostics.sh resource-reference-initial
+    - name: update-source-secret
+      try:
+        - apply:
+            file: resources/source-secret-updated.yaml
+        - assert:
+            file: asserts/updated-replication.yaml
+      catch:
+        - script:
+            timeout: 2m
+            content: ../../scripts/dump-diagnostics.sh resource-reference-update
+    - name: retarget-reference
+      try:
+        - apply:
+            file: resources/source-secret-replacement.yaml
+        - apply:
+            file: resources/resource-reference-retargeted.yaml
+        - assert:
+            file: asserts/retargeted-replication.yaml
+        - script:
+            timeout: 2m
+            content: |
+              kubectl wait --for=delete secret/chainsaw-external-secret -n chainsaw-resource-reference --timeout=2m
+      catch:
+        - script:
+            timeout: 2m
+            content: ../../scripts/dump-diagnostics.sh resource-reference-retarget

--- a/tests/e2e/chainsaw/03-resource-reference/resources/resource-reference-retargeted.yaml
+++ b/tests/e2e/chainsaw/03-resource-reference/resources/resource-reference-retargeted.yaml
@@ -1,0 +1,11 @@
+apiVersion: formance.com/v1beta1
+kind: ResourceReference
+metadata:
+  name: chainsaw-secret-reference
+spec:
+  stack: chainsaw-resource-reference
+  name: chainsaw-external-secret-replacement
+  gvk:
+    group: ""
+    version: v1
+    kind: Secret

--- a/tests/e2e/chainsaw/03-resource-reference/resources/resource-reference.yaml
+++ b/tests/e2e/chainsaw/03-resource-reference/resources/resource-reference.yaml
@@ -1,0 +1,11 @@
+apiVersion: formance.com/v1beta1
+kind: ResourceReference
+metadata:
+  name: chainsaw-secret-reference
+spec:
+  stack: chainsaw-resource-reference
+  name: chainsaw-external-secret
+  gvk:
+    group: ""
+    version: v1
+    kind: Secret

--- a/tests/e2e/chainsaw/03-resource-reference/resources/source-secret-replacement.yaml
+++ b/tests/e2e/chainsaw/03-resource-reference/resources/source-secret-replacement.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: chainsaw-external-secret-replacement
+  namespace: default
+  labels:
+    formance.com/stack: chainsaw-resource-reference
+  annotations:
+    chainsaw.formance.com/source: replacement
+type: Opaque
+stringData:
+  username: chainsaw
+  password: replacement

--- a/tests/e2e/chainsaw/03-resource-reference/resources/source-secret-updated.yaml
+++ b/tests/e2e/chainsaw/03-resource-reference/resources/source-secret-updated.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: chainsaw-external-secret
+  namespace: default
+  labels:
+    formance.com/stack: chainsaw-resource-reference
+  annotations:
+    chainsaw.formance.com/source: updated
+type: Opaque
+stringData:
+  username: chainsaw
+  password: updated
+  token: propagated

--- a/tests/e2e/chainsaw/03-resource-reference/resources/source-secret.yaml
+++ b/tests/e2e/chainsaw/03-resource-reference/resources/source-secret.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: chainsaw-external-secret
+  namespace: default
+  labels:
+    formance.com/stack: chainsaw-resource-reference
+  annotations:
+    chainsaw.formance.com/source: initial
+type: Opaque
+stringData:
+  username: chainsaw
+  password: initial

--- a/tests/e2e/chainsaw/03-resource-reference/resources/stack.yaml
+++ b/tests/e2e/chainsaw/03-resource-reference/resources/stack.yaml
@@ -1,0 +1,6 @@
+apiVersion: formance.com/v1beta1
+kind: Stack
+metadata:
+  name: chainsaw-resource-reference
+spec:
+  version: v0.0.0-e2e

--- a/tests/e2e/chainsaw/04-application-settings/asserts/deployment.yaml
+++ b/tests/e2e/chainsaw/04-application-settings/asserts/deployment.yaml
@@ -1,0 +1,73 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: gateway
+  namespace: chainsaw-application-settings
+  ownerReferences:
+    - apiVersion: formance.com/v1beta1
+      kind: Gateway
+      name: gateway
+spec:
+  replicas: 2
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  template:
+    metadata:
+      annotations:
+        chainsaw-template: "yes"
+        rollout-scope: application-settings
+    spec:
+      terminationGracePeriodSeconds: 17
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: ScheduleAnyway
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: DoNotSchedule
+      containers:
+        - name: gateway
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 100m
+              memory: 128Mi
+          securityContext:
+            runAsUser: 1001
+            runAsGroup: 1001
+            runAsNonRoot: true
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
+          env:
+            - name: CHAINSAW_SETTING
+              value: applied
+            - name: DEBUG
+              value: "false"
+            - name: DEV
+              value: "true"
+            - name: EXISTING
+              value: overridden
+            - name: GRACE_PERIOD
+              value: 30s
+            - name: STACK
+              value: chainsaw-application-settings
+            - name: STACK_URL
+              value: http://gateway:8080
+            - name: JSON_FORMATTING_LOGGER
+              value: "true"
+            - name: SEMCONV_METRICS_NAME
+              value: "true"
+            - name: NODE_IP
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: status.hostIP

--- a/tests/e2e/chainsaw/04-application-settings/asserts/service-and-pdb.yaml
+++ b/tests/e2e/chainsaw/04-application-settings/asserts/service-and-pdb.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: gateway
+  namespace: chainsaw-application-settings
+  annotations:
+    chainsaw-service: "yes"
+  ownerReferences:
+    - apiVersion: formance.com/v1beta1
+      kind: Gateway
+      name: gateway
+spec:
+  trafficDistribution: PreferClose
+  ports:
+    - name: http
+      port: 8080
+      targetPort: http
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: gateway
+  namespace: chainsaw-application-settings
+  ownerReferences:
+    - apiVersion: formance.com/v1beta1
+      kind: Gateway
+      name: gateway
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: gateway

--- a/tests/e2e/chainsaw/04-application-settings/chainsaw-test.yaml
+++ b/tests/e2e/chainsaw/04-application-settings/chainsaw-test.yaml
@@ -1,0 +1,26 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: application-settings
+  labels:
+    suite: settings
+    feature: application-settings
+spec:
+  concurrent: false
+  steps:
+    - name: gateway-shared-application-settings
+      try:
+        - apply:
+            file: resources/settings.yaml
+        - apply:
+            file: resources/stack.yaml
+        - apply:
+            file: resources/gateway.yaml
+        - assert:
+            file: asserts/deployment.yaml
+        - assert:
+            file: asserts/service-and-pdb.yaml
+      catch:
+        - script:
+            timeout: 2m
+            content: ../../scripts/dump-diagnostics.sh application-settings-gateway

--- a/tests/e2e/chainsaw/04-application-settings/resources/gateway.yaml
+++ b/tests/e2e/chainsaw/04-application-settings/resources/gateway.yaml
@@ -1,0 +1,7 @@
+apiVersion: formance.com/v1beta1
+kind: Gateway
+metadata:
+  name: gateway
+spec:
+  stack: chainsaw-application-settings
+  dev: true

--- a/tests/e2e/chainsaw/04-application-settings/resources/settings.yaml
+++ b/tests/e2e/chainsaw/04-application-settings/resources/settings.yaml
@@ -1,0 +1,139 @@
+apiVersion: formance.com/v1beta1
+kind: Settings
+metadata:
+  name: chainsaw-app-gateway-replicas
+spec:
+  stacks:
+    - chainsaw-application-settings
+  key: deployments.gateway.replicas
+  value: "2"
+---
+apiVersion: formance.com/v1beta1
+kind: Settings
+metadata:
+  name: chainsaw-app-gateway-template-annotations
+spec:
+  stacks:
+    - chainsaw-application-settings
+  key: deployments.gateway.spec.template.annotations
+  value: chainsaw-template=yes,rollout-scope=application-settings
+---
+apiVersion: formance.com/v1beta1
+kind: Settings
+metadata:
+  name: chainsaw-app-gateway-container-requests
+spec:
+  stacks:
+    - chainsaw-application-settings
+  key: deployments.gateway.containers.gateway.resource-requirements.requests
+  value: cpu=50m,memory=64Mi
+---
+apiVersion: formance.com/v1beta1
+kind: Settings
+metadata:
+  name: chainsaw-app-gateway-container-limits
+spec:
+  stacks:
+    - chainsaw-application-settings
+  key: deployments.gateway.containers.gateway.resource-requirements.limits
+  value: cpu=100m,memory=128Mi
+---
+apiVersion: formance.com/v1beta1
+kind: Settings
+metadata:
+  name: chainsaw-app-gateway-run-as
+spec:
+  stacks:
+    - chainsaw-application-settings
+  key: deployments.gateway.containers.gateway.run-as
+  value: user=1001,group=1001
+---
+apiVersion: formance.com/v1beta1
+kind: Settings
+metadata:
+  name: chainsaw-app-gateway-env
+spec:
+  stacks:
+    - chainsaw-application-settings
+  key: deployments.gateway.containers.gateway.env-vars
+  value: CHAINSAW_SETTING=applied,EXISTING=overridden
+---
+apiVersion: formance.com/v1beta1
+kind: Settings
+metadata:
+  name: chainsaw-app-gateway-topology
+spec:
+  stacks:
+    - chainsaw-application-settings
+  key: deployments.gateway.topology-spread-constraints
+  value: "true"
+---
+apiVersion: formance.com/v1beta1
+kind: Settings
+metadata:
+  name: chainsaw-app-gateway-semconv
+spec:
+  stacks:
+    - chainsaw-application-settings
+  key: deployments.gateway.semconv-metrics-names
+  value: "true"
+---
+apiVersion: formance.com/v1beta1
+kind: Settings
+metadata:
+  name: chainsaw-app-gateway-termination-grace
+spec:
+  stacks:
+    - chainsaw-application-settings
+  key: deployments.gateway.spec.template.spec.termination-grace-period-seconds
+  value: "17"
+---
+apiVersion: formance.com/v1beta1
+kind: Settings
+metadata:
+  name: chainsaw-app-gateway-pdb
+spec:
+  stacks:
+    - chainsaw-application-settings
+  key: deployments.gateway.pod-disruption-budget
+  value: minAvailable=1
+---
+apiVersion: formance.com/v1beta1
+kind: Settings
+metadata:
+  name: chainsaw-app-gateway-module-grace-period
+spec:
+  stacks:
+    - chainsaw-application-settings
+  key: modules.gateway.grace-period
+  value: 30s
+---
+apiVersion: formance.com/v1beta1
+kind: Settings
+metadata:
+  name: chainsaw-app-logging-json
+spec:
+  stacks:
+    - chainsaw-application-settings
+  key: logging.json
+  value: "true"
+---
+apiVersion: formance.com/v1beta1
+kind: Settings
+metadata:
+  name: chainsaw-app-service-annotations
+spec:
+  stacks:
+    - chainsaw-application-settings
+  key: services.gateway.annotations
+  value: chainsaw-service=yes
+---
+apiVersion: formance.com/v1beta1
+kind: Settings
+metadata:
+  name: chainsaw-app-service-traffic-distribution
+spec:
+  stacks:
+    - chainsaw-application-settings
+  key: services.gateway.traffic-distribution
+  value: PreferClose

--- a/tests/e2e/chainsaw/04-application-settings/resources/stack.yaml
+++ b/tests/e2e/chainsaw/04-application-settings/resources/stack.yaml
@@ -1,0 +1,6 @@
+apiVersion: formance.com/v1beta1
+kind: Stack
+metadata:
+  name: chainsaw-application-settings
+spec:
+  version: v0.0.0-e2e

--- a/tests/e2e/chainsaw/05-modules/authclient/asserts/inline-secret.yaml
+++ b/tests/e2e/chainsaw/05-modules/authclient/asserts/inline-secret.yaml
@@ -1,0 +1,21 @@
+apiVersion: formance.com/v1beta1
+kind: AuthClient
+metadata:
+  name: chainsaw-inline-client
+status:
+  ready: true
+  info: Up to date
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: auth-client-chainsaw-inline-client
+  namespace: chainsaw-authclient
+  ownerReferences:
+    - apiVersion: formance.com/v1beta1
+      kind: AuthClient
+      name: chainsaw-inline-client
+type: Opaque
+data:
+  id: aW5saW5lLWNsaWVudC1pZA==
+  secret: aW5saW5lLWNsaWVudC1zZWNyZXQ=

--- a/tests/e2e/chainsaw/05-modules/authclient/asserts/secret-from-secret.yaml
+++ b/tests/e2e/chainsaw/05-modules/authclient/asserts/secret-from-secret.yaml
@@ -1,0 +1,54 @@
+apiVersion: formance.com/v1beta1
+kind: AuthClient
+metadata:
+  name: chainsaw-referenced-client
+status:
+  ready: true
+  info: Up to date
+---
+apiVersion: formance.com/v1beta1
+kind: ResourceReference
+metadata:
+  name: chainsaw-referenced-client-client-secret
+  ownerReferences:
+    - apiVersion: formance.com/v1beta1
+      kind: AuthClient
+      name: chainsaw-referenced-client
+spec:
+  stack: chainsaw-authclient
+  name: chainsaw-authclient-source-secret
+  gvk:
+    group: ""
+    version: v1
+    kind: Secret
+status:
+  ready: true
+  syncedResource: chainsaw-authclient-source-secret
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: chainsaw-authclient-source-secret
+  namespace: chainsaw-authclient
+  annotations:
+    chainsaw.formance.com/source: authclient
+  ownerReferences:
+    - apiVersion: formance.com/v1beta1
+      kind: ResourceReference
+      name: chainsaw-referenced-client-client-secret
+type: Opaque
+data:
+  secret: cmVmZXJlbmNlZC1jbGllbnQtc2VjcmV0
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: auth-client-chainsaw-referenced-client
+  namespace: chainsaw-authclient
+  ownerReferences:
+    - apiVersion: formance.com/v1beta1
+      kind: AuthClient
+      name: chainsaw-referenced-client
+type: Opaque
+data:
+  id: cmVmZXJlbmNlZC1jbGllbnQtaWQ=

--- a/tests/e2e/chainsaw/05-modules/authclient/chainsaw-test.yaml
+++ b/tests/e2e/chainsaw/05-modules/authclient/chainsaw-test.yaml
@@ -1,0 +1,34 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: authclient-module
+  labels:
+    suite: modules
+    module: authclient
+spec:
+  concurrent: false
+  steps:
+    - name: inline-secret
+      try:
+        - apply:
+            file: resources/stack.yaml
+        - apply:
+            file: resources/authclient-inline.yaml
+        - assert:
+            file: asserts/inline-secret.yaml
+      catch:
+        - script:
+            timeout: 2m
+            content: ../../../scripts/dump-diagnostics.sh authclient-inline
+    - name: secret-from-secret
+      try:
+        - apply:
+            file: resources/source-secret.yaml
+        - apply:
+            file: resources/authclient-from-secret.yaml
+        - assert:
+            file: asserts/secret-from-secret.yaml
+      catch:
+        - script:
+            timeout: 2m
+            content: ../../../scripts/dump-diagnostics.sh authclient-from-secret

--- a/tests/e2e/chainsaw/05-modules/authclient/resources/authclient-from-secret.yaml
+++ b/tests/e2e/chainsaw/05-modules/authclient/resources/authclient-from-secret.yaml
@@ -1,0 +1,10 @@
+apiVersion: formance.com/v1beta1
+kind: AuthClient
+metadata:
+  name: chainsaw-referenced-client
+spec:
+  stack: chainsaw-authclient
+  id: referenced-client-id
+  secretFromSecret:
+    name: chainsaw-authclient-source-secret
+    key: secret

--- a/tests/e2e/chainsaw/05-modules/authclient/resources/authclient-inline.yaml
+++ b/tests/e2e/chainsaw/05-modules/authclient/resources/authclient-inline.yaml
@@ -1,0 +1,16 @@
+apiVersion: formance.com/v1beta1
+kind: AuthClient
+metadata:
+  name: chainsaw-inline-client
+spec:
+  stack: chainsaw-authclient
+  id: inline-client-id
+  secret: inline-client-secret
+  description: Inline client exercised by Chainsaw
+  redirectUris:
+    - https://example.com/callback
+  postLogoutRedirectUris:
+    - https://example.com/logout
+  scopes:
+    - ledger:read
+    - payments:read

--- a/tests/e2e/chainsaw/05-modules/authclient/resources/source-secret.yaml
+++ b/tests/e2e/chainsaw/05-modules/authclient/resources/source-secret.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: chainsaw-authclient-source-secret
+  namespace: default
+  labels:
+    formance.com/stack: chainsaw-authclient
+  annotations:
+    chainsaw.formance.com/source: authclient
+type: Opaque
+stringData:
+  secret: referenced-client-secret

--- a/tests/e2e/chainsaw/05-modules/authclient/resources/stack.yaml
+++ b/tests/e2e/chainsaw/05-modules/authclient/resources/stack.yaml
@@ -1,0 +1,6 @@
+apiVersion: formance.com/v1beta1
+kind: Stack
+metadata:
+  name: chainsaw-authclient
+spec:
+  version: v0.0.0-e2e

--- a/tests/e2e/chainsaw/05-modules/gateway/asserts/ingress-updated-hosts.yaml
+++ b/tests/e2e/chainsaw/05-modules/gateway/asserts/ingress-updated-hosts.yaml
@@ -1,0 +1,77 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: gateway
+  namespace: chainsaw-gateway
+  labels:
+    settings-label: "yes"
+    app.kubernetes.io/component: gateway
+    app.kubernetes.io/name: chainsaw-gateway
+  annotations:
+    settings-annotation: "yes"
+    spec-annotation: "yes"
+  ownerReferences:
+    - apiVersion: formance.com/v1beta1
+      kind: Gateway
+      name: gateway
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: gateway.chainsaw.local
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: gateway
+                port:
+                  name: http
+    - host: api.chainsaw.local
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: gateway
+                port:
+                  name: http
+    - host: extra.chainsaw.local
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: gateway
+                port:
+                  name: http
+    - host: updated.chainsaw-gateway.settings.local
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: gateway
+                port:
+                  name: http
+    - host: api-updated.chainsaw.local
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: gateway
+                port:
+                  name: http
+  tls:
+    - secretName: gateway-tls
+      hosts:
+        - gateway.chainsaw.local
+        - api.chainsaw.local
+        - extra.chainsaw.local
+        - updated.chainsaw-gateway.settings.local
+        - api-updated.chainsaw.local

--- a/tests/e2e/chainsaw/05-modules/gateway/asserts/ingress.yaml
+++ b/tests/e2e/chainsaw/05-modules/gateway/asserts/ingress.yaml
@@ -1,0 +1,66 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: gateway
+  namespace: chainsaw-gateway
+  labels:
+    settings-label: "yes"
+    app.kubernetes.io/component: gateway
+    app.kubernetes.io/name: chainsaw-gateway
+  annotations:
+    settings-annotation: "yes"
+    spec-annotation: "yes"
+  ownerReferences:
+    - apiVersion: formance.com/v1beta1
+      kind: Gateway
+      name: gateway
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: gateway.chainsaw.local
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: gateway
+                port:
+                  name: http
+    - host: api.chainsaw.local
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: gateway
+                port:
+                  name: http
+    - host: extra.chainsaw.local
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: gateway
+                port:
+                  name: http
+    - host: chainsaw-gateway.settings.local
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: gateway
+                port:
+                  name: http
+  tls:
+    - secretName: gateway-tls
+      hosts:
+        - gateway.chainsaw.local
+        - api.chainsaw.local
+        - extra.chainsaw.local
+        - chainsaw-gateway.settings.local

--- a/tests/e2e/chainsaw/05-modules/gateway/chainsaw-test.yaml
+++ b/tests/e2e/chainsaw/05-modules/gateway/chainsaw-test.yaml
@@ -1,0 +1,53 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: gateway-module
+  labels:
+    suite: modules
+    module: gateway
+spec:
+  concurrent: false
+  steps:
+    - name: ingress-from-spec-and-settings
+      try:
+        - apply:
+            file: resources/settings.yaml
+        - apply:
+            file: resources/stack.yaml
+        - apply:
+            file: resources/gateway.yaml
+        - assert:
+            file: asserts/ingress.yaml
+        - script:
+            timeout: 2m
+            content: |
+              set -eu
+              kubectl get configmap gateway -n chainsaw-gateway -o jsonpath='{.data.Caddyfile}' > /tmp/chainsaw-gateway-caddyfile
+              grep -F 'trusted_proxies 10.0.0.0/8 192.168.0.0/16' /tmp/chainsaw-gateway-caddyfile
+              grep -F 'trusted_proxies_strict' /tmp/chainsaw-gateway-caddyfile
+              grep -F 'idle 45s' /tmp/chainsaw-gateway-caddyfile
+      catch:
+        - script:
+            timeout: 2m
+            content: ../../../scripts/dump-diagnostics.sh gateway-module-ingress
+    - name: ingress-hosts-mutation
+      try:
+        - apply:
+            file: resources/settings-updated-hosts.yaml
+        - assert:
+            file: asserts/ingress-updated-hosts.yaml
+      catch:
+        - script:
+            timeout: 2m
+            content: ../../../scripts/dump-diagnostics.sh gateway-module-hosts-mutation
+    - name: ingress-removal
+      try:
+        - script:
+            timeout: 2m
+            content: |
+              kubectl patch gateway gateway --type=json -p='[{"op":"remove","path":"/spec/ingress"}]'
+              kubectl wait --for=delete ingress/gateway -n chainsaw-gateway --timeout=2m
+      catch:
+        - script:
+            timeout: 2m
+            content: ../../../scripts/dump-diagnostics.sh gateway-module-ingress-removal

--- a/tests/e2e/chainsaw/05-modules/gateway/resources/gateway.yaml
+++ b/tests/e2e/chainsaw/05-modules/gateway/resources/gateway.yaml
@@ -1,0 +1,15 @@
+apiVersion: formance.com/v1beta1
+kind: Gateway
+metadata:
+  name: gateway
+spec:
+  stack: chainsaw-gateway
+  dev: true
+  ingress:
+    host: gateway.chainsaw.local
+    hosts:
+      - api.chainsaw.local
+      - extra.chainsaw.local
+    scheme: https
+    annotations:
+      spec-annotation: "yes"

--- a/tests/e2e/chainsaw/05-modules/gateway/resources/settings-updated-hosts.yaml
+++ b/tests/e2e/chainsaw/05-modules/gateway/resources/settings-updated-hosts.yaml
@@ -1,0 +1,9 @@
+apiVersion: formance.com/v1beta1
+kind: Settings
+metadata:
+  name: chainsaw-gateway-ingress-hosts
+spec:
+  stacks:
+    - chainsaw-gateway
+  key: gateway.ingress.hosts
+  value: "updated.{stack}.settings.local, api-updated.chainsaw.local"

--- a/tests/e2e/chainsaw/05-modules/gateway/resources/settings.yaml
+++ b/tests/e2e/chainsaw/05-modules/gateway/resources/settings.yaml
@@ -1,0 +1,79 @@
+apiVersion: formance.com/v1beta1
+kind: Settings
+metadata:
+  name: chainsaw-gateway-ingress-hosts
+spec:
+  stacks:
+    - chainsaw-gateway
+  key: gateway.ingress.hosts
+  value: "{stack}.settings.local, api.chainsaw.local"
+---
+apiVersion: formance.com/v1beta1
+kind: Settings
+metadata:
+  name: chainsaw-gateway-ingress-annotations
+spec:
+  stacks:
+    - chainsaw-gateway
+  key: gateway.ingress.annotations
+  value: settings-annotation=yes
+---
+apiVersion: formance.com/v1beta1
+kind: Settings
+metadata:
+  name: chainsaw-gateway-ingress-labels
+spec:
+  stacks:
+    - chainsaw-gateway
+  key: gateway.ingress.labels
+  value: settings-label=yes
+---
+apiVersion: formance.com/v1beta1
+kind: Settings
+metadata:
+  name: chainsaw-gateway-ingress-class
+spec:
+  stacks:
+    - chainsaw-gateway
+  key: gateway.ingress.class
+  value: nginx
+---
+apiVersion: formance.com/v1beta1
+kind: Settings
+metadata:
+  name: chainsaw-gateway-ingress-tls
+spec:
+  stacks:
+    - chainsaw-gateway
+  key: gateway.ingress.tls.enabled
+  value: "true"
+---
+apiVersion: formance.com/v1beta1
+kind: Settings
+metadata:
+  name: chainsaw-gateway-trusted-proxies
+spec:
+  stacks:
+    - chainsaw-gateway
+  key: gateway.caddyfile.trusted-proxies
+  value: 10.0.0.0/8,192.168.0.0/16
+---
+apiVersion: formance.com/v1beta1
+kind: Settings
+metadata:
+  name: chainsaw-gateway-trusted-proxies-strict
+spec:
+  stacks:
+    - chainsaw-gateway
+  key: gateway.caddyfile.trusted-proxies-strict
+  value: "true"
+---
+apiVersion: formance.com/v1beta1
+kind: Settings
+metadata:
+  name: chainsaw-gateway-idle-timeout
+spec:
+  stacks:
+    - chainsaw-gateway
+  key: gateway.config.idle-timeout
+  value: 45s

--- a/tests/e2e/chainsaw/05-modules/gateway/resources/stack.yaml
+++ b/tests/e2e/chainsaw/05-modules/gateway/resources/stack.yaml
@@ -1,0 +1,6 @@
+apiVersion: formance.com/v1beta1
+kind: Stack
+metadata:
+  name: chainsaw-gateway
+spec:
+  version: v0.0.0-e2e

--- a/tests/e2e/chainsaw/06-core-dependency/chainsaw-test.yaml
+++ b/tests/e2e/chainsaw/06-core-dependency/chainsaw-test.yaml
@@ -1,0 +1,73 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: core-dependency
+  labels:
+    suite: core
+    feature: stack-dependency
+spec:
+  concurrent: false
+  steps:
+    - name: missing-stack-reports-application-error
+      try:
+        - apply:
+            file: resources/gateway-missing-stack.yaml
+        - script:
+            timeout: 2m
+            content: |
+              set -eu
+              until test "$(kubectl get gateway chainsaw-missing-stack -o jsonpath='{.status.info}')" = "stack not found"; do
+                sleep 1
+              done
+      catch:
+        - script:
+            timeout: 2m
+            content: ../../scripts/dump-diagnostics.sh core-dependency-missing-stack
+    - name: skipped-stack-does-not-install-module
+      try:
+        - apply:
+            file: resources/stack-skipped.yaml
+        - apply:
+            file: resources/gateway.yaml
+        - script:
+            timeout: 2m
+            content: |
+              set -eu
+              kubectl wait --for=jsonpath='{.status.conditions[?(@.type=="ReconciledWithStack")].reason}'=Skipped gateway/gateway --timeout=2m
+              if kubectl get deployment gateway -n chainsaw-core-dependency >/dev/null 2>&1; then
+                echo "gateway deployment should not exist while stack is skipped"
+                exit 1
+              fi
+      catch:
+        - script:
+            timeout: 2m
+            content: ../../scripts/dump-diagnostics.sh core-dependency-skipped-stack
+    - name: unlocking-stack-installs-module
+      try:
+        - script:
+            timeout: 2m
+            content: |
+              set -eu
+              kubectl annotate stack chainsaw-core-dependency formance.com/skip- --overwrite
+              kubectl wait --for=jsonpath='{.status.conditions[?(@.type=="ReconciledWithStack")].reason}'=Spec gateway/gateway --timeout=2m
+              kubectl get configmap gateway -n chainsaw-core-dependency
+              kubectl get deployment gateway -n chainsaw-core-dependency
+              kubectl get service gateway -n chainsaw-core-dependency
+      catch:
+        - script:
+            timeout: 2m
+            content: ../../scripts/dump-diagnostics.sh core-dependency-unlocked-stack
+    - name: disabled-stack-removes-module-owned-objects
+      try:
+        - script:
+            timeout: 2m
+            content: |
+              set -eu
+              kubectl patch stack chainsaw-core-dependency --type=merge -p '{"spec":{"disabled":true}}'
+              kubectl wait --for=delete configmap/gateway -n chainsaw-core-dependency --timeout=2m
+              kubectl wait --for=delete deployment/gateway -n chainsaw-core-dependency --timeout=2m
+              kubectl wait --for=delete service/gateway -n chainsaw-core-dependency --timeout=2m
+      catch:
+        - script:
+            timeout: 2m
+            content: ../../scripts/dump-diagnostics.sh core-dependency-disabled-stack

--- a/tests/e2e/chainsaw/06-core-dependency/resources/gateway-missing-stack.yaml
+++ b/tests/e2e/chainsaw/06-core-dependency/resources/gateway-missing-stack.yaml
@@ -1,0 +1,7 @@
+apiVersion: formance.com/v1beta1
+kind: Gateway
+metadata:
+  name: chainsaw-missing-stack
+spec:
+  stack: chainsaw-missing-stack
+  dev: true

--- a/tests/e2e/chainsaw/06-core-dependency/resources/gateway.yaml
+++ b/tests/e2e/chainsaw/06-core-dependency/resources/gateway.yaml
@@ -1,0 +1,7 @@
+apiVersion: formance.com/v1beta1
+kind: Gateway
+metadata:
+  name: gateway
+spec:
+  stack: chainsaw-core-dependency
+  dev: true

--- a/tests/e2e/chainsaw/06-core-dependency/resources/stack-skipped.yaml
+++ b/tests/e2e/chainsaw/06-core-dependency/resources/stack-skipped.yaml
@@ -1,0 +1,8 @@
+apiVersion: formance.com/v1beta1
+kind: Stack
+metadata:
+  name: chainsaw-core-dependency
+  annotations:
+    formance.com/skip: "true"
+spec:
+  version: v1.0.0

--- a/tests/e2e/chainsaw/07-negative-settings/chainsaw-test.yaml
+++ b/tests/e2e/chainsaw/07-negative-settings/chainsaw-test.yaml
@@ -1,0 +1,71 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: negative-settings
+  labels:
+    suite: settings
+    feature: negative-settings
+spec:
+  concurrent: false
+  steps:
+    - name: missing-required-database-setting
+      try:
+        - apply:
+            file: resources/stack.yaml
+        - apply:
+            file: resources/database.yaml
+        - script:
+            timeout: 2m
+            content: |
+              set -eu
+              while true; do
+                info="$(kubectl get database chainsaw-negative-settings-ledger -o jsonpath='{.status.info}')"
+                case "$info" in
+                  *"settings 'postgres.ledger.uri' not found for stack 'chainsaw-negative-settings'"*) break ;;
+                  *) sleep 1 ;;
+                esac
+              done
+      catch:
+        - script:
+            timeout: 2m
+            content: ../../scripts/dump-diagnostics.sh negative-settings-missing-database-setting
+    - name: invalid-typed-application-setting
+      try:
+        - apply:
+            file: resources/bad-replica-setting.yaml
+        - apply:
+            file: resources/gateway.yaml
+        - script:
+            timeout: 2m
+            content: |
+              set -eu
+              while true; do
+                info="$(kubectl get gateway chainsaw-negative-gateway -o jsonpath='{.status.info}')"
+                case "$info" in
+                  *'strconv.ParseInt: parsing "not-a-number": invalid syntax'*) break ;;
+                  *) sleep 1 ;;
+                esac
+              done
+              if kubectl get deployment gateway -n chainsaw-negative-settings >/dev/null 2>&1; then
+                echo "gateway deployment should not exist while replicas setting is invalid"
+                exit 1
+              fi
+      catch:
+        - script:
+            timeout: 2m
+            content: ../../scripts/dump-diagnostics.sh negative-settings-invalid-application-setting
+    - name: fixing-typed-setting-reconciles-application
+      try:
+        - apply:
+            file: resources/good-replica-setting.yaml
+        - script:
+            timeout: 2m
+            content: |
+              set -eu
+              kubectl wait --for=jsonpath='{.status.conditions[?(@.type=="ReconciledWithStack")].reason}'=Spec gateway/chainsaw-negative-gateway --timeout=2m
+              kubectl get deployment gateway -n chainsaw-negative-settings
+              test "$(kubectl get deployment gateway -n chainsaw-negative-settings -o jsonpath='{.spec.replicas}')" = "1"
+      catch:
+        - script:
+            timeout: 2m
+            content: ../../scripts/dump-diagnostics.sh negative-settings-fixed-application-setting

--- a/tests/e2e/chainsaw/07-negative-settings/resources/bad-replica-setting.yaml
+++ b/tests/e2e/chainsaw/07-negative-settings/resources/bad-replica-setting.yaml
@@ -1,0 +1,9 @@
+apiVersion: formance.com/v1beta1
+kind: Settings
+metadata:
+  name: chainsaw-negative-gateway-replicas
+spec:
+  stacks:
+    - chainsaw-negative-settings
+  key: deployments.gateway.replicas
+  value: not-a-number

--- a/tests/e2e/chainsaw/07-negative-settings/resources/database.yaml
+++ b/tests/e2e/chainsaw/07-negative-settings/resources/database.yaml
@@ -1,0 +1,7 @@
+apiVersion: formance.com/v1beta1
+kind: Database
+metadata:
+  name: chainsaw-negative-settings-ledger
+spec:
+  stack: chainsaw-negative-settings
+  service: ledger

--- a/tests/e2e/chainsaw/07-negative-settings/resources/gateway.yaml
+++ b/tests/e2e/chainsaw/07-negative-settings/resources/gateway.yaml
@@ -1,0 +1,7 @@
+apiVersion: formance.com/v1beta1
+kind: Gateway
+metadata:
+  name: chainsaw-negative-gateway
+spec:
+  stack: chainsaw-negative-settings
+  dev: true

--- a/tests/e2e/chainsaw/07-negative-settings/resources/good-replica-setting.yaml
+++ b/tests/e2e/chainsaw/07-negative-settings/resources/good-replica-setting.yaml
@@ -1,0 +1,9 @@
+apiVersion: formance.com/v1beta1
+kind: Settings
+metadata:
+  name: chainsaw-negative-gateway-replicas
+spec:
+  stacks:
+    - chainsaw-negative-settings
+  key: deployments.gateway.replicas
+  value: "1"

--- a/tests/e2e/chainsaw/07-negative-settings/resources/stack.yaml
+++ b/tests/e2e/chainsaw/07-negative-settings/resources/stack.yaml
@@ -1,0 +1,6 @@
+apiVersion: formance.com/v1beta1
+kind: Stack
+metadata:
+  name: chainsaw-negative-settings
+spec:
+  version: v1.0.0

--- a/tests/e2e/chainsaw/08-versioning-registry/chainsaw-test.yaml
+++ b/tests/e2e/chainsaw/08-versioning-registry/chainsaw-test.yaml
@@ -1,0 +1,79 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: versioning-registry
+  labels:
+    suite: stack
+    feature: versioning-registry
+spec:
+  concurrent: false
+  steps:
+    - name: versions-from-file-and-registry-settings
+      try:
+        - apply:
+            file: resources/versions.yaml
+        - apply:
+            file: resources/registry-settings.yaml
+        - apply:
+            file: resources/stack.yaml
+        - apply:
+            file: resources/gateway.yaml
+        - script:
+            timeout: 2m
+            content: |
+              set -eu
+              kubectl wait --for=jsonpath='{.spec.template.spec.containers[0].image}'=mirror.chainsaw.local/custom/gateway:v2.3.4 deployment/gateway -n chainsaw-versioning --timeout=2m
+              test "$(kubectl get deployment gateway -n chainsaw-versioning -o jsonpath='{.spec.template.spec.imagePullSecrets[0].name}')" = "chainsaw-regcred"
+      catch:
+        - script:
+            timeout: 2m
+            content: ../../scripts/dump-diagnostics.sh versioning-registry-from-file
+    - name: stack-version-overrides-versions-file
+      try:
+        - script:
+            timeout: 2m
+            content: |
+              set -eu
+              kubectl patch stack chainsaw-versioning --type=merge -p '{"spec":{"version":"v3.0.0"}}'
+              kubectl wait --for=jsonpath='{.spec.template.spec.containers[0].image}'=mirror.chainsaw.local/custom/gateway:v3.0.0 deployment/gateway -n chainsaw-versioning --timeout=2m
+      catch:
+        - script:
+            timeout: 2m
+            content: ../../scripts/dump-diagnostics.sh versioning-registry-stack-priority
+    - name: module-version-overrides-stack-version
+      try:
+        - script:
+            timeout: 2m
+            content: |
+              set -eu
+              kubectl patch gateway chainsaw-versioning-gateway --type=merge -p '{"spec":{"version":"v4.0.0"}}'
+              kubectl wait --for=jsonpath='{.spec.template.spec.containers[0].image}'=mirror.chainsaw.local/custom/gateway:v4.0.0 deployment/gateway -n chainsaw-versioning --timeout=2m
+      catch:
+        - script:
+            timeout: 2m
+            content: ../../scripts/dump-diagnostics.sh versioning-registry-module-priority
+    - name: missing-version-reports-explicit-error
+      try:
+        - apply:
+            file: resources/stack-without-version.yaml
+        - apply:
+            file: resources/gateway-without-version.yaml
+        - script:
+            timeout: 2m
+            content: |
+              set -eu
+              while true; do
+                info="$(kubectl get gateway chainsaw-version-missing-gateway -o jsonpath='{.status.info}')"
+                case "$info" in
+                  *"no version found for module gateway on stack chainsaw-version-missing"*) break ;;
+                  *) sleep 1 ;;
+                esac
+              done
+              if kubectl get deployment gateway -n chainsaw-version-missing >/dev/null 2>&1; then
+                echo "gateway deployment should not exist without any resolvable version"
+                exit 1
+              fi
+      catch:
+        - script:
+            timeout: 2m
+            content: ../../scripts/dump-diagnostics.sh versioning-registry-missing-version

--- a/tests/e2e/chainsaw/08-versioning-registry/resources/gateway-without-version.yaml
+++ b/tests/e2e/chainsaw/08-versioning-registry/resources/gateway-without-version.yaml
@@ -1,0 +1,7 @@
+apiVersion: formance.com/v1beta1
+kind: Gateway
+metadata:
+  name: chainsaw-version-missing-gateway
+spec:
+  stack: chainsaw-version-missing
+  dev: true

--- a/tests/e2e/chainsaw/08-versioning-registry/resources/gateway.yaml
+++ b/tests/e2e/chainsaw/08-versioning-registry/resources/gateway.yaml
@@ -1,0 +1,7 @@
+apiVersion: formance.com/v1beta1
+kind: Gateway
+metadata:
+  name: chainsaw-versioning-gateway
+spec:
+  stack: chainsaw-versioning
+  dev: true

--- a/tests/e2e/chainsaw/08-versioning-registry/resources/registry-settings.yaml
+++ b/tests/e2e/chainsaw/08-versioning-registry/resources/registry-settings.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: formance.com/v1beta1
+kind: Settings
+metadata:
+  name: chainsaw-registry-endpoint
+spec:
+  stacks:
+    - chainsaw-versioning
+  key: registries."ghcr.io".endpoint
+  value: mirror.chainsaw.local?pullSecret=chainsaw-regcred
+---
+apiVersion: formance.com/v1beta1
+kind: Settings
+metadata:
+  name: chainsaw-registry-gateway-rewrite
+spec:
+  stacks:
+    - chainsaw-versioning
+  key: registries."ghcr.io".images."formancehq/gateway".rewrite
+  value: custom/gateway

--- a/tests/e2e/chainsaw/08-versioning-registry/resources/stack-without-version.yaml
+++ b/tests/e2e/chainsaw/08-versioning-registry/resources/stack-without-version.yaml
@@ -1,0 +1,5 @@
+apiVersion: formance.com/v1beta1
+kind: Stack
+metadata:
+  name: chainsaw-version-missing
+spec: {}

--- a/tests/e2e/chainsaw/08-versioning-registry/resources/stack.yaml
+++ b/tests/e2e/chainsaw/08-versioning-registry/resources/stack.yaml
@@ -1,0 +1,6 @@
+apiVersion: formance.com/v1beta1
+kind: Stack
+metadata:
+  name: chainsaw-versioning
+spec:
+  versionsFromFile: chainsaw-versions

--- a/tests/e2e/chainsaw/08-versioning-registry/resources/versions.yaml
+++ b/tests/e2e/chainsaw/08-versioning-registry/resources/versions.yaml
@@ -1,0 +1,6 @@
+apiVersion: formance.com/v1beta1
+kind: Versions
+metadata:
+  name: chainsaw-versions
+spec:
+  gateway: v2.3.4

--- a/tests/e2e/chainsaw/09-observability/chainsaw-test.yaml
+++ b/tests/e2e/chainsaw/09-observability/chainsaw-test.yaml
@@ -1,0 +1,43 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: observability
+  labels:
+    suite: infrastructure
+    feature: observability
+spec:
+  concurrent: false
+  steps:
+    - name: gateway-opentelemetry-traces-settings
+      try:
+        - apply:
+            file: resources/settings.yaml
+        - apply:
+            file: resources/stack.yaml
+        - apply:
+            file: resources/gateway.yaml
+        - script:
+            timeout: 2m
+            content: |
+              set -eu
+              kubectl wait --for=jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="OTEL_TRACES")].value}'=true deployment/gateway -n chainsaw-observability --timeout=2m
+              kubectl get deployment gateway -n chainsaw-observability -o jsonpath='{range .spec.template.spec.containers[0].env[*]}{.name}={.value}{"\n"}{end}' > /tmp/chainsaw-observability-env
+              grep -Fx 'OTEL_TRACES=true' /tmp/chainsaw-observability-env
+              grep -Fx 'OTEL_TRACES_BATCH=true' /tmp/chainsaw-observability-env
+              grep -Fx 'OTEL_TRACES_EXPORTER=otlp' /tmp/chainsaw-observability-env
+              grep -Fx 'OTEL_TRACES_EXPORTER_OTLP_INSECURE=true' /tmp/chainsaw-observability-env
+              grep -Fx 'OTEL_TRACES_EXPORTER_OTLP_MODE=grpc' /tmp/chainsaw-observability-env
+              grep -Fx 'OTEL_TRACES_ENDPOINT=otel-collector.chainsaw' /tmp/chainsaw-observability-env
+              grep -Fx 'OTEL_TRACES_PORT=4317' /tmp/chainsaw-observability-env
+              grep -Fx 'OTEL_TRACES_EXPORTER_OTLP_ENDPOINT=$(OTEL_TRACES_ENDPOINT):$(OTEL_TRACES_PORT)' /tmp/chainsaw-observability-env
+              grep -Fx 'OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=http://$(OTEL_TRACES_EXPORTER_OTLP_ENDPOINT)' /tmp/chainsaw-observability-env
+              grep -Fx 'OTEL_EXPORTER_OTLP_PROTOCOL=$(OTEL_TRACES_EXPORTER_OTLP_MODE)' /tmp/chainsaw-observability-env
+              grep -Fx 'OTEL_SERVICE_NAME=gateway' /tmp/chainsaw-observability-env
+              grep -Fx 'OTEL_RESOURCE_ATTRIBUTES=pod-name=$(POD_NAME),service.namespace=formance,stack=chainsaw-observability,team=platform' /tmp/chainsaw-observability-env
+              kubectl get configmap gateway -n chainsaw-observability -o jsonpath='{.data.Caddyfile}' > /tmp/chainsaw-observability-caddyfile
+              grep -F 'tracing {' /tmp/chainsaw-observability-caddyfile
+              grep -F 'span gateway' /tmp/chainsaw-observability-caddyfile
+      catch:
+        - script:
+            timeout: 2m
+            content: ../../scripts/dump-diagnostics.sh observability-gateway-traces

--- a/tests/e2e/chainsaw/09-observability/resources/gateway.yaml
+++ b/tests/e2e/chainsaw/09-observability/resources/gateway.yaml
@@ -1,0 +1,7 @@
+apiVersion: formance.com/v1beta1
+kind: Gateway
+metadata:
+  name: chainsaw-observability-gateway
+spec:
+  stack: chainsaw-observability
+  dev: true

--- a/tests/e2e/chainsaw/09-observability/resources/settings.yaml
+++ b/tests/e2e/chainsaw/09-observability/resources/settings.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: formance.com/v1beta1
+kind: Settings
+metadata:
+  name: chainsaw-otel-traces-dsn
+spec:
+  stacks:
+    - chainsaw-observability
+  key: opentelemetry.traces.dsn
+  value: grpc://otel-collector.chainsaw:4317?insecure=true
+---
+apiVersion: formance.com/v1beta1
+kind: Settings
+metadata:
+  name: chainsaw-otel-traces-resource-attributes
+spec:
+  stacks:
+    - chainsaw-observability
+  key: opentelemetry.traces.resource-attributes
+  value: team=platform,service.namespace=formance

--- a/tests/e2e/chainsaw/09-observability/resources/stack.yaml
+++ b/tests/e2e/chainsaw/09-observability/resources/stack.yaml
@@ -1,0 +1,6 @@
+apiVersion: formance.com/v1beta1
+kind: Stack
+metadata:
+  name: chainsaw-observability
+spec:
+  version: v1.0.0

--- a/tests/e2e/chainsaw/10-gatewayhttpapi-sync/chainsaw-test.yaml
+++ b/tests/e2e/chainsaw/10-gatewayhttpapi-sync/chainsaw-test.yaml
@@ -1,0 +1,85 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: gateway-httpapi-sync
+  labels:
+    suite: modules
+    feature: gateway-httpapi-sync
+spec:
+  concurrent: false
+  steps:
+    - name: gateway-renders-httpapi-routes
+      try:
+        - apply:
+            file: resources/stack.yaml
+        - apply:
+            file: resources/gateway.yaml
+        - apply:
+            file: resources/httpapis.yaml
+        - script:
+            timeout: 2m
+            content: |
+              kubectl apply -f resources/httpapi-payments.yaml
+        - script:
+            timeout: 2m
+            content: |
+              set -eu
+              kubectl wait --for=jsonpath='{.status.ready}'=true gatewayhttpapi/chainsaw-httpapi-ledger --timeout=2m
+              kubectl wait --for=jsonpath='{.status.ready}'=true gatewayhttpapi/chainsaw-httpapi-payments --timeout=2m
+              kubectl wait --for=jsonpath='{.status.syncHTTPAPIs[0]}'=ledger gateway/chainsaw-httpapi-gateway --timeout=2m
+              test "$(kubectl get gateway chainsaw-httpapi-gateway -o jsonpath='{.status.syncHTTPAPIs[*]}')" = "ledger payments"
+              test "$(kubectl get service ledger -n chainsaw-httpapi-sync -o jsonpath='{.spec.ports[0].port}')" = "8080"
+              test "$(kubectl get service payments -n chainsaw-httpapi-sync -o jsonpath='{.spec.selector.app\.kubernetes\.io/name}')" = "payments"
+              kubectl get configmap gateway -n chainsaw-httpapi-sync -o jsonpath='{.data.Caddyfile}' > /tmp/chainsaw-httpapi-caddyfile
+              grep -F 'handle /api/ledger/transactions* {' /tmp/chainsaw-httpapi-caddyfile
+              grep -F 'method GET POST' /tmp/chainsaw-httpapi-caddyfile
+              grep -F 'reverse_proxy ledger:8080' /tmp/chainsaw-httpapi-caddyfile
+              grep -F 'handle /api/payments/connectors* {' /tmp/chainsaw-httpapi-caddyfile
+              grep -F 'method GET' /tmp/chainsaw-httpapi-caddyfile
+              grep -F 'reverse_proxy payments:8080' /tmp/chainsaw-httpapi-caddyfile
+      catch:
+        - script:
+            timeout: 2m
+            content: ../../scripts/dump-diagnostics.sh gateway-httpapi-routes
+    - name: httpapi-mutation-reconfigures-gateway
+      try:
+        - apply:
+            file: resources/httpapis-updated.yaml
+        - script:
+            timeout: 2m
+            content: |
+              set -eu
+              until kubectl get configmap gateway -n chainsaw-httpapi-sync -o jsonpath='{.data.Caddyfile}' | grep -F 'handle /api/ledger/v2/transactions* {'; do
+                sleep 1
+              done
+              kubectl get configmap gateway -n chainsaw-httpapi-sync -o jsonpath='{.data.Caddyfile}' > /tmp/chainsaw-httpapi-caddyfile
+              grep -F 'method PATCH' /tmp/chainsaw-httpapi-caddyfile
+              grep -F 'http://ledger:8080/_info http://ledger:8080/_live' /tmp/chainsaw-httpapi-caddyfile
+              if grep -F 'handle /api/ledger/transactions* {' /tmp/chainsaw-httpapi-caddyfile; then
+                echo "old ledger route should not remain after GatewayHTTPAPI mutation"
+                exit 1
+              fi
+      catch:
+        - script:
+            timeout: 2m
+            content: ../../scripts/dump-diagnostics.sh gateway-httpapi-mutation
+    - name: httpapi-deletion-reconfigures-gateway
+      try:
+        - script:
+            timeout: 2m
+            content: |
+              set -eu
+              kubectl delete gatewayhttpapi chainsaw-httpapi-payments
+              kubectl wait --for=delete service/payments -n chainsaw-httpapi-sync --timeout=2m
+              until test "$(kubectl get gateway chainsaw-httpapi-gateway -o jsonpath='{.status.syncHTTPAPIs[*]}')" = "ledger"; do
+                sleep 1
+              done
+              kubectl get configmap gateway -n chainsaw-httpapi-sync -o jsonpath='{.data.Caddyfile}' > /tmp/chainsaw-httpapi-caddyfile
+              if grep -F 'payments' /tmp/chainsaw-httpapi-caddyfile; then
+                echo "deleted GatewayHTTPAPI should not remain in gateway Caddyfile"
+                exit 1
+              fi
+      catch:
+        - script:
+            timeout: 2m
+            content: ../../scripts/dump-diagnostics.sh gateway-httpapi-deletion

--- a/tests/e2e/chainsaw/10-gatewayhttpapi-sync/resources/gateway.yaml
+++ b/tests/e2e/chainsaw/10-gatewayhttpapi-sync/resources/gateway.yaml
@@ -1,0 +1,7 @@
+apiVersion: formance.com/v1beta1
+kind: Gateway
+metadata:
+  name: chainsaw-httpapi-gateway
+spec:
+  stack: chainsaw-httpapi-sync
+  dev: true

--- a/tests/e2e/chainsaw/10-gatewayhttpapi-sync/resources/httpapi-payments.yaml
+++ b/tests/e2e/chainsaw/10-gatewayhttpapi-sync/resources/httpapi-payments.yaml
@@ -1,0 +1,12 @@
+apiVersion: formance.com/v1beta1
+kind: GatewayHTTPAPI
+metadata:
+  name: chainsaw-httpapi-payments
+spec:
+  stack: chainsaw-httpapi-sync
+  name: payments
+  healthCheckEndpoint: _healthcheck
+  rules:
+    - path: /connectors
+      methods:
+        - GET

--- a/tests/e2e/chainsaw/10-gatewayhttpapi-sync/resources/httpapis-updated.yaml
+++ b/tests/e2e/chainsaw/10-gatewayhttpapi-sync/resources/httpapis-updated.yaml
@@ -1,0 +1,12 @@
+apiVersion: formance.com/v1beta1
+kind: GatewayHTTPAPI
+metadata:
+  name: chainsaw-httpapi-ledger
+spec:
+  stack: chainsaw-httpapi-sync
+  name: ledger
+  healthCheckEndpoint: _live
+  rules:
+    - path: /v2/transactions
+      methods:
+        - PATCH

--- a/tests/e2e/chainsaw/10-gatewayhttpapi-sync/resources/httpapis.yaml
+++ b/tests/e2e/chainsaw/10-gatewayhttpapi-sync/resources/httpapis.yaml
@@ -1,0 +1,16 @@
+apiVersion: formance.com/v1beta1
+kind: GatewayHTTPAPI
+metadata:
+  name: chainsaw-httpapi-ledger
+spec:
+  stack: chainsaw-httpapi-sync
+  name: ledger
+  healthCheckEndpoint: _healthcheck
+  rules:
+    - path: /transactions
+      methods:
+        - GET
+        - POST
+    - path: /accounts
+      methods:
+        - GET

--- a/tests/e2e/chainsaw/10-gatewayhttpapi-sync/resources/stack.yaml
+++ b/tests/e2e/chainsaw/10-gatewayhttpapi-sync/resources/stack.yaml
@@ -1,0 +1,6 @@
+apiVersion: formance.com/v1beta1
+kind: Stack
+metadata:
+  name: chainsaw-httpapi-sync
+spec:
+  version: v0.0.0-e2e

--- a/tests/e2e/chainsaw/11-broker-dependencies/chainsaw-test.yaml
+++ b/tests/e2e/chainsaw/11-broker-dependencies/chainsaw-test.yaml
@@ -1,0 +1,72 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: broker-dependencies
+  labels:
+    suite: infrastructure
+    feature: broker-dependencies
+spec:
+  concurrent: false
+  steps:
+    - name: broker-reports-missing-dsn
+      try:
+        - apply:
+            file: resources/stack.yaml
+        - script:
+            timeout: 2m
+            content: |
+              kubectl apply -f resources/broker.yaml
+        - script:
+            timeout: 2m
+            content: |
+              set -eu
+              expected="settings 'broker.dsn' not found for stack 'chainsaw-broker-dependencies'"
+              until test "$(kubectl get broker chainsaw-broker-dependencies -o jsonpath='{.status.info}')" = "$expected"; do
+                sleep 1
+              done
+              if test "$(kubectl get broker chainsaw-broker-dependencies -o jsonpath='{.status.ready}')" = "true"; then
+                echo "broker should not be ready without broker.dsn"
+                exit 1
+              fi
+      catch:
+        - script:
+            timeout: 2m
+            content: ../../scripts/dump-diagnostics.sh broker-missing-dsn
+    - name: consumer-creates-topic-but-waits-on-broker
+      try:
+        - apply:
+            file: resources/consumer.yaml
+        - script:
+            timeout: 2m
+            content: |
+              set -eu
+              until test "$(kubectl get brokertopic chainsaw-broker-dependencies-ledger -o jsonpath='{.status.info}')" = "broker not ready"; do
+                sleep 1
+              done
+              until test "$(kubectl get brokerconsumer chainsaw-broker-consumer -o jsonpath='{.status.conditions[?(@.type=="BrokerTopicCreated")].status}')" = "False"; do
+                sleep 1
+              done
+              test "$(kubectl get brokertopic chainsaw-broker-dependencies-ledger -o jsonpath='{.spec.service}')" = "ledger"
+              test "$(kubectl get brokertopic chainsaw-broker-dependencies-ledger -o jsonpath='{.spec.stack}')" = "chainsaw-broker-dependencies"
+              if test "$(kubectl get brokerconsumer chainsaw-broker-consumer -o jsonpath='{.status.ready}')" = "true"; then
+                echo "broker consumer should not be ready while its broker topic waits on broker"
+                exit 1
+              fi
+      catch:
+        - script:
+            timeout: 2m
+            content: ../../scripts/dump-diagnostics.sh broker-consumer-topic-wait
+    - name: cleanup-broker-finalizer
+      try:
+        - script:
+            timeout: 2m
+            content: |
+              set -eu
+              if kubectl get broker chainsaw-broker-dependencies >/dev/null 2>&1; then
+                kubectl patch broker chainsaw-broker-dependencies --type=merge -p '{"metadata":{"finalizers":[]}}'
+                kubectl delete broker chainsaw-broker-dependencies --wait=true --timeout=2m
+              fi
+      catch:
+        - script:
+            timeout: 2m
+            content: ../../scripts/dump-diagnostics.sh broker-cleanup

--- a/tests/e2e/chainsaw/11-broker-dependencies/resources/broker.yaml
+++ b/tests/e2e/chainsaw/11-broker-dependencies/resources/broker.yaml
@@ -1,0 +1,6 @@
+apiVersion: formance.com/v1beta1
+kind: Broker
+metadata:
+  name: chainsaw-broker-dependencies
+spec:
+  stack: chainsaw-broker-dependencies

--- a/tests/e2e/chainsaw/11-broker-dependencies/resources/consumer.yaml
+++ b/tests/e2e/chainsaw/11-broker-dependencies/resources/consumer.yaml
@@ -1,0 +1,9 @@
+apiVersion: formance.com/v1beta1
+kind: BrokerConsumer
+metadata:
+  name: chainsaw-broker-consumer
+spec:
+  stack: chainsaw-broker-dependencies
+  services:
+    - ledger
+  queriedBy: orchestration

--- a/tests/e2e/chainsaw/11-broker-dependencies/resources/stack.yaml
+++ b/tests/e2e/chainsaw/11-broker-dependencies/resources/stack.yaml
@@ -1,0 +1,6 @@
+apiVersion: formance.com/v1beta1
+kind: Stack
+metadata:
+  name: chainsaw-broker-dependencies
+spec:
+  version: v0.0.0-e2e

--- a/tests/e2e/chainsaw/12-postgres-database/chainsaw-test.yaml
+++ b/tests/e2e/chainsaw/12-postgres-database/chainsaw-test.yaml
@@ -1,0 +1,58 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: postgres-database
+  labels:
+    suite: infrastructure
+    feature: postgres-database
+spec:
+  concurrent: false
+  steps:
+    - name: real-postgres-database-create
+      try:
+        - apply:
+            file: resources/source-secret.yaml
+        - apply:
+            file: resources/stack.yaml
+        - apply:
+            file: resources/postgres.yaml
+        - apply:
+            file: resources/settings.yaml
+        - apply:
+            file: resources/database.yaml
+        - script:
+            timeout: 5m
+            content: |
+              set -eu
+              kubectl rollout status deployment/postgres -n chainsaw-postgres --timeout=2m
+              kubectl wait --for=jsonpath='{.status.ready}'=true resourcereference/chainsaw-postgres-ledger-postgres --timeout=2m
+              kubectl wait --for=jsonpath='{.status.ready}'=true database/chainsaw-postgres-ledger --timeout=5m
+              test "$(kubectl get database chainsaw-postgres-ledger -o jsonpath='{.status.database}')" = "chainsaw-postgres-ledger"
+              test "$(kubectl get secret postgres -n chainsaw-postgres -o jsonpath='{.data.username}')" = "Zm9ybWFuY2U="
+              job="$(kubectl get job -n chainsaw-postgres -o jsonpath='{.items[?(@.metadata.ownerReferences[0].name=="chainsaw-postgres-ledger")].metadata.name}')"
+              test -n "$job"
+              test "$(kubectl get job "$job" -n chainsaw-postgres -o jsonpath='{.status.succeeded}')" = "1"
+              test "$(kubectl get job "$job" -n chainsaw-postgres -o jsonpath='{.spec.template.spec.containers[0].image}')" = "ghcr.io/formancehq/operator-utils:e2e"
+              kubectl exec -n chainsaw-postgres deploy/postgres -- \
+                psql -U formance -d postgres -tAc "SELECT 1 FROM pg_database WHERE datname = 'chainsaw-postgres-ledger'" \
+                | grep -Fx "1"
+      catch:
+        - script:
+            timeout: 2m
+            content: ../../scripts/dump-diagnostics.sh postgres-database-create
+    - name: postgres-host-mutation-marks-out-of-sync
+      try:
+        - apply:
+            file: resources/settings-updated-host.yaml
+        - script:
+            timeout: 2m
+            content: |
+              set -eu
+              kubectl wait --for=jsonpath='{.status.outOfSync}'=true database/chainsaw-postgres-ledger --timeout=2m
+              kubectl exec -n chainsaw-postgres deploy/postgres -- \
+                psql -U formance -d postgres -tAc "SELECT 1 FROM pg_database WHERE datname = 'chainsaw-postgres-ledger'" \
+                | grep -Fx "1"
+      catch:
+        - script:
+            timeout: 2m
+            content: ../../scripts/dump-diagnostics.sh postgres-database-out-of-sync

--- a/tests/e2e/chainsaw/12-postgres-database/resources/database.yaml
+++ b/tests/e2e/chainsaw/12-postgres-database/resources/database.yaml
@@ -1,0 +1,7 @@
+apiVersion: formance.com/v1beta1
+kind: Database
+metadata:
+  name: chainsaw-postgres-ledger
+spec:
+  stack: chainsaw-postgres
+  service: ledger

--- a/tests/e2e/chainsaw/12-postgres-database/resources/postgres.yaml
+++ b/tests/e2e/chainsaw/12-postgres-database/resources/postgres.yaml
@@ -1,0 +1,50 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres
+  namespace: chainsaw-postgres
+spec:
+  selector:
+    app.kubernetes.io/name: postgres
+  ports:
+    - name: postgres
+      port: 5432
+      targetPort: postgres
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: postgres
+  namespace: chainsaw-postgres
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: postgres
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: postgres
+    spec:
+      containers:
+        - name: postgres
+          image: postgres:15-alpine
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: postgres
+              containerPort: 5432
+          env:
+            - name: POSTGRES_USER
+              value: formance
+            - name: POSTGRES_PASSWORD
+              value: formance
+            - name: POSTGRES_DB
+              value: postgres
+          readinessProbe:
+            exec:
+              command:
+                - pg_isready
+                - -U
+                - formance
+            initialDelaySeconds: 2
+            periodSeconds: 2

--- a/tests/e2e/chainsaw/12-postgres-database/resources/settings-updated-host.yaml
+++ b/tests/e2e/chainsaw/12-postgres-database/resources/settings-updated-host.yaml
@@ -1,0 +1,9 @@
+apiVersion: formance.com/v1beta1
+kind: Settings
+metadata:
+  name: chainsaw-postgres-ledger-uri
+spec:
+  stacks:
+    - chainsaw-postgres
+  key: postgres.ledger.uri
+  value: postgresql://postgres-alt.chainsaw-postgres.svc.cluster.local:5432?secret=postgres&disableSSLMode=true

--- a/tests/e2e/chainsaw/12-postgres-database/resources/settings.yaml
+++ b/tests/e2e/chainsaw/12-postgres-database/resources/settings.yaml
@@ -1,0 +1,9 @@
+apiVersion: formance.com/v1beta1
+kind: Settings
+metadata:
+  name: chainsaw-postgres-ledger-uri
+spec:
+  stacks:
+    - chainsaw-postgres
+  key: postgres.ledger.uri
+  value: postgresql://postgres.chainsaw-postgres.svc.cluster.local:5432?secret=postgres&disableSSLMode=true

--- a/tests/e2e/chainsaw/12-postgres-database/resources/source-secret.yaml
+++ b/tests/e2e/chainsaw/12-postgres-database/resources/source-secret.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: chainsaw-postgres-credentials
+  namespace: default
+  labels:
+    formance.com/stack: chainsaw-postgres
+  annotations:
+    formance.com/referenced-by-name: postgres
+type: Opaque
+stringData:
+  username: formance
+  password: formance

--- a/tests/e2e/chainsaw/12-postgres-database/resources/stack.yaml
+++ b/tests/e2e/chainsaw/12-postgres-database/resources/stack.yaml
@@ -1,0 +1,6 @@
+apiVersion: formance.com/v1beta1
+kind: Stack
+metadata:
+  name: chainsaw-postgres
+spec:
+  version: v0.0.0-e2e

--- a/tests/e2e/chainsaw/13-nats-broker/chainsaw-test.yaml
+++ b/tests/e2e/chainsaw/13-nats-broker/chainsaw-test.yaml
@@ -30,7 +30,7 @@ spec:
               test -n "$job"
               test "$(kubectl get job "$job" -n chainsaw-nats -o jsonpath='{.spec.template.spec.containers[0].image}')" = "docker.io/natsio/nats-box:0.19.2"
               kubectl run nats-check-stream -n chainsaw-nats --image=docker.io/natsio/nats-box:0.19.2 --restart=Never --rm -i --command -- \
-                sh -c "nats --server nats://nats.chainsaw-nats.svc.cluster.local:4222 stream info --no-select chainsaw-nats >/dev/null"
+                sh -c "nats --server nats://nats.chainsaw-nats.svc.cluster.local:4222 stream info chainsaw-nats --no-select >/dev/null"
         - apply:
             file: resources/consumer.yaml
         - script:
@@ -42,7 +42,7 @@ spec:
               test "$(kubectl get brokerconsumer chainsaw-nats-consumer -o jsonpath='{.status.conditions[?(@.type=="BrokerTopicCreated")].status}')" = "True"
               test "$(kubectl get brokerconsumer chainsaw-nats-consumer -o jsonpath='{.status.conditions[?(@.type=="NatsStackConsumerCreated")].status}')" = "True"
               kubectl run nats-check-consumer -n chainsaw-nats --image=docker.io/natsio/nats-box:0.19.2 --restart=Never --rm -i --command -- \
-                sh -c "nats --server nats://nats.chainsaw-nats.svc.cluster.local:4222 consumer info --no-select chainsaw-nats gateway_audit >/dev/null"
+                sh -c "nats --server nats://nats.chainsaw-nats.svc.cluster.local:4222 consumer info chainsaw-nats gateway_audit --no-select >/dev/null"
       catch:
         - script:
             timeout: 2m

--- a/tests/e2e/chainsaw/13-nats-broker/chainsaw-test.yaml
+++ b/tests/e2e/chainsaw/13-nats-broker/chainsaw-test.yaml
@@ -30,7 +30,7 @@ spec:
               test -n "$job"
               test "$(kubectl get job "$job" -n chainsaw-nats -o jsonpath='{.spec.template.spec.containers[0].image}')" = "docker.io/natsio/nats-box:0.19.2"
               kubectl run nats-check-stream -n chainsaw-nats --image=docker.io/natsio/nats-box:0.19.2 --restart=Never --rm -i --command -- \
-                sh -c "nats --server nats://nats.chainsaw-nats.svc.cluster.local:4222 stream ls --names | grep -Fx chainsaw-nats"
+                sh -c "nats --server nats://nats.chainsaw-nats.svc.cluster.local:4222 stream info --no-select chainsaw-nats >/dev/null"
         - apply:
             file: resources/consumer.yaml
         - script:
@@ -42,7 +42,7 @@ spec:
               test "$(kubectl get brokerconsumer chainsaw-nats-consumer -o jsonpath='{.status.conditions[?(@.type=="BrokerTopicCreated")].status}')" = "True"
               test "$(kubectl get brokerconsumer chainsaw-nats-consumer -o jsonpath='{.status.conditions[?(@.type=="NatsStackConsumerCreated")].status}')" = "True"
               kubectl run nats-check-consumer -n chainsaw-nats --image=docker.io/natsio/nats-box:0.19.2 --restart=Never --rm -i --command -- \
-                sh -c "nats --server nats://nats.chainsaw-nats.svc.cluster.local:4222 consumer ls chainsaw-nats --names | grep -Fx gateway_audit"
+                sh -c "nats --server nats://nats.chainsaw-nats.svc.cluster.local:4222 consumer info --no-select chainsaw-nats gateway_audit >/dev/null"
       catch:
         - script:
             timeout: 2m

--- a/tests/e2e/chainsaw/13-nats-broker/chainsaw-test.yaml
+++ b/tests/e2e/chainsaw/13-nats-broker/chainsaw-test.yaml
@@ -1,0 +1,63 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: nats-broker
+  labels:
+    suite: infrastructure
+    feature: nats-broker
+spec:
+  concurrent: false
+  steps:
+    - name: real-nats-broker-and-consumer
+      try:
+        - apply:
+            file: resources/stack.yaml
+        - apply:
+            file: resources/nats.yaml
+        - apply:
+            file: resources/settings.yaml
+        - apply:
+            file: resources/broker.yaml
+        - script:
+            timeout: 5m
+            content: |
+              set -eu
+              kubectl rollout status deployment/nats -n chainsaw-nats --timeout=2m
+              kubectl wait --for=jsonpath='{.status.ready}'=true broker/chainsaw-nats --timeout=5m
+              test "$(kubectl get broker chainsaw-nats -o jsonpath='{.status.mode}')" = "OneStreamByStack"
+              test "$(kubectl get broker chainsaw-nats -o jsonpath='{.status.uri}')" = "nats://nats.chainsaw-nats.svc.cluster.local:4222?replicas=1"
+              job="$(kubectl get job -n chainsaw-nats -o jsonpath='{.items[?(@.metadata.ownerReferences[0].name=="chainsaw-nats")].metadata.name}' | tr ' ' '\n' | grep -E 'create-stream|detect-mode' | head -n1)"
+              test -n "$job"
+              test "$(kubectl get job "$job" -n chainsaw-nats -o jsonpath='{.spec.template.spec.containers[0].image}')" = "docker.io/natsio/nats-box:0.19.2"
+              kubectl run nats-check-stream -n chainsaw-nats --image=docker.io/natsio/nats-box:0.19.2 --restart=Never --rm -i --command -- \
+                sh -c "nats --server nats://nats.chainsaw-nats.svc.cluster.local:4222 stream ls --names | grep -Fx chainsaw-nats"
+        - apply:
+            file: resources/consumer.yaml
+        - script:
+            timeout: 5m
+            content: |
+              set -eu
+              kubectl wait --for=jsonpath='{.status.ready}'=true brokertopic/chainsaw-nats-ledger --timeout=2m
+              kubectl wait --for=jsonpath='{.status.ready}'=true brokerconsumer/chainsaw-nats-consumer --timeout=5m
+              test "$(kubectl get brokerconsumer chainsaw-nats-consumer -o jsonpath='{.status.conditions[?(@.type=="BrokerTopicCreated")].status}')" = "True"
+              test "$(kubectl get brokerconsumer chainsaw-nats-consumer -o jsonpath='{.status.conditions[?(@.type=="NatsStackConsumerCreated")].status}')" = "True"
+              kubectl run nats-check-consumer -n chainsaw-nats --image=docker.io/natsio/nats-box:0.19.2 --restart=Never --rm -i --command -- \
+                sh -c "nats --server nats://nats.chainsaw-nats.svc.cluster.local:4222 consumer ls chainsaw-nats --names | grep -Fx gateway_audit"
+      catch:
+        - script:
+            timeout: 2m
+            content: ../../scripts/dump-diagnostics.sh nats-broker
+    - name: cleanup-broker-finalizer
+      try:
+        - script:
+            timeout: 2m
+            content: |
+              set -eu
+              if kubectl get broker chainsaw-nats >/dev/null 2>&1; then
+                kubectl patch broker chainsaw-nats --type=merge -p '{"metadata":{"finalizers":[]}}'
+                kubectl delete broker chainsaw-nats --wait=true --timeout=2m
+              fi
+      catch:
+        - script:
+            timeout: 2m
+            content: ../../scripts/dump-diagnostics.sh nats-broker-cleanup

--- a/tests/e2e/chainsaw/13-nats-broker/resources/broker.yaml
+++ b/tests/e2e/chainsaw/13-nats-broker/resources/broker.yaml
@@ -1,0 +1,6 @@
+apiVersion: formance.com/v1beta1
+kind: Broker
+metadata:
+  name: chainsaw-nats
+spec:
+  stack: chainsaw-nats

--- a/tests/e2e/chainsaw/13-nats-broker/resources/consumer.yaml
+++ b/tests/e2e/chainsaw/13-nats-broker/resources/consumer.yaml
@@ -1,0 +1,10 @@
+apiVersion: formance.com/v1beta1
+kind: BrokerConsumer
+metadata:
+  name: chainsaw-nats-consumer
+spec:
+  stack: chainsaw-nats
+  services:
+    - ledger
+  queriedBy: gateway
+  name: audit

--- a/tests/e2e/chainsaw/13-nats-broker/resources/nats.yaml
+++ b/tests/e2e/chainsaw/13-nats-broker/resources/nats.yaml
@@ -1,0 +1,47 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: nats
+  namespace: chainsaw-nats
+spec:
+  selector:
+    app.kubernetes.io/name: nats
+  ports:
+    - name: client
+      port: 4222
+      targetPort: client
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nats
+  namespace: chainsaw-nats
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: nats
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: nats
+    spec:
+      containers:
+        - name: nats
+          image: nats:2.10-alpine
+          imagePullPolicy: IfNotPresent
+          args:
+            - -js
+            - -m
+            - "8222"
+          ports:
+            - name: client
+              containerPort: 4222
+            - name: monitor
+              containerPort: 8222
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: monitor
+            initialDelaySeconds: 2
+            periodSeconds: 2

--- a/tests/e2e/chainsaw/13-nats-broker/resources/settings.yaml
+++ b/tests/e2e/chainsaw/13-nats-broker/resources/settings.yaml
@@ -1,0 +1,9 @@
+apiVersion: formance.com/v1beta1
+kind: Settings
+metadata:
+  name: chainsaw-nats-broker-dsn
+spec:
+  stacks:
+    - chainsaw-nats
+  key: broker.dsn
+  value: nats://nats.chainsaw-nats.svc.cluster.local:4222?replicas=1

--- a/tests/e2e/chainsaw/13-nats-broker/resources/stack.yaml
+++ b/tests/e2e/chainsaw/13-nats-broker/resources/stack.yaml
@@ -1,0 +1,6 @@
+apiVersion: formance.com/v1beta1
+kind: Stack
+metadata:
+  name: chainsaw-nats
+spec:
+  version: v3.0.0

--- a/tests/e2e/chainsaw/14-ledger-module/chainsaw-test.yaml
+++ b/tests/e2e/chainsaw/14-ledger-module/chainsaw-test.yaml
@@ -1,0 +1,119 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: ledger-module
+  labels:
+    suite: modules
+    feature: ledger-module
+spec:
+  concurrent: false
+  steps:
+    - name: ledger-renders-postgres-broker-and-settings
+      try:
+        - apply:
+            file: resources/source-secret.yaml
+        - apply:
+            file: resources/stack.yaml
+        - apply:
+            file: resources/postgres.yaml
+        - apply:
+            file: resources/nats.yaml
+        - apply:
+            file: resources/settings.yaml
+        - apply:
+            file: resources/database.yaml
+        - apply:
+            file: resources/broker.yaml
+        - apply:
+            file: resources/brokertopic.yaml
+        - script:
+            timeout: 5m
+            content: |
+              set -eu
+              kubectl rollout status deployment/postgres -n chainsaw-ledger --timeout=2m
+              kubectl rollout status deployment/nats -n chainsaw-ledger --timeout=2m
+              kubectl wait --for=jsonpath='{.status.ready}'=true database/chainsaw-ledger-ledger --timeout=5m
+              kubectl wait --for=jsonpath='{.status.ready}'=true broker/chainsaw-ledger --timeout=5m
+              kubectl wait --for=jsonpath='{.status.ready}'=true brokertopic/chainsaw-ledger-ledger --timeout=2m
+        - apply:
+            file: resources/ledger.yaml
+        - script:
+            timeout: 5m
+            content: |
+              set -eu
+              kubectl wait --for=jsonpath='{.spec.template.spec.containers[0].image}'=ghcr.io/formancehq/ledger:v3.0.0 deployment/ledger -n chainsaw-ledger --timeout=2m
+              kubectl wait --for=jsonpath='{.spec.template.spec.containers[0].image}'=ghcr.io/formancehq/ledger:v3.0.0 deployment/ledger-worker -n chainsaw-ledger --timeout=2m
+              kubectl wait --for=jsonpath='{.spec.ports[0].port}'=8080 service/ledger -n chainsaw-ledger --timeout=2m
+              kubectl wait --for=jsonpath='{.spec.ports[0].port}'=8081 service/ledger-worker -n chainsaw-ledger --timeout=2m
+              kubectl wait --for=jsonpath='{.status.ready}'=true gatewayhttpapi/chainsaw-ledger-ledger --timeout=2m
+              assert_jsonpath() {
+                resource="$1"
+                path="$2"
+                expected="$3"
+                actual="$(kubectl get "$resource" -n chainsaw-ledger -o "jsonpath=${path}")"
+                if test "$actual" != "$expected"; then
+                  echo "expected ${resource} ${path} to be '${expected}', got '${actual}'" >&2
+                  exit 1
+                fi
+              }
+              kubectl get deployment ledger -n chainsaw-ledger -o jsonpath='{range .spec.template.spec.containers[0].env[*]}{.name}={.value}{"\n"}{end}' > /tmp/chainsaw-ledger-api-env
+              grep -Fx 'BIND=:8080' /tmp/chainsaw-ledger-api-env
+              grep -Fx 'EXPERIMENTAL_FEATURES=true' /tmp/chainsaw-ledger-api-env
+              grep -Fx 'EXPERIMENTAL_NUMSCRIPT_INTERPRETER=true' /tmp/chainsaw-ledger-api-env
+              grep -Fx 'EXPERIMENTAL_NUMSCRIPT_INTERPRETER_FLAGS=trace strict' /tmp/chainsaw-ledger-api-env
+              grep -Fx 'DEFAULT_PAGE_SIZE=50' /tmp/chainsaw-ledger-api-env
+              grep -Fx 'MAX_PAGE_SIZE=1000' /tmp/chainsaw-ledger-api-env
+              grep -Fx 'BULK_MAX_SIZE=200' /tmp/chainsaw-ledger-api-env
+              grep -Fx 'SCHEMA_ENFORCEMENT_MODE=permissive' /tmp/chainsaw-ledger-api-env
+              grep -Fx 'POSTGRES_HOST=postgres.chainsaw-ledger.svc.cluster.local' /tmp/chainsaw-ledger-api-env
+              grep -Fx 'POSTGRES_PORT=5432' /tmp/chainsaw-ledger-api-env
+              grep -Fx 'POSTGRES_DATABASE=chainsaw-ledger-ledger' /tmp/chainsaw-ledger-api-env
+              grep -Fx 'POSTGRES_URI=$(POSTGRES_NO_DATABASE_URI)/$(POSTGRES_DATABASE)?sslmode=disable' /tmp/chainsaw-ledger-api-env
+              grep -Fx 'STORAGE_POSTGRES_CONN_STRING=$(POSTGRES_URI)' /tmp/chainsaw-ledger-api-env
+              grep -Fx 'STORAGE_DRIVER=postgres' /tmp/chainsaw-ledger-api-env
+              grep -Fx 'BROKER=nats' /tmp/chainsaw-ledger-api-env
+              grep -Fx 'PUBLISHER_NATS_ENABLED=true' /tmp/chainsaw-ledger-api-env
+              grep -Fx 'PUBLISHER_NATS_URL=nats.chainsaw-ledger.svc.cluster.local:4222' /tmp/chainsaw-ledger-api-env
+              grep -Fx 'PUBLISHER_TOPIC_MAPPING=*:chainsaw-ledger.ledger' /tmp/chainsaw-ledger-api-env
+              grep -Fx 'PUBLISHER_NATS_AUTO_PROVISION=false' /tmp/chainsaw-ledger-api-env
+              grep -Fx 'JSON_FORMATTING_LOGGER=true' /tmp/chainsaw-ledger-api-env
+              grep -Fx 'GRACE_PERIOD=30s' /tmp/chainsaw-ledger-api-env
+              grep -Fx 'OTEL_TRACES=true' /tmp/chainsaw-ledger-api-env
+              grep -Fx 'OTEL_SERVICE_NAME=ledger' /tmp/chainsaw-ledger-api-env
+              grep -Fx 'OTEL_RESOURCE_ATTRIBUTES=pod-name=$(POD_NAME) service.namespace=formance stack=chainsaw-ledger team=platform' /tmp/chainsaw-ledger-api-env
+              assert_jsonpath deployment/ledger '{.spec.replicas}' '2'
+              assert_jsonpath deployment/ledger '{.spec.template.spec.containers[0].resources.requests.cpu}' '25m'
+              assert_jsonpath deployment/ledger '{.spec.template.spec.containers[0].resources.limits.memory}' '256Mi'
+              assert_jsonpath deployment/ledger '{.spec.template.spec.containers[0].securityContext.runAsUser}' '10001'
+              assert_jsonpath deployment/ledger '{.spec.template.metadata.annotations.chainsaw\.formance\.com/template}' 'ledger'
+              assert_jsonpath pdb/ledger '{.spec.minAvailable}' '1'
+              assert_jsonpath service/ledger '{.metadata.annotations.chainsaw\.formance\.com/service}' 'ledger'
+              kubectl get deployment ledger-worker -n chainsaw-ledger -o jsonpath='{range .spec.template.spec.containers[0].env[*]}{.name}={.value}{"\n"}{end}' > /tmp/chainsaw-ledger-worker-env
+              grep -Fx 'WORKER_ASYNC_BLOCK_HASHER_MAX_BLOCK_SIZE=1000' /tmp/chainsaw-ledger-worker-env
+              grep -Fx 'WORKER_ASYNC_BLOCK_HASHER_SCHEDULE=*/5 * * * *' /tmp/chainsaw-ledger-worker-env
+              grep -Fx 'WORKER_PIPELINES_PULL_INTERVAL=1s' /tmp/chainsaw-ledger-worker-env
+              grep -Fx 'WORKER_PIPELINES_PUSH_RETRY_PERIOD=2s' /tmp/chainsaw-ledger-worker-env
+              grep -Fx 'WORKER_PIPELINES_SYNC_PERIOD=3s' /tmp/chainsaw-ledger-worker-env
+              grep -Fx 'WORKER_PIPELINES_LOGS_PAGE_SIZE=42' /tmp/chainsaw-ledger-worker-env
+              grep -Fx 'WORKER_BUCKET_CLEANUP_RETENTION_PERIOD=24h' /tmp/chainsaw-ledger-worker-env
+              grep -Fx 'WORKER_BUCKET_CLEANUP_SCHEDULE=0 * * * *' /tmp/chainsaw-ledger-worker-env
+              assert_jsonpath deployment/ledger-worker '{.spec.strategy.type}' 'Recreate'
+              assert_jsonpath deployment/ledger-worker '{.spec.template.spec.containers[0].ports[0].containerPort}' '8081'
+      catch:
+        - script:
+            timeout: 2m
+            content: ../../scripts/dump-diagnostics.sh ledger-module
+    - name: cleanup-broker-finalizer
+      try:
+        - script:
+            timeout: 2m
+            content: |
+              set -eu
+              if kubectl get broker chainsaw-ledger >/dev/null 2>&1; then
+                kubectl patch broker chainsaw-ledger --type=merge -p '{"metadata":{"finalizers":[]}}'
+                kubectl delete broker chainsaw-ledger --wait=true --timeout=2m
+              fi
+      catch:
+        - script:
+            timeout: 2m
+            content: ../../scripts/dump-diagnostics.sh ledger-module-cleanup

--- a/tests/e2e/chainsaw/14-ledger-module/resources/broker.yaml
+++ b/tests/e2e/chainsaw/14-ledger-module/resources/broker.yaml
@@ -1,0 +1,6 @@
+apiVersion: formance.com/v1beta1
+kind: Broker
+metadata:
+  name: chainsaw-ledger
+spec:
+  stack: chainsaw-ledger

--- a/tests/e2e/chainsaw/14-ledger-module/resources/brokertopic.yaml
+++ b/tests/e2e/chainsaw/14-ledger-module/resources/brokertopic.yaml
@@ -1,0 +1,7 @@
+apiVersion: formance.com/v1beta1
+kind: BrokerTopic
+metadata:
+  name: chainsaw-ledger-ledger
+spec:
+  stack: chainsaw-ledger
+  service: ledger

--- a/tests/e2e/chainsaw/14-ledger-module/resources/database.yaml
+++ b/tests/e2e/chainsaw/14-ledger-module/resources/database.yaml
@@ -1,0 +1,9 @@
+apiVersion: formance.com/v1beta1
+kind: Database
+metadata:
+  name: chainsaw-ledger-ledger
+  annotations:
+    formance.com/module-version: v3.0.0
+spec:
+  stack: chainsaw-ledger
+  service: ledger

--- a/tests/e2e/chainsaw/14-ledger-module/resources/ledger.yaml
+++ b/tests/e2e/chainsaw/14-ledger-module/resources/ledger.yaml
@@ -1,0 +1,6 @@
+apiVersion: formance.com/v1beta1
+kind: Ledger
+metadata:
+  name: ledger
+spec:
+  stack: chainsaw-ledger

--- a/tests/e2e/chainsaw/14-ledger-module/resources/nats.yaml
+++ b/tests/e2e/chainsaw/14-ledger-module/resources/nats.yaml
@@ -1,0 +1,47 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: nats
+  namespace: chainsaw-ledger
+spec:
+  selector:
+    app.kubernetes.io/name: nats
+  ports:
+    - name: client
+      port: 4222
+      targetPort: client
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nats
+  namespace: chainsaw-ledger
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: nats
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: nats
+    spec:
+      containers:
+        - name: nats
+          image: nats:2.10-alpine
+          imagePullPolicy: IfNotPresent
+          args:
+            - -js
+            - -m
+            - "8222"
+          ports:
+            - name: client
+              containerPort: 4222
+            - name: monitor
+              containerPort: 8222
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: monitor
+            initialDelaySeconds: 2
+            periodSeconds: 2

--- a/tests/e2e/chainsaw/14-ledger-module/resources/postgres.yaml
+++ b/tests/e2e/chainsaw/14-ledger-module/resources/postgres.yaml
@@ -1,0 +1,50 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres
+  namespace: chainsaw-ledger
+spec:
+  selector:
+    app.kubernetes.io/name: postgres
+  ports:
+    - name: postgres
+      port: 5432
+      targetPort: postgres
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: postgres
+  namespace: chainsaw-ledger
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: postgres
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: postgres
+    spec:
+      containers:
+        - name: postgres
+          image: postgres:15-alpine
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: postgres
+              containerPort: 5432
+          env:
+            - name: POSTGRES_USER
+              value: formance
+            - name: POSTGRES_PASSWORD
+              value: formance
+            - name: POSTGRES_DB
+              value: postgres
+          readinessProbe:
+            exec:
+              command:
+                - pg_isready
+                - -U
+                - formance
+            initialDelaySeconds: 2
+            periodSeconds: 2

--- a/tests/e2e/chainsaw/14-ledger-module/resources/settings.yaml
+++ b/tests/e2e/chainsaw/14-ledger-module/resources/settings.yaml
@@ -1,0 +1,249 @@
+apiVersion: formance.com/v1beta1
+kind: Settings
+metadata:
+  name: chainsaw-ledger-postgres-uri
+spec:
+  stacks:
+    - chainsaw-ledger
+  key: postgres.ledger.uri
+  value: postgresql://postgres.chainsaw-ledger.svc.cluster.local:5432?secret=postgres&disableSSLMode=true
+---
+apiVersion: formance.com/v1beta1
+kind: Settings
+metadata:
+  name: chainsaw-ledger-broker-dsn
+spec:
+  stacks:
+    - chainsaw-ledger
+  key: broker.dsn
+  value: nats://nats.chainsaw-ledger.svc.cluster.local:4222?replicas=1
+---
+apiVersion: formance.com/v1beta1
+kind: Settings
+metadata:
+  name: chainsaw-ledger-experimental-features
+spec:
+  stacks:
+    - chainsaw-ledger
+  key: ledger.experimental-features
+  value: "true"
+---
+apiVersion: formance.com/v1beta1
+kind: Settings
+metadata:
+  name: chainsaw-ledger-experimental-numscript
+spec:
+  stacks:
+    - chainsaw-ledger
+  key: ledger.experimental-numscript
+  value: "true"
+---
+apiVersion: formance.com/v1beta1
+kind: Settings
+metadata:
+  name: chainsaw-ledger-experimental-numscript-flags
+spec:
+  stacks:
+    - chainsaw-ledger
+  key: ledger.experimental-numscript-flags
+  value: trace,strict
+---
+apiVersion: formance.com/v1beta1
+kind: Settings
+metadata:
+  name: chainsaw-ledger-default-page-size
+spec:
+  stacks:
+    - chainsaw-ledger
+  key: ledger.api.default-page-size
+  value: "50"
+---
+apiVersion: formance.com/v1beta1
+kind: Settings
+metadata:
+  name: chainsaw-ledger-max-page-size
+spec:
+  stacks:
+    - chainsaw-ledger
+  key: ledger.api.max-page-size
+  value: "1000"
+---
+apiVersion: formance.com/v1beta1
+kind: Settings
+metadata:
+  name: chainsaw-ledger-bulk-max-size
+spec:
+  stacks:
+    - chainsaw-ledger
+  key: ledger.api.bulk-max-size
+  value: "200"
+---
+apiVersion: formance.com/v1beta1
+kind: Settings
+metadata:
+  name: chainsaw-ledger-schema-enforcement
+spec:
+  stacks:
+    - chainsaw-ledger
+  key: ledger.schema-enforcement-mode
+  value: permissive
+---
+apiVersion: formance.com/v1beta1
+kind: Settings
+metadata:
+  name: chainsaw-ledger-exporters
+spec:
+  stacks:
+    - chainsaw-ledger
+  key: ledger.experimental-exporters
+  value: "true"
+---
+apiVersion: formance.com/v1beta1
+kind: Settings
+metadata:
+  name: chainsaw-ledger-worker-async-block-hasher
+spec:
+  stacks:
+    - chainsaw-ledger
+  key: ledger.worker.async-block-hasher
+  value: max-block-size=1000,schedule="*/5 * * * *"
+---
+apiVersion: formance.com/v1beta1
+kind: Settings
+metadata:
+  name: chainsaw-ledger-worker-pipelines
+spec:
+  stacks:
+    - chainsaw-ledger
+  key: ledger.worker.pipelines
+  value: pull-interval=1s,push-retry-period=2s,sync-period=3s,logs-page-size=42
+---
+apiVersion: formance.com/v1beta1
+kind: Settings
+metadata:
+  name: chainsaw-ledger-worker-bucket-cleanup
+spec:
+  stacks:
+    - chainsaw-ledger
+  key: ledger.worker.bucket-cleanup
+  value: retention-period=24h,schedule="0 * * * *"
+---
+apiVersion: formance.com/v1beta1
+kind: Settings
+metadata:
+  name: chainsaw-ledger-database-pool
+spec:
+  stacks:
+    - chainsaw-ledger
+  key: modules.ledger.database.connection-pool
+  value: max-idle=10,max-idle-time=10s,max-open=20,max-lifetime=5m
+---
+apiVersion: formance.com/v1beta1
+kind: Settings
+metadata:
+  name: chainsaw-ledger-replicas
+spec:
+  stacks:
+    - chainsaw-ledger
+  key: deployments.ledger.replicas
+  value: "2"
+---
+apiVersion: formance.com/v1beta1
+kind: Settings
+metadata:
+  name: chainsaw-ledger-template-annotations
+spec:
+  stacks:
+    - chainsaw-ledger
+  key: deployments.ledger.spec.template.annotations
+  value: chainsaw.formance.com/template=ledger
+---
+apiVersion: formance.com/v1beta1
+kind: Settings
+metadata:
+  name: chainsaw-ledger-container-requests
+spec:
+  stacks:
+    - chainsaw-ledger
+  key: deployments.ledger.containers.ledger.resource-requirements.requests
+  value: cpu=25m,memory=128Mi
+---
+apiVersion: formance.com/v1beta1
+kind: Settings
+metadata:
+  name: chainsaw-ledger-container-limits
+spec:
+  stacks:
+    - chainsaw-ledger
+  key: deployments.ledger.containers.ledger.resource-requirements.limits
+  value: memory=256Mi
+---
+apiVersion: formance.com/v1beta1
+kind: Settings
+metadata:
+  name: chainsaw-ledger-run-as
+spec:
+  stacks:
+    - chainsaw-ledger
+  key: deployments.ledger.containers.ledger.run-as
+  value: user=10001,group=10001
+---
+apiVersion: formance.com/v1beta1
+kind: Settings
+metadata:
+  name: chainsaw-ledger-pdb
+spec:
+  stacks:
+    - chainsaw-ledger
+  key: deployments.ledger.pod-disruption-budget
+  value: minAvailable=1
+---
+apiVersion: formance.com/v1beta1
+kind: Settings
+metadata:
+  name: chainsaw-ledger-grace-period
+spec:
+  stacks:
+    - chainsaw-ledger
+  key: modules.ledger.grace-period
+  value: 30s
+---
+apiVersion: formance.com/v1beta1
+kind: Settings
+metadata:
+  name: chainsaw-ledger-service-annotations
+spec:
+  stacks:
+    - chainsaw-ledger
+  key: services.ledger.annotations
+  value: chainsaw.formance.com/service=ledger
+---
+apiVersion: formance.com/v1beta1
+kind: Settings
+metadata:
+  name: chainsaw-ledger-logging-json
+spec:
+  stacks:
+    - chainsaw-ledger
+  key: logging.json
+  value: "true"
+---
+apiVersion: formance.com/v1beta1
+kind: Settings
+metadata:
+  name: chainsaw-ledger-otel-traces-dsn
+spec:
+  stacks:
+    - chainsaw-ledger
+  key: opentelemetry.traces.dsn
+  value: grpc://otel-collector.chainsaw:4317?insecure=true
+---
+apiVersion: formance.com/v1beta1
+kind: Settings
+metadata:
+  name: chainsaw-ledger-otel-resource-attributes
+spec:
+  stacks:
+    - chainsaw-ledger
+  key: opentelemetry.traces.resource-attributes
+  value: service.namespace=formance,team=platform

--- a/tests/e2e/chainsaw/14-ledger-module/resources/source-secret.yaml
+++ b/tests/e2e/chainsaw/14-ledger-module/resources/source-secret.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: chainsaw-ledger-postgres-credentials
+  namespace: default
+  labels:
+    formance.com/stack: chainsaw-ledger
+  annotations:
+    formance.com/referenced-by-name: postgres
+stringData:
+  username: formance
+  password: formance

--- a/tests/e2e/chainsaw/14-ledger-module/resources/stack.yaml
+++ b/tests/e2e/chainsaw/14-ledger-module/resources/stack.yaml
@@ -1,0 +1,6 @@
+apiVersion: formance.com/v1beta1
+kind: Stack
+metadata:
+  name: chainsaw-ledger
+spec:
+  version: v3.0.0

--- a/tests/e2e/chainsaw/15-auth-module/chainsaw-test.yaml
+++ b/tests/e2e/chainsaw/15-auth-module/chainsaw-test.yaml
@@ -1,0 +1,88 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: auth-module
+  labels:
+    suite: modules
+    feature: auth-module
+spec:
+  concurrent: false
+  steps:
+    - name: auth-renders-database-clients-config-and-settings
+      try:
+        - apply:
+            file: resources/source-secret.yaml
+        - apply:
+            file: resources/stack.yaml
+        - apply:
+            file: resources/postgres.yaml
+        - apply:
+            file: resources/settings.yaml
+        - apply:
+            file: resources/database.yaml
+        - script:
+            timeout: 5m
+            content: |
+              set -eu
+              kubectl rollout status deployment/postgres -n chainsaw-auth --timeout=2m
+              kubectl wait --for=jsonpath='{.status.ready}'=true database/chainsaw-auth-auth --timeout=5m
+        - apply:
+            file: resources/client-secret.yaml
+        - apply:
+            file: resources/authclients.yaml
+        - script:
+            timeout: 2m
+            content: |
+              set -eu
+              kubectl wait --for=jsonpath='{.status.ready}'=true authclient/chainsaw-inline-client --timeout=2m
+              kubectl wait --for=jsonpath='{.status.ready}'=true authclient/chainsaw-referenced-client --timeout=2m
+        - apply:
+            file: resources/auth.yaml
+        - script:
+            timeout: 5m
+            content: |
+              set -eu
+              assert_jsonpath() {
+                resource="$1"
+                path="$2"
+                expected="$3"
+                actual="$(kubectl get "$resource" -n chainsaw-auth -o "jsonpath=${path}")"
+                if test "$actual" != "$expected"; then
+                  echo "expected ${resource} ${path} to be '${expected}', got '${actual}'" >&2
+                  exit 1
+                fi
+              }
+              kubectl wait --for=jsonpath='{.spec.template.spec.containers[0].image}'=ghcr.io/formancehq/auth:v3.0.0 deployment/auth -n chainsaw-auth --timeout=2m
+              kubectl wait --for=jsonpath='{.status.ready}'=true gatewayhttpapi/chainsaw-auth-auth --timeout=2m
+              kubectl wait --for=jsonpath='{.spec.ports[0].port}'=8080 service/auth -n chainsaw-auth --timeout=2m
+              assert_jsonpath deployment/auth '{.spec.replicas}' '2'
+              assert_jsonpath deployment/auth '{.spec.template.spec.containers[0].securityContext.runAsUser}' '10002'
+              assert_jsonpath pdb/auth '{.spec.minAvailable}' '1'
+              assert_jsonpath service/auth '{.metadata.annotations.chainsaw\.formance\.com/service}' 'auth'
+              kubectl get deployment auth -n chainsaw-auth -o jsonpath='{range .spec.template.spec.containers[0].env[*]}{.name}={.value}{"\n"}{end}' > /tmp/chainsaw-auth-env
+              grep -Fx 'BASE_URL=http://auth:8080' /tmp/chainsaw-auth-env
+              grep -Fx 'CONFIG=/config/config.yaml' /tmp/chainsaw-auth-env
+              grep -Fx 'AUTH_ISSUERS=https://issuer.chainsaw.local,https://issuer-alt.chainsaw.local' /tmp/chainsaw-auth-env
+              grep -Fx 'DELEGATED_CLIENT_ID=delegated-client' /tmp/chainsaw-auth-env
+              grep -Fx 'DELEGATED_ISSUER=https://delegated.chainsaw.local' /tmp/chainsaw-auth-env
+              grep -Fx 'CAOS_OIDC_DEV=1' /tmp/chainsaw-auth-env
+              grep -Fx 'POSTGRES_HOST=postgres.chainsaw-auth.svc.cluster.local' /tmp/chainsaw-auth-env
+              grep -Fx 'POSTGRES_DATABASE=chainsaw-auth-auth' /tmp/chainsaw-auth-env
+              grep -Fx 'OTEL_TRACES=true' /tmp/chainsaw-auth-env
+              grep -Fx 'OTEL_SERVICE_NAME=auth' /tmp/chainsaw-auth-env
+              kubectl get deployment auth -n chainsaw-auth -o jsonpath='{range .spec.template.spec.containers[0].env[*]}{.name}={.valueFrom.secretKeyRef.name}/{.valueFrom.secretKeyRef.key}{"\n"}{end}' > /tmp/chainsaw-auth-secret-env
+              grep -Fx 'SIGNING_KEY=chainsaw-auth-signing-key/signing-key' /tmp/chainsaw-auth-secret-env
+              grep -Fx 'DELEGATED_CLIENT_SECRET=chainsaw-auth-signing-key/delegated-secret' /tmp/chainsaw-auth-secret-env
+              grep -Fx 'AUTH_CLIENT_SECRET_CHAINSAW_REFERENCED_CLIENT=chainsaw-auth-client-secret/secret' /tmp/chainsaw-auth-secret-env
+              kubectl get configmap auth-configuration -n chainsaw-auth -o go-template='{{ index .data "config.yaml" }}' > /tmp/chainsaw-auth-config
+              grep -F 'id: inline-client' /tmp/chainsaw-auth-config
+              grep -F 'id: referenced-client' /tmp/chainsaw-auth-config
+              grep -F 'secrets:' /tmp/chainsaw-auth-config
+              grep -F '    - inline-secret' /tmp/chainsaw-auth-config
+              grep -F '    - $AUTH_CLIENT_SECRET_CHAINSAW_REFERENCED_CLIENT' /tmp/chainsaw-auth-config
+              grep -F 'ledger:read' /tmp/chainsaw-auth-config
+              grep -F 'payments:write' /tmp/chainsaw-auth-config
+      catch:
+        - script:
+            timeout: 2m
+            content: ../../scripts/dump-diagnostics.sh auth-module

--- a/tests/e2e/chainsaw/15-auth-module/resources/auth.yaml
+++ b/tests/e2e/chainsaw/15-auth-module/resources/auth.yaml
@@ -1,0 +1,15 @@
+apiVersion: formance.com/v1beta1
+kind: Auth
+metadata:
+  name: auth
+spec:
+  stack: chainsaw-auth
+  signingKeyFromSecret:
+    name: chainsaw-auth-signing-key
+    key: signing-key
+  delegatedOIDCServer:
+    issuer: https://delegated.chainsaw.local
+    clientID: delegated-client
+    clientSecretFromSecret:
+      name: chainsaw-auth-signing-key
+      key: delegated-secret

--- a/tests/e2e/chainsaw/15-auth-module/resources/authclients.yaml
+++ b/tests/e2e/chainsaw/15-auth-module/resources/authclients.yaml
@@ -1,0 +1,28 @@
+apiVersion: formance.com/v1beta1
+kind: AuthClient
+metadata:
+  name: chainsaw-inline-client
+spec:
+  stack: chainsaw-auth
+  id: inline-client
+  secret: inline-secret
+  redirectUris:
+    - https://app.chainsaw.local/callback
+  postLogoutRedirectUris:
+    - https://app.chainsaw.local/logout
+  scopes:
+    - ledger:read
+    - payments:write
+---
+apiVersion: formance.com/v1beta1
+kind: AuthClient
+metadata:
+  name: chainsaw-referenced-client
+spec:
+  stack: chainsaw-auth
+  id: referenced-client
+  secretFromSecret:
+    name: chainsaw-auth-client-secret
+    key: secret
+  scopes:
+    - ledger:write

--- a/tests/e2e/chainsaw/15-auth-module/resources/client-secret.yaml
+++ b/tests/e2e/chainsaw/15-auth-module/resources/client-secret.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: chainsaw-auth-client-secret
+  namespace: chainsaw-auth
+  labels:
+    formance.com/stack: chainsaw-auth
+type: Opaque
+stringData:
+  secret: referenced-secret
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: chainsaw-auth-signing-key
+  namespace: chainsaw-auth
+  labels:
+    formance.com/stack: chainsaw-auth
+type: Opaque
+stringData:
+  signing-key: referenced-signing-key
+  delegated-secret: referenced-delegated-secret

--- a/tests/e2e/chainsaw/15-auth-module/resources/database.yaml
+++ b/tests/e2e/chainsaw/15-auth-module/resources/database.yaml
@@ -1,0 +1,9 @@
+apiVersion: formance.com/v1beta1
+kind: Database
+metadata:
+  name: chainsaw-auth-auth
+  annotations:
+    formance.com/module-version: v3.0.0
+spec:
+  stack: chainsaw-auth
+  service: auth

--- a/tests/e2e/chainsaw/15-auth-module/resources/postgres.yaml
+++ b/tests/e2e/chainsaw/15-auth-module/resources/postgres.yaml
@@ -1,0 +1,51 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres
+  namespace: chainsaw-auth
+spec:
+  selector:
+    app.kubernetes.io/name: postgres
+  ports:
+    - name: postgres
+      port: 5432
+      targetPort: 5432
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: postgres
+  namespace: chainsaw-auth
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: postgres
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: postgres
+    spec:
+      containers:
+        - name: postgres
+          image: postgres:15-alpine
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 5432
+              name: postgres
+          env:
+            - name: POSTGRES_USER
+              value: formance
+            - name: POSTGRES_PASSWORD
+              value: formance
+            - name: POSTGRES_DB
+              value: postgres
+          readinessProbe:
+            exec:
+              command:
+                - pg_isready
+                - -U
+                - formance
+            initialDelaySeconds: 2
+            periodSeconds: 2
+            timeoutSeconds: 1

--- a/tests/e2e/chainsaw/15-auth-module/resources/settings.yaml
+++ b/tests/e2e/chainsaw/15-auth-module/resources/settings.yaml
@@ -1,0 +1,69 @@
+apiVersion: formance.com/v1beta1
+kind: Settings
+metadata:
+  name: chainsaw-auth-postgres-uri
+spec:
+  stacks:
+    - chainsaw-auth
+  key: postgres.auth.uri
+  value: postgresql://postgres.chainsaw-auth.svc.cluster.local:5432?secret=postgres&disableSSLMode=true
+---
+apiVersion: formance.com/v1beta1
+kind: Settings
+metadata:
+  name: chainsaw-auth-issuers
+spec:
+  stacks:
+    - chainsaw-auth
+  key: auth.issuers
+  value: https://issuer.chainsaw.local,https://issuer-alt.chainsaw.local
+---
+apiVersion: formance.com/v1beta1
+kind: Settings
+metadata:
+  name: chainsaw-auth-pdb
+spec:
+  stacks:
+    - chainsaw-auth
+  key: deployments.auth.pod-disruption-budget
+  value: minAvailable=1
+---
+apiVersion: formance.com/v1beta1
+kind: Settings
+metadata:
+  name: chainsaw-auth-replicas
+spec:
+  stacks:
+    - chainsaw-auth
+  key: deployments.auth.replicas
+  value: "2"
+---
+apiVersion: formance.com/v1beta1
+kind: Settings
+metadata:
+  name: chainsaw-auth-run-as
+spec:
+  stacks:
+    - chainsaw-auth
+  key: deployments.auth.containers.auth.run-as
+  value: user=10002,group=10002
+---
+apiVersion: formance.com/v1beta1
+kind: Settings
+metadata:
+  name: chainsaw-auth-service-annotations
+spec:
+  stacks:
+    - chainsaw-auth
+  key: services.auth.annotations
+  value: chainsaw.formance.com/service=auth
+---
+apiVersion: formance.com/v1beta1
+kind: Settings
+metadata:
+  name: chainsaw-auth-otel-traces
+spec:
+  stacks:
+    - chainsaw-auth
+  key: opentelemetry.traces.dsn
+  value: grpc://otel-collector.chainsaw:4317?insecure=true

--- a/tests/e2e/chainsaw/15-auth-module/resources/source-secret.yaml
+++ b/tests/e2e/chainsaw/15-auth-module/resources/source-secret.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: chainsaw-auth-postgres-credentials
+  namespace: default
+  labels:
+    formance.com/stack: chainsaw-auth
+  annotations:
+    formance.com/referenced-by-name: postgres
+type: Opaque
+stringData:
+  username: formance
+  password: formance

--- a/tests/e2e/chainsaw/15-auth-module/resources/stack.yaml
+++ b/tests/e2e/chainsaw/15-auth-module/resources/stack.yaml
@@ -1,0 +1,7 @@
+apiVersion: formance.com/v1beta1
+kind: Stack
+metadata:
+  name: chainsaw-auth
+spec:
+  version: v3.0.0
+  dev: true

--- a/tests/e2e/chainsaw/16-wallets-module/chainsaw-test.yaml
+++ b/tests/e2e/chainsaw/16-wallets-module/chainsaw-test.yaml
@@ -1,0 +1,58 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: wallets-module
+  labels:
+    suite: modules
+    feature: wallets-module
+spec:
+  concurrent: false
+  steps:
+    - name: wallets-renders-authclient-gateway-and-settings
+      try:
+        - apply:
+            file: resources/stack.yaml
+        - apply:
+            file: resources/settings.yaml
+        - apply:
+            file: resources/auth.yaml
+        - apply:
+            file: resources/wallets.yaml
+        - script:
+            timeout: 5m
+            content: |
+              set -eu
+              assert_jsonpath() {
+                resource="$1"
+                path="$2"
+                expected="$3"
+                actual="$(kubectl get "$resource" -n chainsaw-wallets -o "jsonpath=${path}")"
+                if test "$actual" != "$expected"; then
+                  echo "expected ${resource} ${path} to be '${expected}', got '${actual}'" >&2
+                  exit 1
+                fi
+              }
+              kubectl wait --for=jsonpath='{.status.ready}'=true authclient/chainsaw-wallets-wallets --timeout=2m
+              kubectl wait --for=jsonpath='{.spec.template.spec.containers[0].image}'=ghcr.io/formancehq/wallets:v3.0.0 deployment/wallets -n chainsaw-wallets --timeout=2m
+              kubectl wait --for=jsonpath='{.status.ready}'=true gatewayhttpapi/chainsaw-wallets-wallets --timeout=2m
+              kubectl wait --for=jsonpath='{.spec.ports[0].port}'=8080 service/wallets -n chainsaw-wallets --timeout=2m
+              assert_jsonpath deployment/wallets '{.spec.template.spec.containers[0].resources.requests.cpu}' '20m'
+              assert_jsonpath deployment/wallets '{.spec.template.spec.containers[0].resources.limits.memory}' '128Mi'
+              assert_jsonpath pdb/wallets '{.spec.minAvailable}' '1'
+              assert_jsonpath service/wallets '{.metadata.annotations.chainsaw\.formance\.com/service}' 'wallets'
+              kubectl get deployment wallets -n chainsaw-wallets -o jsonpath='{range .spec.template.spec.containers[0].env[*]}{.name}={.value}{"\n"}{end}' > /tmp/chainsaw-wallets-env
+              grep -Fx 'AUTH_ENABLED=true' /tmp/chainsaw-wallets-env
+              grep -Fx 'AUTH_ISSUER=http://auth:8080' /tmp/chainsaw-wallets-env
+              grep -Fx 'AUTH_ISSUERS=https://issuer.wallets.chainsaw.local' /tmp/chainsaw-wallets-env
+              grep -Fx 'AUTH_CHECK_SCOPES=true' /tmp/chainsaw-wallets-env
+              grep -Fx 'AUTH_SERVICE=wallets' /tmp/chainsaw-wallets-env
+              grep -Fx 'OTEL_TRACES=true' /tmp/chainsaw-wallets-env
+              grep -Fx 'OTEL_SERVICE_NAME=wallets' /tmp/chainsaw-wallets-env
+              kubectl get deployment wallets -n chainsaw-wallets -o jsonpath='{range .spec.template.spec.containers[0].env[*]}{.name}={.valueFrom.secretKeyRef.name}/{.valueFrom.secretKeyRef.key}{"\n"}{end}' > /tmp/chainsaw-wallets-secret-env
+              grep -Fx 'STACK_CLIENT_ID=auth-client-chainsaw-wallets-wallets/id' /tmp/chainsaw-wallets-secret-env
+              grep -Fx 'STACK_CLIENT_SECRET=auth-client-chainsaw-wallets-wallets/secret' /tmp/chainsaw-wallets-secret-env
+              test "$(kubectl get authclient chainsaw-wallets-wallets -o jsonpath='{.spec.scopes[*]}')" = "ledger:read ledger:write"
+      catch:
+        - script:
+            timeout: 2m
+            content: ../../scripts/dump-diagnostics.sh wallets-module

--- a/tests/e2e/chainsaw/16-wallets-module/resources/auth.yaml
+++ b/tests/e2e/chainsaw/16-wallets-module/resources/auth.yaml
@@ -1,0 +1,6 @@
+apiVersion: formance.com/v1beta1
+kind: Auth
+metadata:
+  name: auth
+spec:
+  stack: chainsaw-wallets

--- a/tests/e2e/chainsaw/16-wallets-module/resources/settings.yaml
+++ b/tests/e2e/chainsaw/16-wallets-module/resources/settings.yaml
@@ -1,0 +1,69 @@
+apiVersion: formance.com/v1beta1
+kind: Settings
+metadata:
+  name: chainsaw-wallets-check-scopes
+spec:
+  stacks:
+    - chainsaw-wallets
+  key: auth.wallets.check-scopes
+  value: "true"
+---
+apiVersion: formance.com/v1beta1
+kind: Settings
+metadata:
+  name: chainsaw-wallets-issuers
+spec:
+  stacks:
+    - chainsaw-wallets
+  key: auth.issuers
+  value: https://issuer.wallets.chainsaw.local
+---
+apiVersion: formance.com/v1beta1
+kind: Settings
+metadata:
+  name: chainsaw-wallets-otel-traces
+spec:
+  stacks:
+    - chainsaw-wallets
+  key: opentelemetry.traces.dsn
+  value: grpc://otel-collector.chainsaw:4317?insecure=true
+---
+apiVersion: formance.com/v1beta1
+kind: Settings
+metadata:
+  name: chainsaw-wallets-resource-requests
+spec:
+  stacks:
+    - chainsaw-wallets
+  key: deployments.wallets.containers.wallets.resource-requirements.requests
+  value: cpu=20m,memory=64Mi
+---
+apiVersion: formance.com/v1beta1
+kind: Settings
+metadata:
+  name: chainsaw-wallets-resource-limits
+spec:
+  stacks:
+    - chainsaw-wallets
+  key: deployments.wallets.containers.wallets.resource-requirements.limits
+  value: memory=128Mi
+---
+apiVersion: formance.com/v1beta1
+kind: Settings
+metadata:
+  name: chainsaw-wallets-pdb
+spec:
+  stacks:
+    - chainsaw-wallets
+  key: deployments.wallets.pod-disruption-budget
+  value: minAvailable=1
+---
+apiVersion: formance.com/v1beta1
+kind: Settings
+metadata:
+  name: chainsaw-wallets-service-annotations
+spec:
+  stacks:
+    - chainsaw-wallets
+  key: services.wallets.annotations
+  value: chainsaw.formance.com/service=wallets

--- a/tests/e2e/chainsaw/16-wallets-module/resources/stack.yaml
+++ b/tests/e2e/chainsaw/16-wallets-module/resources/stack.yaml
@@ -1,0 +1,7 @@
+apiVersion: formance.com/v1beta1
+kind: Stack
+metadata:
+  name: chainsaw-wallets
+spec:
+  version: v3.0.0
+  dev: true

--- a/tests/e2e/chainsaw/16-wallets-module/resources/wallets.yaml
+++ b/tests/e2e/chainsaw/16-wallets-module/resources/wallets.yaml
@@ -1,0 +1,6 @@
+apiVersion: formance.com/v1beta1
+kind: Wallets
+metadata:
+  name: wallets
+spec:
+  stack: chainsaw-wallets

--- a/tests/e2e/chainsaw/17-reconciliation-module/chainsaw-test.yaml
+++ b/tests/e2e/chainsaw/17-reconciliation-module/chainsaw-test.yaml
@@ -1,0 +1,79 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: reconciliation-module
+  labels:
+    suite: modules
+    feature: reconciliation-module
+spec:
+  concurrent: false
+  steps:
+    - name: reconciliation-renders-postgres-authclient-gateway-and-settings
+      try:
+        - apply:
+            file: resources/source-secret.yaml
+        - apply:
+            file: resources/stack.yaml
+        - apply:
+            file: resources/postgres.yaml
+        - apply:
+            file: resources/settings.yaml
+        - apply:
+            file: resources/database.yaml
+        - script:
+            timeout: 5m
+            content: |
+              set -eu
+              kubectl rollout status deployment/postgres -n chainsaw-reconciliation --timeout=2m
+              kubectl wait --for=jsonpath='{.status.ready}'=true database/chainsaw-reconciliation-reconciliation --timeout=5m
+        - apply:
+            file: resources/reconciliation.yaml
+        - script:
+            timeout: 5m
+            content: |
+              set -eu
+              assert_jsonpath() {
+                resource="$1"
+                path="$2"
+                expected="$3"
+                actual="$(kubectl get "$resource" -n chainsaw-reconciliation -o "jsonpath=${path}")"
+                if test "$actual" != "$expected"; then
+                  echo "expected ${resource} ${path} to be '${expected}', got '${actual}'" >&2
+                  exit 1
+                fi
+              }
+              kubectl wait --for=jsonpath='{.status.ready}'=true authclient/chainsaw-reconciliation-reconciliation --timeout=2m
+              kubectl wait --for=jsonpath='{.spec.template.spec.containers[0].image}'=ghcr.io/formancehq/reconciliation:v3.0.0 deployment/reconciliation -n chainsaw-reconciliation --timeout=2m
+              kubectl wait --for=jsonpath='{.status.ready}'=true gatewayhttpapi/chainsaw-reconciliation-reconciliation --timeout=2m
+              kubectl wait --for=jsonpath='{.spec.ports[0].port}'=8080 service/reconciliation -n chainsaw-reconciliation --timeout=2m
+              assert_jsonpath deployment/reconciliation '{.spec.replicas}' '2'
+              assert_jsonpath deployment/reconciliation '{.spec.template.spec.containers[0].resources.requests.cpu}' '15m'
+              assert_jsonpath deployment/reconciliation '{.spec.template.spec.containers[0].resources.limits.memory}' '192Mi'
+              assert_jsonpath deployment/reconciliation '{.spec.template.metadata.annotations.chainsaw\.formance\.com/template}' 'reconciliation'
+              assert_jsonpath pdb/reconciliation '{.spec.minAvailable}' '1'
+              assert_jsonpath service/reconciliation '{.metadata.annotations.chainsaw\.formance\.com/service}' 'reconciliation'
+              kubectl get deployment reconciliation -n chainsaw-reconciliation -o jsonpath='{range .spec.template.spec.containers[0].env[*]}{.name}={.value}{"\n"}{end}' > /tmp/chainsaw-reconciliation-env
+              grep -Fx 'DEV=true' /tmp/chainsaw-reconciliation-env
+              grep -Fx 'STACK=chainsaw-reconciliation' /tmp/chainsaw-reconciliation-env
+              grep -Fx 'POSTGRES_HOST=postgres.chainsaw-reconciliation.svc.cluster.local' /tmp/chainsaw-reconciliation-env
+              grep -Fx 'POSTGRES_PORT=5432' /tmp/chainsaw-reconciliation-env
+              grep -Fx 'POSTGRES_DATABASE=chainsaw-reconciliation-reconciliation' /tmp/chainsaw-reconciliation-env
+              grep -Fx 'POSTGRES_URI=$(POSTGRES_NO_DATABASE_URI)/$(POSTGRES_DATABASE)?sslmode=disable' /tmp/chainsaw-reconciliation-env
+              grep -Fx 'POSTGRES_DATABASE_NAME=$(POSTGRES_DATABASE)' /tmp/chainsaw-reconciliation-env
+              grep -Fx 'POSTGRES_MAX_IDLE_CONNS=3' /tmp/chainsaw-reconciliation-env
+              grep -Fx 'POSTGRES_CONN_MAX_IDLE_TIME=7s' /tmp/chainsaw-reconciliation-env
+              grep -Fx 'POSTGRES_MAX_OPEN_CONNS=9' /tmp/chainsaw-reconciliation-env
+              grep -Fx 'POSTGRES_CONN_MAX_LIFETIME=2m' /tmp/chainsaw-reconciliation-env
+              grep -Fx 'OTEL_TRACES=true' /tmp/chainsaw-reconciliation-env
+              grep -Fx 'OTEL_SERVICE_NAME=reconciliation' /tmp/chainsaw-reconciliation-env
+              grep -Fx 'OTEL_RESOURCE_ATTRIBUTES=pod-name=$(POD_NAME) service.namespace=formance stack=chainsaw-reconciliation team=platform' /tmp/chainsaw-reconciliation-env
+              kubectl get deployment reconciliation -n chainsaw-reconciliation -o jsonpath='{range .spec.template.spec.containers[0].env[*]}{.name}={.valueFrom.secretKeyRef.name}/{.valueFrom.secretKeyRef.key}{"\n"}{end}' > /tmp/chainsaw-reconciliation-secret-env
+              grep -Fx 'POSTGRES_USERNAME=postgres/username' /tmp/chainsaw-reconciliation-secret-env
+              grep -Fx 'POSTGRES_PASSWORD=postgres/password' /tmp/chainsaw-reconciliation-secret-env
+              grep -Fx 'STACK_CLIENT_ID=auth-client-chainsaw-reconciliation-reconciliation/id' /tmp/chainsaw-reconciliation-secret-env
+              grep -Fx 'STACK_CLIENT_SECRET=auth-client-chainsaw-reconciliation-reconciliation/secret' /tmp/chainsaw-reconciliation-secret-env
+              test "$(kubectl get authclient chainsaw-reconciliation-reconciliation -o jsonpath='{.spec.scopes[*]}')" = "ledger:read payments:read"
+      catch:
+        - script:
+            timeout: 2m
+            content: ../../scripts/dump-diagnostics.sh reconciliation-module

--- a/tests/e2e/chainsaw/17-reconciliation-module/resources/database.yaml
+++ b/tests/e2e/chainsaw/17-reconciliation-module/resources/database.yaml
@@ -1,0 +1,9 @@
+apiVersion: formance.com/v1beta1
+kind: Database
+metadata:
+  name: chainsaw-reconciliation-reconciliation
+  annotations:
+    formance.com/module-version: v3.0.0
+spec:
+  stack: chainsaw-reconciliation
+  service: reconciliation

--- a/tests/e2e/chainsaw/17-reconciliation-module/resources/postgres.yaml
+++ b/tests/e2e/chainsaw/17-reconciliation-module/resources/postgres.yaml
@@ -1,0 +1,51 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres
+  namespace: chainsaw-reconciliation
+spec:
+  selector:
+    app.kubernetes.io/name: postgres
+  ports:
+    - name: postgres
+      port: 5432
+      targetPort: 5432
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: postgres
+  namespace: chainsaw-reconciliation
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: postgres
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: postgres
+    spec:
+      containers:
+        - name: postgres
+          image: postgres:15-alpine
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 5432
+              name: postgres
+          env:
+            - name: POSTGRES_USER
+              value: formance
+            - name: POSTGRES_PASSWORD
+              value: formance
+            - name: POSTGRES_DB
+              value: postgres
+          readinessProbe:
+            exec:
+              command:
+                - pg_isready
+                - -U
+                - formance
+            initialDelaySeconds: 2
+            periodSeconds: 2
+            timeoutSeconds: 1

--- a/tests/e2e/chainsaw/17-reconciliation-module/resources/reconciliation.yaml
+++ b/tests/e2e/chainsaw/17-reconciliation-module/resources/reconciliation.yaml
@@ -1,0 +1,6 @@
+apiVersion: formance.com/v1beta1
+kind: Reconciliation
+metadata:
+  name: reconciliation
+spec:
+  stack: chainsaw-reconciliation

--- a/tests/e2e/chainsaw/17-reconciliation-module/resources/settings.yaml
+++ b/tests/e2e/chainsaw/17-reconciliation-module/resources/settings.yaml
@@ -1,0 +1,99 @@
+apiVersion: formance.com/v1beta1
+kind: Settings
+metadata:
+  name: chainsaw-reconciliation-postgres-uri
+spec:
+  stacks:
+    - chainsaw-reconciliation
+  key: postgres.reconciliation.uri
+  value: postgresql://postgres.chainsaw-reconciliation.svc.cluster.local:5432?secret=postgres&disableSSLMode=true
+---
+apiVersion: formance.com/v1beta1
+kind: Settings
+metadata:
+  name: chainsaw-reconciliation-otel-traces
+spec:
+  stacks:
+    - chainsaw-reconciliation
+  key: opentelemetry.traces.dsn
+  value: grpc://otel-collector.chainsaw:4317?insecure=true
+---
+apiVersion: formance.com/v1beta1
+kind: Settings
+metadata:
+  name: chainsaw-reconciliation-otel-resource-attributes
+spec:
+  stacks:
+    - chainsaw-reconciliation
+  key: opentelemetry.traces.resource-attributes
+  value: service.namespace=formance,team=platform
+---
+apiVersion: formance.com/v1beta1
+kind: Settings
+metadata:
+  name: chainsaw-reconciliation-database-pool
+spec:
+  stacks:
+    - chainsaw-reconciliation
+  key: modules.reconciliation.database.connection-pool
+  value: max-idle=3,max-idle-time=7s,max-open=9,max-lifetime=2m
+---
+apiVersion: formance.com/v1beta1
+kind: Settings
+metadata:
+  name: chainsaw-reconciliation-replicas
+spec:
+  stacks:
+    - chainsaw-reconciliation
+  key: deployments.reconciliation.replicas
+  value: "2"
+---
+apiVersion: formance.com/v1beta1
+kind: Settings
+metadata:
+  name: chainsaw-reconciliation-template-annotations
+spec:
+  stacks:
+    - chainsaw-reconciliation
+  key: deployments.reconciliation.spec.template.annotations
+  value: chainsaw.formance.com/template=reconciliation
+---
+apiVersion: formance.com/v1beta1
+kind: Settings
+metadata:
+  name: chainsaw-reconciliation-container-requests
+spec:
+  stacks:
+    - chainsaw-reconciliation
+  key: deployments.reconciliation.containers.reconciliation.resource-requirements.requests
+  value: cpu=15m,memory=64Mi
+---
+apiVersion: formance.com/v1beta1
+kind: Settings
+metadata:
+  name: chainsaw-reconciliation-container-limits
+spec:
+  stacks:
+    - chainsaw-reconciliation
+  key: deployments.reconciliation.containers.reconciliation.resource-requirements.limits
+  value: memory=192Mi
+---
+apiVersion: formance.com/v1beta1
+kind: Settings
+metadata:
+  name: chainsaw-reconciliation-pdb
+spec:
+  stacks:
+    - chainsaw-reconciliation
+  key: deployments.reconciliation.pod-disruption-budget
+  value: minAvailable=1
+---
+apiVersion: formance.com/v1beta1
+kind: Settings
+metadata:
+  name: chainsaw-reconciliation-service-annotations
+spec:
+  stacks:
+    - chainsaw-reconciliation
+  key: services.reconciliation.annotations
+  value: chainsaw.formance.com/service=reconciliation

--- a/tests/e2e/chainsaw/17-reconciliation-module/resources/source-secret.yaml
+++ b/tests/e2e/chainsaw/17-reconciliation-module/resources/source-secret.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: chainsaw-reconciliation-postgres-credentials
+  namespace: default
+  labels:
+    formance.com/stack: chainsaw-reconciliation
+  annotations:
+    formance.com/referenced-by-name: postgres
+stringData:
+  username: formance
+  password: formance

--- a/tests/e2e/chainsaw/17-reconciliation-module/resources/stack.yaml
+++ b/tests/e2e/chainsaw/17-reconciliation-module/resources/stack.yaml
@@ -1,0 +1,7 @@
+apiVersion: formance.com/v1beta1
+kind: Stack
+metadata:
+  name: chainsaw-reconciliation
+spec:
+  version: v3.0.0
+  dev: true

--- a/tests/e2e/chainsaw/18-webhooks-module/chainsaw-test.yaml
+++ b/tests/e2e/chainsaw/18-webhooks-module/chainsaw-test.yaml
@@ -1,0 +1,98 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: webhooks-module
+  labels:
+    suite: modules
+    feature: webhooks-module
+spec:
+  concurrent: false
+  steps:
+    - name: webhooks-renders-postgres-broker-consumer-gateway-and-settings
+      try:
+        - apply:
+            file: resources/source-secret.yaml
+        - apply:
+            file: resources/stack.yaml
+        - apply:
+            file: resources/postgres.yaml
+        - apply:
+            file: resources/nats.yaml
+        - apply:
+            file: resources/settings.yaml
+        - apply:
+            file: resources/database.yaml
+        - apply:
+            file: resources/broker.yaml
+        - script:
+            timeout: 5m
+            content: |
+              set -eu
+              kubectl rollout status deployment/postgres -n chainsaw-webhooks --timeout=2m
+              kubectl rollout status deployment/nats -n chainsaw-webhooks --timeout=2m
+              kubectl wait --for=jsonpath='{.status.ready}'=true database/chainsaw-webhooks-webhooks --timeout=5m
+              kubectl wait --for=jsonpath='{.status.ready}'=true broker/chainsaw-webhooks --timeout=5m
+        - apply:
+            file: resources/webhooks.yaml
+        - script:
+            timeout: 5m
+            content: |
+              set -eu
+              assert_jsonpath() {
+                resource="$1"
+                path="$2"
+                expected="$3"
+                actual="$(kubectl get "$resource" -n chainsaw-webhooks -o "jsonpath=${path}")"
+                if test "$actual" != "$expected"; then
+                  echo "expected ${resource} ${path} to be '${expected}', got '${actual}'" >&2
+                  exit 1
+                fi
+              }
+              kubectl wait --for=jsonpath='{.status.ready}'=true brokerconsumer/webhooks-webhooks --timeout=5m
+              kubectl wait --for=jsonpath='{.spec.template.spec.containers[0].image}'=ghcr.io/formancehq/webhooks:v3.0.0 deployment/webhooks -n chainsaw-webhooks --timeout=2m
+              kubectl wait --for=jsonpath='{.status.ready}'=true gatewayhttpapi/chainsaw-webhooks-webhooks --timeout=2m
+              kubectl wait --for=jsonpath='{.spec.ports[0].port}'=8080 service/webhooks -n chainsaw-webhooks --timeout=2m
+              assert_jsonpath deployment/webhooks '{.spec.replicas}' '2'
+              assert_jsonpath deployment/webhooks '{.spec.template.spec.containers[0].args[0]}' 'serve'
+              assert_jsonpath deployment/webhooks '{.spec.template.spec.containers[0].resources.requests.cpu}' '20m'
+              assert_jsonpath deployment/webhooks '{.spec.template.spec.containers[0].resources.limits.memory}' '160Mi'
+              assert_jsonpath deployment/webhooks '{.spec.template.metadata.annotations.chainsaw\.formance\.com/template}' 'webhooks'
+              assert_jsonpath pdb/webhooks '{.spec.minAvailable}' '1'
+              assert_jsonpath service/webhooks '{.metadata.annotations.chainsaw\.formance\.com/service}' 'webhooks'
+              kubectl get deployment webhooks -n chainsaw-webhooks -o jsonpath='{range .spec.template.spec.containers[0].env[*]}{.name}={.value}{"\n"}{end}' > /tmp/chainsaw-webhooks-env
+              grep -Fx 'DEV=true' /tmp/chainsaw-webhooks-env
+              grep -Fx 'STACK=chainsaw-webhooks' /tmp/chainsaw-webhooks-env
+              grep -Fx 'POSTGRES_HOST=postgres.chainsaw-webhooks.svc.cluster.local' /tmp/chainsaw-webhooks-env
+              grep -Fx 'POSTGRES_PORT=5432' /tmp/chainsaw-webhooks-env
+              grep -Fx 'POSTGRES_DATABASE=chainsaw-webhooks-webhooks' /tmp/chainsaw-webhooks-env
+              grep -Fx 'POSTGRES_URI=$(POSTGRES_NO_DATABASE_URI)/$(POSTGRES_DATABASE)?sslmode=disable' /tmp/chainsaw-webhooks-env
+              grep -Fx 'STORAGE_POSTGRES_CONN_STRING=$(POSTGRES_URI)' /tmp/chainsaw-webhooks-env
+              grep -Fx 'BROKER=nats' /tmp/chainsaw-webhooks-env
+              grep -Fx 'PUBLISHER_NATS_ENABLED=true' /tmp/chainsaw-webhooks-env
+              grep -Fx 'PUBLISHER_NATS_URL=nats.chainsaw-webhooks.svc.cluster.local:4222' /tmp/chainsaw-webhooks-env
+              grep -Fx 'PUBLISHER_NATS_CLIENT_ID=chainsaw-webhooks-webhooks' /tmp/chainsaw-webhooks-env
+              grep -Fx 'PUBLISHER_NATS_AUTO_PROVISION=false' /tmp/chainsaw-webhooks-env
+              grep -Fx 'WORKER=true' /tmp/chainsaw-webhooks-env
+              grep -Fx 'OTEL_TRACES=true' /tmp/chainsaw-webhooks-env
+              grep -Fx 'OTEL_SERVICE_NAME=webhooks' /tmp/chainsaw-webhooks-env
+              kubectl get deployment webhooks -n chainsaw-webhooks -o jsonpath='{range .spec.template.spec.containers[0].env[*]}{.name}={.valueFrom.secretKeyRef.name}/{.valueFrom.secretKeyRef.key}{"\n"}{end}' > /tmp/chainsaw-webhooks-secret-env
+              grep -Fx 'POSTGRES_USERNAME=postgres/username' /tmp/chainsaw-webhooks-secret-env
+              grep -Fx 'POSTGRES_PASSWORD=postgres/password' /tmp/chainsaw-webhooks-secret-env
+      catch:
+        - script:
+            timeout: 2m
+            content: ../../scripts/dump-diagnostics.sh webhooks-module
+    - name: cleanup-broker-finalizer
+      try:
+        - script:
+            timeout: 2m
+            content: |
+              set -eu
+              if kubectl get broker chainsaw-webhooks >/dev/null 2>&1; then
+                kubectl patch broker chainsaw-webhooks --type=merge -p '{"metadata":{"finalizers":[]}}'
+                kubectl delete broker chainsaw-webhooks --wait=true --timeout=2m
+              fi
+      catch:
+        - script:
+            timeout: 2m
+            content: ../../scripts/dump-diagnostics.sh webhooks-module-cleanup

--- a/tests/e2e/chainsaw/18-webhooks-module/resources/broker.yaml
+++ b/tests/e2e/chainsaw/18-webhooks-module/resources/broker.yaml
@@ -1,0 +1,6 @@
+apiVersion: formance.com/v1beta1
+kind: Broker
+metadata:
+  name: chainsaw-webhooks
+spec:
+  stack: chainsaw-webhooks

--- a/tests/e2e/chainsaw/18-webhooks-module/resources/database.yaml
+++ b/tests/e2e/chainsaw/18-webhooks-module/resources/database.yaml
@@ -1,0 +1,9 @@
+apiVersion: formance.com/v1beta1
+kind: Database
+metadata:
+  name: chainsaw-webhooks-webhooks
+  annotations:
+    formance.com/module-version: v3.0.0
+spec:
+  stack: chainsaw-webhooks
+  service: webhooks

--- a/tests/e2e/chainsaw/18-webhooks-module/resources/nats.yaml
+++ b/tests/e2e/chainsaw/18-webhooks-module/resources/nats.yaml
@@ -1,0 +1,50 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: nats
+  namespace: chainsaw-webhooks
+spec:
+  selector:
+    app.kubernetes.io/name: nats
+  ports:
+    - name: client
+      port: 4222
+      targetPort: 4222
+    - name: monitoring
+      port: 8222
+      targetPort: 8222
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nats
+  namespace: chainsaw-webhooks
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: nats
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: nats
+    spec:
+      containers:
+        - name: nats
+          image: nats:2.10-alpine
+          imagePullPolicy: IfNotPresent
+          args:
+            - -js
+            - -m
+            - "8222"
+          ports:
+            - containerPort: 4222
+              name: client
+            - containerPort: 8222
+              name: monitoring
+          readinessProbe:
+            tcpSocket:
+              port: 4222
+            initialDelaySeconds: 2
+            periodSeconds: 2
+            timeoutSeconds: 1

--- a/tests/e2e/chainsaw/18-webhooks-module/resources/postgres.yaml
+++ b/tests/e2e/chainsaw/18-webhooks-module/resources/postgres.yaml
@@ -1,0 +1,51 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres
+  namespace: chainsaw-webhooks
+spec:
+  selector:
+    app.kubernetes.io/name: postgres
+  ports:
+    - name: postgres
+      port: 5432
+      targetPort: 5432
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: postgres
+  namespace: chainsaw-webhooks
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: postgres
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: postgres
+    spec:
+      containers:
+        - name: postgres
+          image: postgres:15-alpine
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 5432
+              name: postgres
+          env:
+            - name: POSTGRES_USER
+              value: formance
+            - name: POSTGRES_PASSWORD
+              value: formance
+            - name: POSTGRES_DB
+              value: postgres
+          readinessProbe:
+            exec:
+              command:
+                - pg_isready
+                - -U
+                - formance
+            initialDelaySeconds: 2
+            periodSeconds: 2
+            timeoutSeconds: 1

--- a/tests/e2e/chainsaw/18-webhooks-module/resources/settings.yaml
+++ b/tests/e2e/chainsaw/18-webhooks-module/resources/settings.yaml
@@ -1,0 +1,89 @@
+apiVersion: formance.com/v1beta1
+kind: Settings
+metadata:
+  name: chainsaw-webhooks-postgres-uri
+spec:
+  stacks:
+    - chainsaw-webhooks
+  key: postgres.webhooks.uri
+  value: postgresql://postgres.chainsaw-webhooks.svc.cluster.local:5432?secret=postgres&disableSSLMode=true
+---
+apiVersion: formance.com/v1beta1
+kind: Settings
+metadata:
+  name: chainsaw-webhooks-broker-dsn
+spec:
+  stacks:
+    - chainsaw-webhooks
+  key: broker.dsn
+  value: nats://nats.chainsaw-webhooks.svc.cluster.local:4222?replicas=1
+---
+apiVersion: formance.com/v1beta1
+kind: Settings
+metadata:
+  name: chainsaw-webhooks-otel-traces
+spec:
+  stacks:
+    - chainsaw-webhooks
+  key: opentelemetry.traces.dsn
+  value: grpc://otel-collector.chainsaw:4317?insecure=true
+---
+apiVersion: formance.com/v1beta1
+kind: Settings
+metadata:
+  name: chainsaw-webhooks-replicas
+spec:
+  stacks:
+    - chainsaw-webhooks
+  key: deployments.webhooks.replicas
+  value: "2"
+---
+apiVersion: formance.com/v1beta1
+kind: Settings
+metadata:
+  name: chainsaw-webhooks-template-annotations
+spec:
+  stacks:
+    - chainsaw-webhooks
+  key: deployments.webhooks.spec.template.annotations
+  value: chainsaw.formance.com/template=webhooks
+---
+apiVersion: formance.com/v1beta1
+kind: Settings
+metadata:
+  name: chainsaw-webhooks-container-requests
+spec:
+  stacks:
+    - chainsaw-webhooks
+  key: deployments.webhooks.containers.api.resource-requirements.requests
+  value: cpu=20m,memory=64Mi
+---
+apiVersion: formance.com/v1beta1
+kind: Settings
+metadata:
+  name: chainsaw-webhooks-container-limits
+spec:
+  stacks:
+    - chainsaw-webhooks
+  key: deployments.webhooks.containers.api.resource-requirements.limits
+  value: memory=160Mi
+---
+apiVersion: formance.com/v1beta1
+kind: Settings
+metadata:
+  name: chainsaw-webhooks-pdb
+spec:
+  stacks:
+    - chainsaw-webhooks
+  key: deployments.webhooks.pod-disruption-budget
+  value: minAvailable=1
+---
+apiVersion: formance.com/v1beta1
+kind: Settings
+metadata:
+  name: chainsaw-webhooks-service-annotations
+spec:
+  stacks:
+    - chainsaw-webhooks
+  key: services.webhooks.annotations
+  value: chainsaw.formance.com/service=webhooks

--- a/tests/e2e/chainsaw/18-webhooks-module/resources/source-secret.yaml
+++ b/tests/e2e/chainsaw/18-webhooks-module/resources/source-secret.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: chainsaw-webhooks-postgres-credentials
+  namespace: default
+  labels:
+    formance.com/stack: chainsaw-webhooks
+  annotations:
+    formance.com/referenced-by-name: postgres
+stringData:
+  username: formance
+  password: formance

--- a/tests/e2e/chainsaw/18-webhooks-module/resources/stack.yaml
+++ b/tests/e2e/chainsaw/18-webhooks-module/resources/stack.yaml
@@ -1,0 +1,7 @@
+apiVersion: formance.com/v1beta1
+kind: Stack
+metadata:
+  name: chainsaw-webhooks
+spec:
+  version: v3.0.0
+  dev: true

--- a/tests/e2e/chainsaw/18-webhooks-module/resources/webhooks.yaml
+++ b/tests/e2e/chainsaw/18-webhooks-module/resources/webhooks.yaml
@@ -1,0 +1,6 @@
+apiVersion: formance.com/v1beta1
+kind: Webhooks
+metadata:
+  name: webhooks
+spec:
+  stack: chainsaw-webhooks

--- a/tests/e2e/chainsaw/19-stargate-module/chainsaw-test.yaml
+++ b/tests/e2e/chainsaw/19-stargate-module/chainsaw-test.yaml
@@ -1,0 +1,55 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: stargate-module
+  labels:
+    suite: modules
+    feature: stargate-module
+spec:
+  concurrent: false
+  steps:
+    - name: stargate-renders-deployment-service-and-settings
+      try:
+        - apply:
+            file: resources/stack.yaml
+        - apply:
+            file: resources/settings.yaml
+        - apply:
+            file: resources/stargate.yaml
+        - script:
+            timeout: 5m
+            content: |
+              set -eu
+              assert_jsonpath() {
+                resource="$1"
+                path="$2"
+                expected="$3"
+                actual="$(kubectl get "$resource" -n chainsaw-stargate -o "jsonpath=${path}")"
+                if test "$actual" != "$expected"; then
+                  echo "expected ${resource} ${path} to be '${expected}', got '${actual}'" >&2
+                  exit 1
+                fi
+              }
+              kubectl wait --for=jsonpath='{.spec.template.spec.containers[0].image}'=ghcr.io/formancehq/stargate:v3.0.0 deployment/stargate -n chainsaw-stargate --timeout=2m
+              assert_jsonpath deployment/stargate '{.spec.replicas}' '2'
+              assert_jsonpath deployment/stargate '{.spec.template.spec.containers[0].resources.requests.cpu}' '10m'
+              assert_jsonpath deployment/stargate '{.spec.template.spec.containers[0].resources.limits.memory}' '128Mi'
+              assert_jsonpath deployment/stargate '{.spec.template.metadata.annotations.chainsaw\.formance\.com/template}' 'stargate'
+              assert_jsonpath pdb/stargate '{.spec.minAvailable}' '1'
+              kubectl get deployment stargate -n chainsaw-stargate -o jsonpath='{range .spec.template.spec.containers[0].env[*]}{.name}={.value}{"\n"}{end}' > /tmp/chainsaw-stargate-env
+              grep -Fx 'DEV=true' /tmp/chainsaw-stargate-env
+              grep -Fx 'STACK=chainsaw-stargate' /tmp/chainsaw-stargate-env
+              grep -Fx 'ORGANIZATION_ID=org_chainsaw' /tmp/chainsaw-stargate-env
+              grep -Fx 'STACK_ID=stack_chainsaw' /tmp/chainsaw-stargate-env
+              grep -Fx 'STARGATE_SERVER_URL=https://stargate.chainsaw.local' /tmp/chainsaw-stargate-env
+              grep -Fx 'GATEWAY_URL=http://gateway:8080' /tmp/chainsaw-stargate-env
+              grep -Fx 'STARGATE_AUTH_CLIENT_ID=chainsaw-client' /tmp/chainsaw-stargate-env
+              grep -Fx 'STARGATE_AUTH_CLIENT_SECRET=chainsaw-secret' /tmp/chainsaw-stargate-env
+              grep -Fx 'STARGATE_AUTH_ISSUER_URL=https://issuer.stargate.chainsaw.local' /tmp/chainsaw-stargate-env
+              grep -Fx 'TLS_ENABLED=false' /tmp/chainsaw-stargate-env
+              grep -Fx 'OTEL_TRACES=true' /tmp/chainsaw-stargate-env
+              grep -Fx 'OTEL_SERVICE_NAME=stargate' /tmp/chainsaw-stargate-env
+      catch:
+        - script:
+            timeout: 2m
+            content: ../../scripts/dump-diagnostics.sh stargate-module

--- a/tests/e2e/chainsaw/19-stargate-module/resources/settings.yaml
+++ b/tests/e2e/chainsaw/19-stargate-module/resources/settings.yaml
@@ -1,0 +1,69 @@
+apiVersion: formance.com/v1beta1
+kind: Settings
+metadata:
+  name: chainsaw-stargate-otel-traces
+spec:
+  stacks:
+    - chainsaw-stargate
+  key: opentelemetry.traces.dsn
+  value: grpc://otel-collector.chainsaw:4317?insecure=true
+---
+apiVersion: formance.com/v1beta1
+kind: Settings
+metadata:
+  name: chainsaw-stargate-replicas
+spec:
+  stacks:
+    - chainsaw-stargate
+  key: deployments.stargate.replicas
+  value: "2"
+---
+apiVersion: formance.com/v1beta1
+kind: Settings
+metadata:
+  name: chainsaw-stargate-template-annotations
+spec:
+  stacks:
+    - chainsaw-stargate
+  key: deployments.stargate.spec.template.annotations
+  value: chainsaw.formance.com/template=stargate
+---
+apiVersion: formance.com/v1beta1
+kind: Settings
+metadata:
+  name: chainsaw-stargate-container-requests
+spec:
+  stacks:
+    - chainsaw-stargate
+  key: deployments.stargate.containers.stargate.resource-requirements.requests
+  value: cpu=10m,memory=64Mi
+---
+apiVersion: formance.com/v1beta1
+kind: Settings
+metadata:
+  name: chainsaw-stargate-container-limits
+spec:
+  stacks:
+    - chainsaw-stargate
+  key: deployments.stargate.containers.stargate.resource-requirements.limits
+  value: memory=128Mi
+---
+apiVersion: formance.com/v1beta1
+kind: Settings
+metadata:
+  name: chainsaw-stargate-pdb
+spec:
+  stacks:
+    - chainsaw-stargate
+  key: deployments.stargate.pod-disruption-budget
+  value: minAvailable=1
+---
+apiVersion: formance.com/v1beta1
+kind: Settings
+metadata:
+  name: chainsaw-stargate-service-annotations
+spec:
+  stacks:
+    - chainsaw-stargate
+  key: services.stargate.annotations
+  value: chainsaw.formance.com/service=stargate

--- a/tests/e2e/chainsaw/19-stargate-module/resources/stack.yaml
+++ b/tests/e2e/chainsaw/19-stargate-module/resources/stack.yaml
@@ -1,0 +1,7 @@
+apiVersion: formance.com/v1beta1
+kind: Stack
+metadata:
+  name: chainsaw-stargate
+spec:
+  version: v3.0.0
+  dev: true

--- a/tests/e2e/chainsaw/19-stargate-module/resources/stargate.yaml
+++ b/tests/e2e/chainsaw/19-stargate-module/resources/stargate.yaml
@@ -1,0 +1,15 @@
+apiVersion: formance.com/v1beta1
+kind: Stargate
+metadata:
+  name: stargate
+spec:
+  stack: chainsaw-stargate
+  serverURL: https://stargate.chainsaw.local
+  organizationID: org_chainsaw
+  stackID: stack_chainsaw
+  auth:
+    clientID: chainsaw-client
+    clientSecret: chainsaw-secret
+    issuer: https://issuer.stargate.chainsaw.local
+  tls:
+    disable: true

--- a/tests/e2e/chainsaw/20-orchestration-module/chainsaw-test.yaml
+++ b/tests/e2e/chainsaw/20-orchestration-module/chainsaw-test.yaml
@@ -98,12 +98,17 @@ spec:
         - script:
             timeout: 2m
             content: ../../scripts/dump-diagnostics.sh orchestration-module
-    - name: cleanup-broker-finalizer
+    - name: cleanup-finalizers
       try:
         - script:
             timeout: 2m
             content: |
               set -eu
+              kubectl patch stack chainsaw-orchestration --type=merge -p '{"spec":{"disabled":true}}'
+              if kubectl get database chainsaw-orchestration-orchestration >/dev/null 2>&1; then
+                kubectl patch database chainsaw-orchestration-orchestration --type=merge -p '{"metadata":{"finalizers":[]}}'
+                kubectl delete database chainsaw-orchestration-orchestration --ignore-not-found=true --wait=false
+              fi
               if kubectl get broker chainsaw-orchestration >/dev/null 2>&1; then
                 kubectl patch broker chainsaw-orchestration --type=merge -p '{"metadata":{"finalizers":[]}}'
                 kubectl delete broker chainsaw-orchestration --wait=true --timeout=2m

--- a/tests/e2e/chainsaw/20-orchestration-module/chainsaw-test.yaml
+++ b/tests/e2e/chainsaw/20-orchestration-module/chainsaw-test.yaml
@@ -107,7 +107,6 @@ spec:
               kubectl patch stack chainsaw-orchestration --type=merge -p '{"spec":{"disabled":true}}'
               if kubectl get database chainsaw-orchestration-orchestration >/dev/null 2>&1; then
                 kubectl patch database chainsaw-orchestration-orchestration --type=merge -p '{"metadata":{"finalizers":[]}}'
-                kubectl delete database chainsaw-orchestration-orchestration --ignore-not-found=true --wait=false
               fi
               if kubectl get broker chainsaw-orchestration >/dev/null 2>&1; then
                 kubectl patch broker chainsaw-orchestration --type=merge -p '{"metadata":{"finalizers":[]}}'

--- a/tests/e2e/chainsaw/20-orchestration-module/chainsaw-test.yaml
+++ b/tests/e2e/chainsaw/20-orchestration-module/chainsaw-test.yaml
@@ -1,0 +1,114 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: orchestration-module
+  labels:
+    suite: modules
+    feature: orchestration-module
+spec:
+  concurrent: false
+  steps:
+    - name: orchestration-renders-postgres-broker-authclient-temporal-gateway-and-settings
+      try:
+        - apply:
+            file: resources/source-secret.yaml
+        - apply:
+            file: resources/stack.yaml
+        - apply:
+            file: resources/postgres.yaml
+        - apply:
+            file: resources/nats.yaml
+        - apply:
+            file: resources/settings.yaml
+        - apply:
+            file: resources/database.yaml
+        - apply:
+            file: resources/broker.yaml
+        - apply:
+            file: resources/auth.yaml
+        - script:
+            timeout: 5m
+            content: |
+              set -eu
+              kubectl rollout status deployment/postgres -n chainsaw-orchestration --timeout=2m
+              kubectl rollout status deployment/nats -n chainsaw-orchestration --timeout=2m
+              kubectl wait --for=jsonpath='{.status.ready}'=true database/chainsaw-orchestration-orchestration --timeout=5m
+              kubectl wait --for=jsonpath='{.status.ready}'=true broker/chainsaw-orchestration --timeout=5m
+        - apply:
+            file: resources/orchestration.yaml
+        - script:
+            timeout: 5m
+            content: |
+              set -eu
+              assert_jsonpath() {
+                resource="$1"
+                path="$2"
+                expected="$3"
+                actual="$(kubectl get "$resource" -n chainsaw-orchestration -o "jsonpath=${path}")"
+                if test "$actual" != "$expected"; then
+                  echo "expected ${resource} ${path} to be '${expected}', got '${actual}'" >&2
+                  exit 1
+                fi
+              }
+              kubectl wait --for=jsonpath='{.status.ready}'=true brokerconsumer/orchestration-orchestration --timeout=5m
+              kubectl wait --for=jsonpath='{.status.ready}'=true authclient/chainsaw-orchestration-orchestration --timeout=2m
+              kubectl wait --for=jsonpath='{.spec.template.spec.containers[0].image}'=ghcr.io/formancehq/orchestration:v3.0.0 deployment/orchestration -n chainsaw-orchestration --timeout=2m
+              kubectl wait --for=jsonpath='{.status.ready}'=true gatewayhttpapi/chainsaw-orchestration-orchestration --timeout=2m
+              kubectl wait --for=jsonpath='{.spec.ports[0].port}'=8080 service/orchestration -n chainsaw-orchestration --timeout=2m
+              assert_jsonpath deployment/orchestration '{.spec.template.spec.containers[0].resources.requests.cpu}' '20m'
+              assert_jsonpath deployment/orchestration '{.spec.template.spec.containers[0].resources.limits.memory}' '192Mi'
+              assert_jsonpath pdb/orchestration '{.spec.minAvailable}' '1'
+              assert_jsonpath service/orchestration '{.metadata.annotations.chainsaw\.formance\.com/service}' 'orchestration'
+              kubectl get deployment orchestration -n chainsaw-orchestration -o jsonpath='{range .spec.template.spec.containers[0].env[*]}{.name}={.value}{"\n"}{end}' > /tmp/chainsaw-orchestration-env
+              grep -Fx 'DEV=true' /tmp/chainsaw-orchestration-env
+              grep -Fx 'STACK=chainsaw-orchestration' /tmp/chainsaw-orchestration-env
+              grep -Fx 'POSTGRES_HOST=postgres.chainsaw-orchestration.svc.cluster.local' /tmp/chainsaw-orchestration-env
+              grep -Fx 'POSTGRES_PORT=5432' /tmp/chainsaw-orchestration-env
+              grep -Fx 'POSTGRES_DATABASE=chainsaw-orchestration-orchestration' /tmp/chainsaw-orchestration-env
+              grep -Fx 'POSTGRES_DSN=$(POSTGRES_URI)' /tmp/chainsaw-orchestration-env
+              grep -Fx 'TEMPORAL_ADDRESS=temporal.chainsaw-orchestration.svc.cluster.local:7233' /tmp/chainsaw-orchestration-env
+              grep -Fx 'TEMPORAL_NAMESPACE=default' /tmp/chainsaw-orchestration-env
+              grep -Fx 'TEMPORAL_TASK_QUEUE=chainsaw-orchestration' /tmp/chainsaw-orchestration-env
+              grep -Fx 'TEMPORAL_SSL_CLIENT_CERT=crt-data' /tmp/chainsaw-orchestration-env
+              grep -Fx 'TEMPORAL_SSL_CLIENT_KEY=key-data' /tmp/chainsaw-orchestration-env
+              grep -Fx 'TEMPORAL_INIT_SEARCH_ATTRIBUTES=true' /tmp/chainsaw-orchestration-env
+              grep -Fx 'TEMPORAL_MAX_PARALLEL_ACTIVITIES=17' /tmp/chainsaw-orchestration-env
+              grep -Fx 'WORKER=true' /tmp/chainsaw-orchestration-env
+              grep -Fx 'TOPICS=' /tmp/chainsaw-orchestration-env
+              grep -Fx 'BROKER=nats' /tmp/chainsaw-orchestration-env
+              grep -Fx 'PUBLISHER_NATS_ENABLED=true' /tmp/chainsaw-orchestration-env
+              grep -Fx 'PUBLISHER_NATS_URL=nats.chainsaw-orchestration.svc.cluster.local:4222' /tmp/chainsaw-orchestration-env
+              grep -Fx 'PUBLISHER_NATS_CLIENT_ID=chainsaw-orchestration-orchestration' /tmp/chainsaw-orchestration-env
+              grep -Fx 'PUBLISHER_TOPIC_MAPPING=*:chainsaw-orchestration.orchestration' /tmp/chainsaw-orchestration-env
+              grep -Fx 'PUBLISHER_NATS_AUTO_PROVISION=false' /tmp/chainsaw-orchestration-env
+              grep -Fx 'AUTH_ENABLED=true' /tmp/chainsaw-orchestration-env
+              grep -Fx 'AUTH_ISSUER=http://auth:8080' /tmp/chainsaw-orchestration-env
+              grep -Fx 'AUTH_ISSUERS=https://issuer.orchestration.chainsaw.local' /tmp/chainsaw-orchestration-env
+              grep -Fx 'AUTH_CHECK_SCOPES=true' /tmp/chainsaw-orchestration-env
+              grep -Fx 'AUTH_SERVICE=orchestration' /tmp/chainsaw-orchestration-env
+              grep -Fx 'OTEL_TRACES=true' /tmp/chainsaw-orchestration-env
+              grep -Fx 'OTEL_SERVICE_NAME=orchestration' /tmp/chainsaw-orchestration-env
+              kubectl get deployment orchestration -n chainsaw-orchestration -o jsonpath='{range .spec.template.spec.containers[0].env[*]}{.name}={.valueFrom.secretKeyRef.name}/{.valueFrom.secretKeyRef.key}{"\n"}{end}' > /tmp/chainsaw-orchestration-secret-env
+              grep -Fx 'POSTGRES_USERNAME=postgres/username' /tmp/chainsaw-orchestration-secret-env
+              grep -Fx 'POSTGRES_PASSWORD=postgres/password' /tmp/chainsaw-orchestration-secret-env
+              grep -Fx 'STACK_CLIENT_ID=auth-client-chainsaw-orchestration-orchestration/id' /tmp/chainsaw-orchestration-secret-env
+              grep -Fx 'STACK_CLIENT_SECRET=auth-client-chainsaw-orchestration-orchestration/secret' /tmp/chainsaw-orchestration-secret-env
+              test "$(kubectl get authclient chainsaw-orchestration-orchestration -o jsonpath='{.spec.scopes[*]}')" = "ledger:read ledger:write payments:read payments:write wallets:read wallets:write"
+      catch:
+        - script:
+            timeout: 2m
+            content: ../../scripts/dump-diagnostics.sh orchestration-module
+    - name: cleanup-broker-finalizer
+      try:
+        - script:
+            timeout: 2m
+            content: |
+              set -eu
+              if kubectl get broker chainsaw-orchestration >/dev/null 2>&1; then
+                kubectl patch broker chainsaw-orchestration --type=merge -p '{"metadata":{"finalizers":[]}}'
+                kubectl delete broker chainsaw-orchestration --wait=true --timeout=2m
+              fi
+      catch:
+        - script:
+            timeout: 2m
+            content: ../../scripts/dump-diagnostics.sh orchestration-module-cleanup

--- a/tests/e2e/chainsaw/20-orchestration-module/resources/auth.yaml
+++ b/tests/e2e/chainsaw/20-orchestration-module/resources/auth.yaml
@@ -1,0 +1,6 @@
+apiVersion: formance.com/v1beta1
+kind: Auth
+metadata:
+  name: auth
+spec:
+  stack: chainsaw-orchestration

--- a/tests/e2e/chainsaw/20-orchestration-module/resources/broker.yaml
+++ b/tests/e2e/chainsaw/20-orchestration-module/resources/broker.yaml
@@ -1,0 +1,6 @@
+apiVersion: formance.com/v1beta1
+kind: Broker
+metadata:
+  name: chainsaw-orchestration
+spec:
+  stack: chainsaw-orchestration

--- a/tests/e2e/chainsaw/20-orchestration-module/resources/database.yaml
+++ b/tests/e2e/chainsaw/20-orchestration-module/resources/database.yaml
@@ -1,0 +1,9 @@
+apiVersion: formance.com/v1beta1
+kind: Database
+metadata:
+  name: chainsaw-orchestration-orchestration
+  annotations:
+    formance.com/module-version: v3.0.0
+spec:
+  stack: chainsaw-orchestration
+  service: orchestration

--- a/tests/e2e/chainsaw/20-orchestration-module/resources/nats.yaml
+++ b/tests/e2e/chainsaw/20-orchestration-module/resources/nats.yaml
@@ -1,0 +1,50 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: nats
+  namespace: chainsaw-orchestration
+spec:
+  selector:
+    app.kubernetes.io/name: nats
+  ports:
+    - name: client
+      port: 4222
+      targetPort: 4222
+    - name: monitoring
+      port: 8222
+      targetPort: 8222
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nats
+  namespace: chainsaw-orchestration
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: nats
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: nats
+    spec:
+      containers:
+        - name: nats
+          image: nats:2.10-alpine
+          imagePullPolicy: IfNotPresent
+          args:
+            - -js
+            - -m
+            - "8222"
+          ports:
+            - containerPort: 4222
+              name: client
+            - containerPort: 8222
+              name: monitoring
+          readinessProbe:
+            tcpSocket:
+              port: 4222
+            initialDelaySeconds: 2
+            periodSeconds: 2
+            timeoutSeconds: 1

--- a/tests/e2e/chainsaw/20-orchestration-module/resources/orchestration.yaml
+++ b/tests/e2e/chainsaw/20-orchestration-module/resources/orchestration.yaml
@@ -1,0 +1,6 @@
+apiVersion: formance.com/v1beta1
+kind: Orchestration
+metadata:
+  name: orchestration
+spec:
+  stack: chainsaw-orchestration

--- a/tests/e2e/chainsaw/20-orchestration-module/resources/postgres.yaml
+++ b/tests/e2e/chainsaw/20-orchestration-module/resources/postgres.yaml
@@ -1,0 +1,51 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres
+  namespace: chainsaw-orchestration
+spec:
+  selector:
+    app.kubernetes.io/name: postgres
+  ports:
+    - name: postgres
+      port: 5432
+      targetPort: 5432
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: postgres
+  namespace: chainsaw-orchestration
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: postgres
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: postgres
+    spec:
+      containers:
+        - name: postgres
+          image: postgres:15-alpine
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 5432
+              name: postgres
+          env:
+            - name: POSTGRES_USER
+              value: formance
+            - name: POSTGRES_PASSWORD
+              value: formance
+            - name: POSTGRES_DB
+              value: postgres
+          readinessProbe:
+            exec:
+              command:
+                - pg_isready
+                - -U
+                - formance
+            initialDelaySeconds: 2
+            periodSeconds: 2
+            timeoutSeconds: 1

--- a/tests/e2e/chainsaw/20-orchestration-module/resources/settings.yaml
+++ b/tests/e2e/chainsaw/20-orchestration-module/resources/settings.yaml
@@ -1,0 +1,129 @@
+apiVersion: formance.com/v1beta1
+kind: Settings
+metadata:
+  name: chainsaw-orchestration-postgres-uri
+spec:
+  stacks:
+    - chainsaw-orchestration
+  key: postgres.orchestration.uri
+  value: postgresql://postgres.chainsaw-orchestration.svc.cluster.local:5432?secret=postgres&disableSSLMode=true
+---
+apiVersion: formance.com/v1beta1
+kind: Settings
+metadata:
+  name: chainsaw-orchestration-broker-dsn
+spec:
+  stacks:
+    - chainsaw-orchestration
+  key: broker.dsn
+  value: nats://nats.chainsaw-orchestration.svc.cluster.local:4222?replicas=1
+---
+apiVersion: formance.com/v1beta1
+kind: Settings
+metadata:
+  name: chainsaw-orchestration-temporal-dsn
+spec:
+  stacks:
+    - chainsaw-orchestration
+  key: temporal.dsn
+  value: temporal://temporal.chainsaw-orchestration.svc.cluster.local:7233/default?initSearchAttributes=true
+---
+apiVersion: formance.com/v1beta1
+kind: Settings
+metadata:
+  name: chainsaw-orchestration-temporal-tls-crt
+spec:
+  stacks:
+    - chainsaw-orchestration
+  key: temporal.tls.crt
+  value: crt-data
+---
+apiVersion: formance.com/v1beta1
+kind: Settings
+metadata:
+  name: chainsaw-orchestration-temporal-tls-key
+spec:
+  stacks:
+    - chainsaw-orchestration
+  key: temporal.tls.key
+  value: key-data
+---
+apiVersion: formance.com/v1beta1
+kind: Settings
+metadata:
+  name: chainsaw-orchestration-max-parallel-activities
+spec:
+  stacks:
+    - chainsaw-orchestration
+  key: orchestration.max-parallel-activities
+  value: "17"
+---
+apiVersion: formance.com/v1beta1
+kind: Settings
+metadata:
+  name: chainsaw-orchestration-auth-issuers
+spec:
+  stacks:
+    - chainsaw-orchestration
+  key: auth.issuers
+  value: https://issuer.orchestration.chainsaw.local
+---
+apiVersion: formance.com/v1beta1
+kind: Settings
+metadata:
+  name: chainsaw-orchestration-auth-check-scopes
+spec:
+  stacks:
+    - chainsaw-orchestration
+  key: auth.orchestration.check-scopes
+  value: "true"
+---
+apiVersion: formance.com/v1beta1
+kind: Settings
+metadata:
+  name: chainsaw-orchestration-otel-traces
+spec:
+  stacks:
+    - chainsaw-orchestration
+  key: opentelemetry.traces.dsn
+  value: grpc://otel-collector.chainsaw:4317?insecure=true
+---
+apiVersion: formance.com/v1beta1
+kind: Settings
+metadata:
+  name: chainsaw-orchestration-container-requests
+spec:
+  stacks:
+    - chainsaw-orchestration
+  key: deployments.orchestration.containers.api.resource-requirements.requests
+  value: cpu=20m,memory=64Mi
+---
+apiVersion: formance.com/v1beta1
+kind: Settings
+metadata:
+  name: chainsaw-orchestration-container-limits
+spec:
+  stacks:
+    - chainsaw-orchestration
+  key: deployments.orchestration.containers.api.resource-requirements.limits
+  value: memory=192Mi
+---
+apiVersion: formance.com/v1beta1
+kind: Settings
+metadata:
+  name: chainsaw-orchestration-pdb
+spec:
+  stacks:
+    - chainsaw-orchestration
+  key: deployments.orchestration.pod-disruption-budget
+  value: minAvailable=1
+---
+apiVersion: formance.com/v1beta1
+kind: Settings
+metadata:
+  name: chainsaw-orchestration-service-annotations
+spec:
+  stacks:
+    - chainsaw-orchestration
+  key: services.orchestration.annotations
+  value: chainsaw.formance.com/service=orchestration

--- a/tests/e2e/chainsaw/20-orchestration-module/resources/source-secret.yaml
+++ b/tests/e2e/chainsaw/20-orchestration-module/resources/source-secret.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: chainsaw-orchestration-postgres-credentials
+  namespace: default
+  labels:
+    formance.com/stack: chainsaw-orchestration
+  annotations:
+    formance.com/referenced-by-name: postgres
+stringData:
+  username: formance
+  password: formance

--- a/tests/e2e/chainsaw/20-orchestration-module/resources/stack.yaml
+++ b/tests/e2e/chainsaw/20-orchestration-module/resources/stack.yaml
@@ -1,0 +1,7 @@
+apiVersion: formance.com/v1beta1
+kind: Stack
+metadata:
+  name: chainsaw-orchestration
+spec:
+  version: v3.0.0
+  dev: true

--- a/tests/e2e/chainsaw/21-payments-module/chainsaw-test.yaml
+++ b/tests/e2e/chainsaw/21-payments-module/chainsaw-test.yaml
@@ -111,7 +111,6 @@ spec:
               kubectl patch stack chainsaw-payments --type=merge -p '{"spec":{"disabled":true}}'
               if kubectl get database chainsaw-payments-payments >/dev/null 2>&1; then
                 kubectl patch database chainsaw-payments-payments --type=merge -p '{"metadata":{"finalizers":[]}}'
-                kubectl delete database chainsaw-payments-payments --ignore-not-found=true --wait=false
               fi
               if kubectl get broker chainsaw-payments >/dev/null 2>&1; then
                 kubectl patch broker chainsaw-payments --type=merge -p '{"metadata":{"finalizers":[]}}'

--- a/tests/e2e/chainsaw/21-payments-module/chainsaw-test.yaml
+++ b/tests/e2e/chainsaw/21-payments-module/chainsaw-test.yaml
@@ -102,12 +102,17 @@ spec:
         - script:
             timeout: 2m
             content: ../../scripts/dump-diagnostics.sh payments-module
-    - name: cleanup-broker-finalizer
+    - name: cleanup-finalizers
       try:
         - script:
             timeout: 2m
             content: |
               set -eu
+              kubectl patch stack chainsaw-payments --type=merge -p '{"spec":{"disabled":true}}'
+              if kubectl get database chainsaw-payments-payments >/dev/null 2>&1; then
+                kubectl patch database chainsaw-payments-payments --type=merge -p '{"metadata":{"finalizers":[]}}'
+                kubectl delete database chainsaw-payments-payments --ignore-not-found=true --wait=false
+              fi
               if kubectl get broker chainsaw-payments >/dev/null 2>&1; then
                 kubectl patch broker chainsaw-payments --type=merge -p '{"metadata":{"finalizers":[]}}'
                 kubectl delete broker chainsaw-payments --wait=true --timeout=2m

--- a/tests/e2e/chainsaw/21-payments-module/chainsaw-test.yaml
+++ b/tests/e2e/chainsaw/21-payments-module/chainsaw-test.yaml
@@ -1,0 +1,118 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: payments-module
+  labels:
+    suite: modules
+    feature: payments-module
+spec:
+  concurrent: false
+  steps:
+    - name: payments-renders-postgres-broker-temporal-gateway-and-settings
+      try:
+        - apply:
+            file: resources/source-secret.yaml
+        - apply:
+            file: resources/stack.yaml
+        - apply:
+            file: resources/postgres.yaml
+        - apply:
+            file: resources/nats.yaml
+        - apply:
+            file: resources/settings.yaml
+        - apply:
+            file: resources/database.yaml
+        - apply:
+            file: resources/broker.yaml
+        - apply:
+            file: resources/brokertopic.yaml
+        - apply:
+            file: resources/auth.yaml
+        - script:
+            timeout: 5m
+            content: |
+              set -eu
+              kubectl rollout status deployment/postgres -n chainsaw-payments --timeout=2m
+              kubectl rollout status deployment/nats -n chainsaw-payments --timeout=2m
+              kubectl wait --for=jsonpath='{.status.ready}'=true database/chainsaw-payments-payments --timeout=5m
+              kubectl wait --for=jsonpath='{.status.ready}'=true broker/chainsaw-payments --timeout=5m
+              kubectl wait --for=jsonpath='{.status.ready}'=true brokertopic/chainsaw-payments-payments --timeout=2m
+        - apply:
+            file: resources/payments.yaml
+        - script:
+            timeout: 5m
+            content: |
+              set -eu
+              assert_jsonpath() {
+                resource="$1"
+                path="$2"
+                expected="$3"
+                actual="$(kubectl get "$resource" -n chainsaw-payments -o "jsonpath=${path}")"
+                if test "$actual" != "$expected"; then
+                  echo "expected ${resource} ${path} to be '${expected}', got '${actual}'" >&2
+                  exit 1
+                fi
+              }
+              kubectl wait --for=jsonpath='{.spec.template.spec.containers[0].image}'=ghcr.io/formancehq/payments:v3.0.0 deployment/payments -n chainsaw-payments --timeout=2m
+              kubectl wait --for=jsonpath='{.spec.template.spec.containers[0].image}'=ghcr.io/formancehq/payments:v3.0.0 deployment/payments-worker -n chainsaw-payments --timeout=2m
+              kubectl wait --for=jsonpath='{.status.ready}'=true gatewayhttpapi/chainsaw-payments-payments --timeout=2m
+              kubectl wait --for=jsonpath='{.spec.ports[0].port}'=8080 service/payments -n chainsaw-payments --timeout=2m
+              assert_jsonpath deployment/payments '{.spec.template.spec.containers[0].args[0]}' 'server'
+              assert_jsonpath deployment/payments-worker '{.spec.template.spec.containers[0].args[0]}' 'worker'
+              assert_jsonpath deployment/payments '{.spec.template.spec.containers[0].resources.requests.cpu}' '20m'
+              assert_jsonpath deployment/payments '{.spec.template.spec.containers[0].resources.limits.memory}' '192Mi'
+              assert_jsonpath deployment/payments-worker '{.spec.template.spec.containers[0].resources.requests.cpu}' '15m'
+              assert_jsonpath deployment/payments-worker '{.spec.template.spec.containers[0].resources.limits.memory}' '160Mi'
+              assert_jsonpath service/payments '{.metadata.annotations.chainsaw\.formance\.com/service}' 'payments'
+              kubectl get deployment payments -n chainsaw-payments -o jsonpath='{range .spec.template.spec.containers[0].env[*]}{.name}={.value}{"\n"}{end}' > /tmp/chainsaw-payments-api-env
+              grep -Fx 'DEV=true' /tmp/chainsaw-payments-api-env
+              grep -Fx 'STACK=chainsaw-payments' /tmp/chainsaw-payments-api-env
+              grep -Fx 'POSTGRES_HOST=postgres.chainsaw-payments.svc.cluster.local' /tmp/chainsaw-payments-api-env
+              grep -Fx 'POSTGRES_PORT=5432' /tmp/chainsaw-payments-api-env
+              grep -Fx 'POSTGRES_DATABASE=chainsaw-payments-payments' /tmp/chainsaw-payments-api-env
+              grep -Fx 'POSTGRES_DATABASE_NAME=$(POSTGRES_DATABASE)' /tmp/chainsaw-payments-api-env
+              grep -Fx 'CONFIG_ENCRYPTION_KEY=chainsaw-encryption-key' /tmp/chainsaw-payments-api-env
+              grep -Fx 'BROKER=nats' /tmp/chainsaw-payments-api-env
+              grep -Fx 'PUBLISHER_NATS_ENABLED=true' /tmp/chainsaw-payments-api-env
+              grep -Fx 'PUBLISHER_NATS_URL=nats.chainsaw-payments.svc.cluster.local:4222' /tmp/chainsaw-payments-api-env
+              grep -Fx 'PUBLISHER_NATS_CLIENT_ID=chainsaw-payments-payments' /tmp/chainsaw-payments-api-env
+              grep -Fx 'PUBLISHER_TOPIC_MAPPING=*:chainsaw-payments.payments' /tmp/chainsaw-payments-api-env
+              grep -Fx 'PUBLISHER_NATS_AUTO_PROVISION=false' /tmp/chainsaw-payments-api-env
+              grep -Fx 'AUTH_ENABLED=true' /tmp/chainsaw-payments-api-env
+              grep -Fx 'AUTH_ISSUER=http://auth:8080' /tmp/chainsaw-payments-api-env
+              grep -Fx 'AUTH_ISSUERS=https://issuer.payments.chainsaw.local' /tmp/chainsaw-payments-api-env
+              grep -Fx 'AUTH_CHECK_SCOPES=true' /tmp/chainsaw-payments-api-env
+              grep -Fx 'AUTH_SERVICE=payments' /tmp/chainsaw-payments-api-env
+              grep -Fx 'OTEL_TRACES=true' /tmp/chainsaw-payments-api-env
+              grep -Fx 'OTEL_SERVICE_NAME=payments' /tmp/chainsaw-payments-api-env
+              kubectl get deployment payments-worker -n chainsaw-payments -o jsonpath='{range .spec.template.spec.containers[0].env[*]}{.name}={.value}{"\n"}{end}' > /tmp/chainsaw-payments-worker-env
+              grep -Fx 'TEMPORAL_ADDRESS=temporal.chainsaw-payments.svc.cluster.local:7233' /tmp/chainsaw-payments-worker-env
+              grep -Fx 'TEMPORAL_NAMESPACE=default' /tmp/chainsaw-payments-worker-env
+              grep -Fx 'TEMPORAL_SSL_CLIENT_CERT=crt-data' /tmp/chainsaw-payments-worker-env
+              grep -Fx 'TEMPORAL_SSL_CLIENT_KEY=key-data' /tmp/chainsaw-payments-worker-env
+              grep -Fx 'TEMPORAL_INIT_SEARCH_ATTRIBUTES=true' /tmp/chainsaw-payments-worker-env
+              grep -Fx 'TEMPORAL_MAX_CONCURRENT_WORKFLOW_TASK_POLLERS=6' /tmp/chainsaw-payments-worker-env
+              grep -Fx 'TEMPORAL_MAX_CONCURRENT_ACTIVITY_TASK_POLLERS=7' /tmp/chainsaw-payments-worker-env
+              grep -Fx 'TEMPORAL_MAX_SLOTS_PER_POLLER=8' /tmp/chainsaw-payments-worker-env
+              grep -Fx 'TEMPORAL_MAX_LOCAL_ACTIVITY_SLOTS=9' /tmp/chainsaw-payments-worker-env
+              kubectl get deployment payments -n chainsaw-payments -o jsonpath='{range .spec.template.spec.containers[0].env[*]}{.name}={.valueFrom.secretKeyRef.name}/{.valueFrom.secretKeyRef.key}{"\n"}{end}' > /tmp/chainsaw-payments-secret-env
+              grep -Fx 'POSTGRES_USERNAME=postgres/username' /tmp/chainsaw-payments-secret-env
+              grep -Fx 'POSTGRES_PASSWORD=postgres/password' /tmp/chainsaw-payments-secret-env
+      catch:
+        - script:
+            timeout: 2m
+            content: ../../scripts/dump-diagnostics.sh payments-module
+    - name: cleanup-broker-finalizer
+      try:
+        - script:
+            timeout: 2m
+            content: |
+              set -eu
+              if kubectl get broker chainsaw-payments >/dev/null 2>&1; then
+                kubectl patch broker chainsaw-payments --type=merge -p '{"metadata":{"finalizers":[]}}'
+                kubectl delete broker chainsaw-payments --wait=true --timeout=2m
+              fi
+      catch:
+        - script:
+            timeout: 2m
+            content: ../../scripts/dump-diagnostics.sh payments-module-cleanup

--- a/tests/e2e/chainsaw/21-payments-module/resources/auth.yaml
+++ b/tests/e2e/chainsaw/21-payments-module/resources/auth.yaml
@@ -1,0 +1,6 @@
+apiVersion: formance.com/v1beta1
+kind: Auth
+metadata:
+  name: auth
+spec:
+  stack: chainsaw-payments

--- a/tests/e2e/chainsaw/21-payments-module/resources/broker.yaml
+++ b/tests/e2e/chainsaw/21-payments-module/resources/broker.yaml
@@ -1,0 +1,6 @@
+apiVersion: formance.com/v1beta1
+kind: Broker
+metadata:
+  name: chainsaw-payments
+spec:
+  stack: chainsaw-payments

--- a/tests/e2e/chainsaw/21-payments-module/resources/brokertopic.yaml
+++ b/tests/e2e/chainsaw/21-payments-module/resources/brokertopic.yaml
@@ -1,0 +1,7 @@
+apiVersion: formance.com/v1beta1
+kind: BrokerTopic
+metadata:
+  name: chainsaw-payments-payments
+spec:
+  stack: chainsaw-payments
+  service: payments

--- a/tests/e2e/chainsaw/21-payments-module/resources/database.yaml
+++ b/tests/e2e/chainsaw/21-payments-module/resources/database.yaml
@@ -1,0 +1,9 @@
+apiVersion: formance.com/v1beta1
+kind: Database
+metadata:
+  name: chainsaw-payments-payments
+  annotations:
+    formance.com/module-version: v3.0.0
+spec:
+  stack: chainsaw-payments
+  service: payments

--- a/tests/e2e/chainsaw/21-payments-module/resources/nats.yaml
+++ b/tests/e2e/chainsaw/21-payments-module/resources/nats.yaml
@@ -1,0 +1,50 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: nats
+  namespace: chainsaw-payments
+spec:
+  selector:
+    app.kubernetes.io/name: nats
+  ports:
+    - name: client
+      port: 4222
+      targetPort: 4222
+    - name: monitoring
+      port: 8222
+      targetPort: 8222
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nats
+  namespace: chainsaw-payments
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: nats
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: nats
+    spec:
+      containers:
+        - name: nats
+          image: nats:2.10-alpine
+          imagePullPolicy: IfNotPresent
+          args:
+            - -js
+            - -m
+            - "8222"
+          ports:
+            - containerPort: 4222
+              name: client
+            - containerPort: 8222
+              name: monitoring
+          readinessProbe:
+            tcpSocket:
+              port: 4222
+            initialDelaySeconds: 2
+            periodSeconds: 2
+            timeoutSeconds: 1

--- a/tests/e2e/chainsaw/21-payments-module/resources/payments.yaml
+++ b/tests/e2e/chainsaw/21-payments-module/resources/payments.yaml
@@ -1,0 +1,6 @@
+apiVersion: formance.com/v1beta1
+kind: Payments
+metadata:
+  name: payments
+spec:
+  stack: chainsaw-payments

--- a/tests/e2e/chainsaw/21-payments-module/resources/postgres.yaml
+++ b/tests/e2e/chainsaw/21-payments-module/resources/postgres.yaml
@@ -1,0 +1,51 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres
+  namespace: chainsaw-payments
+spec:
+  selector:
+    app.kubernetes.io/name: postgres
+  ports:
+    - name: postgres
+      port: 5432
+      targetPort: 5432
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: postgres
+  namespace: chainsaw-payments
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: postgres
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: postgres
+    spec:
+      containers:
+        - name: postgres
+          image: postgres:15-alpine
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 5432
+              name: postgres
+          env:
+            - name: POSTGRES_USER
+              value: formance
+            - name: POSTGRES_PASSWORD
+              value: formance
+            - name: POSTGRES_DB
+              value: postgres
+          readinessProbe:
+            exec:
+              command:
+                - pg_isready
+                - -U
+                - formance
+            initialDelaySeconds: 2
+            periodSeconds: 2
+            timeoutSeconds: 1

--- a/tests/e2e/chainsaw/21-payments-module/resources/settings.yaml
+++ b/tests/e2e/chainsaw/21-payments-module/resources/settings.yaml
@@ -1,0 +1,189 @@
+apiVersion: formance.com/v1beta1
+kind: Settings
+metadata:
+  name: chainsaw-payments-postgres-uri
+spec:
+  stacks:
+    - chainsaw-payments
+  key: postgres.payments.uri
+  value: postgresql://postgres.chainsaw-payments.svc.cluster.local:5432?secret=postgres&disableSSLMode=true
+---
+apiVersion: formance.com/v1beta1
+kind: Settings
+metadata:
+  name: chainsaw-payments-broker-dsn
+spec:
+  stacks:
+    - chainsaw-payments
+  key: broker.dsn
+  value: nats://nats.chainsaw-payments.svc.cluster.local:4222?replicas=1
+---
+apiVersion: formance.com/v1beta1
+kind: Settings
+metadata:
+  name: chainsaw-payments-temporal-dsn
+spec:
+  stacks:
+    - chainsaw-payments
+  key: temporal.dsn
+  value: temporal://temporal.chainsaw-payments.svc.cluster.local:7233/default?initSearchAttributes=true
+---
+apiVersion: formance.com/v1beta1
+kind: Settings
+metadata:
+  name: chainsaw-payments-temporal-tls-crt
+spec:
+  stacks:
+    - chainsaw-payments
+  key: temporal.tls.crt
+  value: crt-data
+---
+apiVersion: formance.com/v1beta1
+kind: Settings
+metadata:
+  name: chainsaw-payments-temporal-tls-key
+spec:
+  stacks:
+    - chainsaw-payments
+  key: temporal.tls.key
+  value: key-data
+---
+apiVersion: formance.com/v1beta1
+kind: Settings
+metadata:
+  name: chainsaw-payments-encryption-key
+spec:
+  stacks:
+    - chainsaw-payments
+  key: payments.encryption-key
+  value: chainsaw-encryption-key
+---
+apiVersion: formance.com/v1beta1
+kind: Settings
+metadata:
+  name: chainsaw-payments-clear-temporal
+spec:
+  stacks:
+    - chainsaw-payments
+  key: payments.clear-temporal
+  value: "false"
+---
+apiVersion: formance.com/v1beta1
+kind: Settings
+metadata:
+  name: chainsaw-payments-auth-issuers
+spec:
+  stacks:
+    - chainsaw-payments
+  key: auth.issuers
+  value: https://issuer.payments.chainsaw.local
+---
+apiVersion: formance.com/v1beta1
+kind: Settings
+metadata:
+  name: chainsaw-payments-auth-check-scopes
+spec:
+  stacks:
+    - chainsaw-payments
+  key: auth.payments.check-scopes
+  value: "true"
+---
+apiVersion: formance.com/v1beta1
+kind: Settings
+metadata:
+  name: chainsaw-payments-otel-traces
+spec:
+  stacks:
+    - chainsaw-payments
+  key: opentelemetry.traces.dsn
+  value: grpc://otel-collector.chainsaw:4317?insecure=true
+---
+apiVersion: formance.com/v1beta1
+kind: Settings
+metadata:
+  name: chainsaw-payments-worker-pollers
+spec:
+  stacks:
+    - chainsaw-payments
+  key: payments.worker.temporal-max-concurrent-workflow-task-pollers
+  value: "6"
+---
+apiVersion: formance.com/v1beta1
+kind: Settings
+metadata:
+  name: chainsaw-payments-worker-activity-pollers
+spec:
+  stacks:
+    - chainsaw-payments
+  key: payments.worker.temporal-max-concurrent-activity-task-pollers
+  value: "7"
+---
+apiVersion: formance.com/v1beta1
+kind: Settings
+metadata:
+  name: chainsaw-payments-worker-slots
+spec:
+  stacks:
+    - chainsaw-payments
+  key: payments.worker.temporal-max-slots-per-poller
+  value: "8"
+---
+apiVersion: formance.com/v1beta1
+kind: Settings
+metadata:
+  name: chainsaw-payments-worker-local-slots
+spec:
+  stacks:
+    - chainsaw-payments
+  key: payments.worker.temporal-max-local-activity-slots
+  value: "9"
+---
+apiVersion: formance.com/v1beta1
+kind: Settings
+metadata:
+  name: chainsaw-payments-api-requests
+spec:
+  stacks:
+    - chainsaw-payments
+  key: deployments.payments.containers.payments-api.resource-requirements.requests
+  value: cpu=20m,memory=64Mi
+---
+apiVersion: formance.com/v1beta1
+kind: Settings
+metadata:
+  name: chainsaw-payments-api-limits
+spec:
+  stacks:
+    - chainsaw-payments
+  key: deployments.payments.containers.payments-api.resource-requirements.limits
+  value: memory=192Mi
+---
+apiVersion: formance.com/v1beta1
+kind: Settings
+metadata:
+  name: chainsaw-payments-worker-requests
+spec:
+  stacks:
+    - chainsaw-payments
+  key: deployments.payments-worker.containers.payments-worker.resource-requirements.requests
+  value: cpu=15m,memory=64Mi
+---
+apiVersion: formance.com/v1beta1
+kind: Settings
+metadata:
+  name: chainsaw-payments-worker-limits
+spec:
+  stacks:
+    - chainsaw-payments
+  key: deployments.payments-worker.containers.payments-worker.resource-requirements.limits
+  value: memory=160Mi
+---
+apiVersion: formance.com/v1beta1
+kind: Settings
+metadata:
+  name: chainsaw-payments-service-annotations
+spec:
+  stacks:
+    - chainsaw-payments
+  key: services.payments.annotations
+  value: chainsaw.formance.com/service=payments

--- a/tests/e2e/chainsaw/21-payments-module/resources/source-secret.yaml
+++ b/tests/e2e/chainsaw/21-payments-module/resources/source-secret.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: chainsaw-payments-postgres-credentials
+  namespace: default
+  labels:
+    formance.com/stack: chainsaw-payments
+  annotations:
+    formance.com/referenced-by-name: postgres
+stringData:
+  username: formance
+  password: formance

--- a/tests/e2e/chainsaw/21-payments-module/resources/stack.yaml
+++ b/tests/e2e/chainsaw/21-payments-module/resources/stack.yaml
@@ -1,0 +1,7 @@
+apiVersion: formance.com/v1beta1
+kind: Stack
+metadata:
+  name: chainsaw-payments
+spec:
+  version: v3.0.0
+  dev: true

--- a/tests/e2e/chainsaw/22-transactionplane-module/chainsaw-test.yaml
+++ b/tests/e2e/chainsaw/22-transactionplane-module/chainsaw-test.yaml
@@ -114,7 +114,7 @@ spec:
         - script:
             timeout: 2m
             content: ../../scripts/dump-diagnostics.sh transactionplane-module
-    - name: cleanup-broker-finalizer
+    - name: cleanup-finalizers
       try:
         - script:
             timeout: 2m
@@ -122,6 +122,12 @@ spec:
               set -eu
               kubectl patch stack chainsaw-transactionplane --type=merge -p '{"spec":{"disabled":true}}'
               kubectl delete settings chainsaw-transactionplane-broker-dsn --ignore-not-found=true --wait=true --timeout=2m
+              for database in chainsaw-transactionplane-transactionplane chainsaw-transactionplane-auth; do
+                if kubectl get database "$database" >/dev/null 2>&1; then
+                  kubectl patch database "$database" --type=merge -p '{"metadata":{"finalizers":[]}}'
+                  kubectl delete database "$database" --ignore-not-found=true --wait=false
+                fi
+              done
               if kubectl get broker chainsaw-transactionplane >/dev/null 2>&1; then
                 kubectl patch broker chainsaw-transactionplane --type=merge -p '{"metadata":{"finalizers":[]}}'
                 kubectl delete broker chainsaw-transactionplane --wait=true --timeout=2m

--- a/tests/e2e/chainsaw/22-transactionplane-module/chainsaw-test.yaml
+++ b/tests/e2e/chainsaw/22-transactionplane-module/chainsaw-test.yaml
@@ -1,0 +1,132 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: transactionplane-module
+  labels:
+    suite: modules
+    feature: transactionplane-module
+spec:
+  concurrent: false
+  steps:
+    - name: transactionplane-renders-database-broker-authclient-gateway-and-worker-modes
+      try:
+        - apply:
+            file: resources/source-secret.yaml
+        - apply:
+            file: resources/stack.yaml
+        - apply:
+            file: resources/serviceaccount.yaml
+        - apply:
+            file: resources/postgres.yaml
+        - apply:
+            file: resources/nats.yaml
+        - apply:
+            file: resources/settings.yaml
+        - apply:
+            file: resources/database.yaml
+        - apply:
+            file: resources/auth-database.yaml
+        - apply:
+            file: resources/broker.yaml
+        - apply:
+            file: resources/auth.yaml
+        - script:
+            timeout: 5m
+            content: |
+              set -eu
+              kubectl rollout status deployment/postgres -n chainsaw-transactionplane --timeout=2m
+              kubectl rollout status deployment/nats -n chainsaw-transactionplane --timeout=2m
+              kubectl wait --for=jsonpath='{.status.ready}'=true database/chainsaw-transactionplane-transactionplane --timeout=5m
+              kubectl wait --for=jsonpath='{.status.ready}'=true database/chainsaw-transactionplane-auth --timeout=5m
+              kubectl wait --for=jsonpath='{.status.ready}'=true broker/chainsaw-transactionplane --timeout=5m
+        - apply:
+            file: resources/aws-serviceaccount-setting.yaml
+        - apply:
+            file: resources/transactionplane.yaml
+        - script:
+            timeout: 5m
+            content: |
+              set -eu
+              assert_jsonpath() {
+                resource="$1"
+                path="$2"
+                expected="$3"
+                actual="$(kubectl get "$resource" -n chainsaw-transactionplane -o "jsonpath=${path}")"
+                if test "$actual" != "$expected"; then
+                  echo "expected ${resource} ${path} to be '${expected}', got '${actual}'" >&2
+                  exit 1
+                fi
+              }
+              kubectl wait --for=jsonpath='{.status.ready}'=true brokerconsumer/transactionplane-transactionplane --timeout=5m
+              kubectl wait --for=jsonpath='{.status.ready}'=true authclient/chainsaw-transactionplane-transactionplane --timeout=2m
+              kubectl wait --for=jsonpath='{.spec.template.spec.containers[0].image}'=ghcr.io/formancehq/transaction-plane:v3.0.0 deployment/transactionplane -n chainsaw-transactionplane --timeout=2m
+              kubectl wait --for=jsonpath='{.spec.template.spec.containers[0].image}'=ghcr.io/formancehq/transaction-plane:v3.0.0 deployment/transactionplane-worker -n chainsaw-transactionplane --timeout=2m
+              kubectl wait --for=jsonpath='{.status.ready}'=true gatewayhttpapi/chainsaw-transactionplane-transactionplane --timeout=2m
+              kubectl wait --for=jsonpath='{.spec.ports[0].port}'=8080 service/transactionplane -n chainsaw-transactionplane --timeout=2m
+              assert_jsonpath deployment/transactionplane '{.spec.template.spec.containers[0].args[0]}' 'serve'
+              assert_jsonpath deployment/transactionplane-worker '{.spec.template.spec.containers[0].args[0]}' 'worker'
+              assert_jsonpath deployment/transactionplane '{.spec.template.spec.containers[0].resources.requests.cpu}' '25m'
+              assert_jsonpath deployment/transactionplane '{.spec.template.spec.containers[0].resources.limits.memory}' '256Mi'
+              assert_jsonpath deployment/transactionplane '{.spec.template.spec.serviceAccountName}' 'chainsaw-transactionplane-sa'
+              assert_jsonpath pdb/transactionplane '{.spec.minAvailable}' '1'
+              assert_jsonpath service/transactionplane '{.metadata.annotations.chainsaw\.formance\.com/service}' 'transactionplane'
+              test "$(kubectl get brokerconsumer transactionplane-transactionplane -o jsonpath='{.spec.services[*]}')" = "transactionplane"
+              kubectl get deployment transactionplane -n chainsaw-transactionplane -o jsonpath='{range .spec.template.spec.containers[0].env[*]}{.name}={.value}{"\n"}{end}' > /tmp/chainsaw-transactionplane-env
+              grep -Fx 'DEV=true' /tmp/chainsaw-transactionplane-env
+              grep -Fx 'STACK=chainsaw-transactionplane' /tmp/chainsaw-transactionplane-env
+              grep -Fx 'POSTGRES_HOST=postgres.chainsaw-transactionplane.svc.cluster.local' /tmp/chainsaw-transactionplane-env
+              grep -Fx 'POSTGRES_PORT=5432' /tmp/chainsaw-transactionplane-env
+              grep -Fx 'POSTGRES_DATABASE=chainsaw-transactionplane-transactionplane' /tmp/chainsaw-transactionplane-env
+              grep -Fx 'POSTGRES_URI=$(POSTGRES_NO_DATABASE_URI)/$(POSTGRES_DATABASE)?sslmode=disable' /tmp/chainsaw-transactionplane-env
+              grep -Fx 'TOPICS=chainsaw-transactionplane.transactionplane' /tmp/chainsaw-transactionplane-env
+              grep -Fx 'BROKER=nats' /tmp/chainsaw-transactionplane-env
+              grep -Fx 'PUBLISHER_NATS_ENABLED=true' /tmp/chainsaw-transactionplane-env
+              grep -Fx 'PUBLISHER_NATS_URL=nats.chainsaw-transactionplane.svc.cluster.local:4222' /tmp/chainsaw-transactionplane-env
+              grep -Fx 'PUBLISHER_NATS_CLIENT_ID=chainsaw-transactionplane-transactionplane' /tmp/chainsaw-transactionplane-env
+              grep -Fx 'PUBLISHER_TOPIC_MAPPING=*:chainsaw-transactionplane.transactionplane' /tmp/chainsaw-transactionplane-env
+              grep -Fx 'PUBLISHER_NATS_AUTO_PROVISION=false' /tmp/chainsaw-transactionplane-env
+              grep -Fx 'AUTH_ENABLED=true' /tmp/chainsaw-transactionplane-env
+              grep -Fx 'AUTH_ISSUER=http://auth:8080' /tmp/chainsaw-transactionplane-env
+              grep -Fx 'AUTH_ISSUERS=https://issuer.transactionplane.chainsaw.local' /tmp/chainsaw-transactionplane-env
+              grep -Fx 'AUTH_CHECK_SCOPES=true' /tmp/chainsaw-transactionplane-env
+              grep -Fx 'AUTH_SERVICE=transactionplane' /tmp/chainsaw-transactionplane-env
+              grep -Fx 'OTEL_TRACES=true' /tmp/chainsaw-transactionplane-env
+              grep -Fx 'OTEL_SERVICE_NAME=transactionPlane' /tmp/chainsaw-transactionplane-env
+              kubectl get deployment transactionplane -n chainsaw-transactionplane -o jsonpath='{range .spec.template.spec.containers[0].env[*]}{.name}={.valueFrom.secretKeyRef.name}/{.valueFrom.secretKeyRef.key}{"\n"}{end}' > /tmp/chainsaw-transactionplane-secret-env
+              grep -Fx 'POSTGRES_USERNAME=postgres/username' /tmp/chainsaw-transactionplane-secret-env
+              grep -Fx 'POSTGRES_PASSWORD=postgres/password' /tmp/chainsaw-transactionplane-secret-env
+              grep -Fx 'STACK_CLIENT_ID=auth-client-chainsaw-transactionplane-transactionplane/id' /tmp/chainsaw-transactionplane-secret-env
+              grep -Fx 'STACK_CLIENT_SECRET=auth-client-chainsaw-transactionplane-transactionplane/secret' /tmp/chainsaw-transactionplane-secret-env
+              test "$(kubectl get authclient chainsaw-transactionplane-transactionplane -o jsonpath='{.spec.scopes[*]}')" = "ledger:read ledger:write payments:read payments:write"
+        - apply:
+            file: resources/worker-enabled.yaml
+        - script:
+            timeout: 5m
+            content: |
+              set -eu
+              kubectl wait --for=delete deployment/transactionplane-worker -n chainsaw-transactionplane --timeout=2m
+              until kubectl get deployment transactionplane -n chainsaw-transactionplane -o jsonpath='{range .spec.template.spec.containers[0].env[*]}{.name}={.value}{"\n"}{end}' | grep -Fx 'WORKER_ENABLED=true'; do
+                sleep 1
+              done
+              test "$(kubectl get deployment transactionplane -n chainsaw-transactionplane -o jsonpath='{.spec.template.spec.containers[0].args[0]}')" = "serve"
+              kubectl delete settings chainsaw-transactionplane-service-account --wait=true --timeout=2m
+      catch:
+        - script:
+            timeout: 2m
+            content: ../../scripts/dump-diagnostics.sh transactionplane-module
+    - name: cleanup-broker-finalizer
+      try:
+        - script:
+            timeout: 2m
+            content: |
+              set -eu
+              kubectl patch stack chainsaw-transactionplane --type=merge -p '{"spec":{"disabled":true}}'
+              kubectl delete settings chainsaw-transactionplane-broker-dsn --ignore-not-found=true --wait=true --timeout=2m
+              if kubectl get broker chainsaw-transactionplane >/dev/null 2>&1; then
+                kubectl patch broker chainsaw-transactionplane --type=merge -p '{"metadata":{"finalizers":[]}}'
+                kubectl delete broker chainsaw-transactionplane --wait=true --timeout=2m
+              fi
+      catch:
+        - script:
+            timeout: 2m
+            content: ../../scripts/dump-diagnostics.sh transactionplane-module-cleanup

--- a/tests/e2e/chainsaw/22-transactionplane-module/chainsaw-test.yaml
+++ b/tests/e2e/chainsaw/22-transactionplane-module/chainsaw-test.yaml
@@ -59,6 +59,12 @@ spec:
               }
               kubectl wait --for=jsonpath='{.status.ready}'=true brokerconsumer/transactionplane-transactionplane --timeout=5m
               kubectl wait --for=jsonpath='{.status.ready}'=true authclient/chainsaw-transactionplane-transactionplane --timeout=2m
+              until kubectl get deployment/transactionplane -n chainsaw-transactionplane >/dev/null 2>&1; do
+                sleep 1
+              done
+              until kubectl get deployment/transactionplane-worker -n chainsaw-transactionplane >/dev/null 2>&1; do
+                sleep 1
+              done
               kubectl wait --for=jsonpath='{.spec.template.spec.containers[0].image}'=ghcr.io/formancehq/transaction-plane:v3.0.0 deployment/transactionplane -n chainsaw-transactionplane --timeout=2m
               kubectl wait --for=jsonpath='{.spec.template.spec.containers[0].image}'=ghcr.io/formancehq/transaction-plane:v3.0.0 deployment/transactionplane-worker -n chainsaw-transactionplane --timeout=2m
               kubectl wait --for=jsonpath='{.status.ready}'=true gatewayhttpapi/chainsaw-transactionplane-transactionplane --timeout=2m
@@ -125,7 +131,6 @@ spec:
               for database in chainsaw-transactionplane-transactionplane chainsaw-transactionplane-auth; do
                 if kubectl get database "$database" >/dev/null 2>&1; then
                   kubectl patch database "$database" --type=merge -p '{"metadata":{"finalizers":[]}}'
-                  kubectl delete database "$database" --ignore-not-found=true --wait=false
                 fi
               done
               if kubectl get broker chainsaw-transactionplane >/dev/null 2>&1; then

--- a/tests/e2e/chainsaw/22-transactionplane-module/chainsaw-test.yaml
+++ b/tests/e2e/chainsaw/22-transactionplane-module/chainsaw-test.yaml
@@ -115,7 +115,6 @@ spec:
                 sleep 1
               done
               test "$(kubectl get deployment transactionplane -n chainsaw-transactionplane -o jsonpath='{.spec.template.spec.containers[0].args[0]}')" = "serve"
-              kubectl delete settings chainsaw-transactionplane-service-account --wait=true --timeout=2m
       catch:
         - script:
             timeout: 2m
@@ -127,7 +126,6 @@ spec:
             content: |
               set -eu
               kubectl patch stack chainsaw-transactionplane --type=merge -p '{"spec":{"disabled":true}}'
-              kubectl delete settings chainsaw-transactionplane-broker-dsn --ignore-not-found=true --wait=true --timeout=2m
               for database in chainsaw-transactionplane-transactionplane chainsaw-transactionplane-auth; do
                 if kubectl get database "$database" >/dev/null 2>&1; then
                   kubectl patch database "$database" --type=merge -p '{"metadata":{"finalizers":[]}}'
@@ -135,7 +133,6 @@ spec:
               done
               if kubectl get broker chainsaw-transactionplane >/dev/null 2>&1; then
                 kubectl patch broker chainsaw-transactionplane --type=merge -p '{"metadata":{"finalizers":[]}}'
-                kubectl delete broker chainsaw-transactionplane --wait=true --timeout=2m
               fi
       catch:
         - script:

--- a/tests/e2e/chainsaw/22-transactionplane-module/resources/auth-database.yaml
+++ b/tests/e2e/chainsaw/22-transactionplane-module/resources/auth-database.yaml
@@ -1,0 +1,9 @@
+apiVersion: formance.com/v1beta1
+kind: Database
+metadata:
+  name: chainsaw-transactionplane-auth
+  annotations:
+    formance.com/module-version: v3.0.0
+spec:
+  stack: chainsaw-transactionplane
+  service: auth

--- a/tests/e2e/chainsaw/22-transactionplane-module/resources/auth.yaml
+++ b/tests/e2e/chainsaw/22-transactionplane-module/resources/auth.yaml
@@ -1,0 +1,6 @@
+apiVersion: formance.com/v1beta1
+kind: Auth
+metadata:
+  name: auth
+spec:
+  stack: chainsaw-transactionplane

--- a/tests/e2e/chainsaw/22-transactionplane-module/resources/aws-serviceaccount-setting.yaml
+++ b/tests/e2e/chainsaw/22-transactionplane-module/resources/aws-serviceaccount-setting.yaml
@@ -1,0 +1,9 @@
+apiVersion: formance.com/v1beta1
+kind: Settings
+metadata:
+  name: chainsaw-transactionplane-service-account
+spec:
+  stacks:
+    - chainsaw-transactionplane
+  key: aws.service-account
+  value: chainsaw-transactionplane-sa

--- a/tests/e2e/chainsaw/22-transactionplane-module/resources/broker.yaml
+++ b/tests/e2e/chainsaw/22-transactionplane-module/resources/broker.yaml
@@ -1,0 +1,6 @@
+apiVersion: formance.com/v1beta1
+kind: Broker
+metadata:
+  name: chainsaw-transactionplane
+spec:
+  stack: chainsaw-transactionplane

--- a/tests/e2e/chainsaw/22-transactionplane-module/resources/database.yaml
+++ b/tests/e2e/chainsaw/22-transactionplane-module/resources/database.yaml
@@ -1,0 +1,9 @@
+apiVersion: formance.com/v1beta1
+kind: Database
+metadata:
+  name: chainsaw-transactionplane-transactionplane
+  annotations:
+    formance.com/module-version: v3.0.0
+spec:
+  stack: chainsaw-transactionplane
+  service: transactionplane

--- a/tests/e2e/chainsaw/22-transactionplane-module/resources/nats.yaml
+++ b/tests/e2e/chainsaw/22-transactionplane-module/resources/nats.yaml
@@ -1,0 +1,50 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: nats
+  namespace: chainsaw-transactionplane
+spec:
+  selector:
+    app.kubernetes.io/name: nats
+  ports:
+    - name: client
+      port: 4222
+      targetPort: 4222
+    - name: monitoring
+      port: 8222
+      targetPort: 8222
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nats
+  namespace: chainsaw-transactionplane
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: nats
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: nats
+    spec:
+      containers:
+        - name: nats
+          image: nats:2.10-alpine
+          imagePullPolicy: IfNotPresent
+          args:
+            - -js
+            - -m
+            - "8222"
+          ports:
+            - containerPort: 4222
+              name: client
+            - containerPort: 8222
+              name: monitoring
+          readinessProbe:
+            tcpSocket:
+              port: 4222
+            initialDelaySeconds: 2
+            periodSeconds: 2
+            timeoutSeconds: 1

--- a/tests/e2e/chainsaw/22-transactionplane-module/resources/postgres.yaml
+++ b/tests/e2e/chainsaw/22-transactionplane-module/resources/postgres.yaml
@@ -1,0 +1,51 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres
+  namespace: chainsaw-transactionplane
+spec:
+  selector:
+    app.kubernetes.io/name: postgres
+  ports:
+    - name: postgres
+      port: 5432
+      targetPort: 5432
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: postgres
+  namespace: chainsaw-transactionplane
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: postgres
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: postgres
+    spec:
+      containers:
+        - name: postgres
+          image: postgres:15-alpine
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 5432
+              name: postgres
+          env:
+            - name: POSTGRES_USER
+              value: formance
+            - name: POSTGRES_PASSWORD
+              value: formance
+            - name: POSTGRES_DB
+              value: postgres
+          readinessProbe:
+            exec:
+              command:
+                - pg_isready
+                - -U
+                - formance
+            initialDelaySeconds: 2
+            periodSeconds: 2
+            timeoutSeconds: 1

--- a/tests/e2e/chainsaw/22-transactionplane-module/resources/serviceaccount.yaml
+++ b/tests/e2e/chainsaw/22-transactionplane-module/resources/serviceaccount.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: chainsaw-transactionplane-sa
+  namespace: chainsaw-transactionplane
+  labels:
+    formance.com/stack: chainsaw-transactionplane

--- a/tests/e2e/chainsaw/22-transactionplane-module/resources/settings.yaml
+++ b/tests/e2e/chainsaw/22-transactionplane-module/resources/settings.yaml
@@ -1,0 +1,99 @@
+apiVersion: formance.com/v1beta1
+kind: Settings
+metadata:
+  name: chainsaw-transactionplane-postgres-uri
+spec:
+  stacks:
+    - chainsaw-transactionplane
+  key: postgres.transactionplane.uri
+  value: postgresql://postgres.chainsaw-transactionplane.svc.cluster.local:5432?secret=postgres&disableSSLMode=true
+---
+apiVersion: formance.com/v1beta1
+kind: Settings
+metadata:
+  name: chainsaw-transactionplane-postgres-auth-uri
+spec:
+  stacks:
+    - chainsaw-transactionplane
+  key: postgres.auth.uri
+  value: postgresql://postgres.chainsaw-transactionplane.svc.cluster.local:5432?secret=postgres&disableSSLMode=true
+---
+apiVersion: formance.com/v1beta1
+kind: Settings
+metadata:
+  name: chainsaw-transactionplane-broker-dsn
+spec:
+  stacks:
+    - chainsaw-transactionplane
+  key: broker.dsn
+  value: nats://nats.chainsaw-transactionplane.svc.cluster.local:4222?replicas=1
+---
+apiVersion: formance.com/v1beta1
+kind: Settings
+metadata:
+  name: chainsaw-transactionplane-auth-issuers
+spec:
+  stacks:
+    - chainsaw-transactionplane
+  key: auth.issuers
+  value: https://issuer.transactionplane.chainsaw.local
+---
+apiVersion: formance.com/v1beta1
+kind: Settings
+metadata:
+  name: chainsaw-transactionplane-auth-check-scopes
+spec:
+  stacks:
+    - chainsaw-transactionplane
+  key: auth.transactionplane.check-scopes
+  value: "true"
+---
+apiVersion: formance.com/v1beta1
+kind: Settings
+metadata:
+  name: chainsaw-transactionplane-otel-traces
+spec:
+  stacks:
+    - chainsaw-transactionplane
+  key: opentelemetry.traces.dsn
+  value: grpc://otel-collector.chainsaw:4317?insecure=true
+---
+apiVersion: formance.com/v1beta1
+kind: Settings
+metadata:
+  name: chainsaw-transactionplane-container-requests
+spec:
+  stacks:
+    - chainsaw-transactionplane
+  key: deployments.transactionplane.containers.transactionplane.resource-requirements.requests
+  value: cpu=25m,memory=80Mi
+---
+apiVersion: formance.com/v1beta1
+kind: Settings
+metadata:
+  name: chainsaw-transactionplane-container-limits
+spec:
+  stacks:
+    - chainsaw-transactionplane
+  key: deployments.transactionplane.containers.transactionplane.resource-requirements.limits
+  value: memory=256Mi
+---
+apiVersion: formance.com/v1beta1
+kind: Settings
+metadata:
+  name: chainsaw-transactionplane-pdb
+spec:
+  stacks:
+    - chainsaw-transactionplane
+  key: deployments.transactionplane.pod-disruption-budget
+  value: minAvailable=1
+---
+apiVersion: formance.com/v1beta1
+kind: Settings
+metadata:
+  name: chainsaw-transactionplane-service-annotations
+spec:
+  stacks:
+    - chainsaw-transactionplane
+  key: services.transactionplane.annotations
+  value: chainsaw.formance.com/service=transactionplane

--- a/tests/e2e/chainsaw/22-transactionplane-module/resources/source-secret.yaml
+++ b/tests/e2e/chainsaw/22-transactionplane-module/resources/source-secret.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: chainsaw-transactionplane-postgres-credentials
+  namespace: default
+  labels:
+    formance.com/stack: chainsaw-transactionplane
+  annotations:
+    formance.com/referenced-by-name: postgres
+stringData:
+  username: formance
+  password: formance

--- a/tests/e2e/chainsaw/22-transactionplane-module/resources/stack.yaml
+++ b/tests/e2e/chainsaw/22-transactionplane-module/resources/stack.yaml
@@ -1,0 +1,7 @@
+apiVersion: formance.com/v1beta1
+kind: Stack
+metadata:
+  name: chainsaw-transactionplane
+spec:
+  version: v3.0.0
+  dev: true

--- a/tests/e2e/chainsaw/22-transactionplane-module/resources/transactionplane.yaml
+++ b/tests/e2e/chainsaw/22-transactionplane-module/resources/transactionplane.yaml
@@ -1,0 +1,6 @@
+apiVersion: formance.com/v1beta1
+kind: TransactionPlane
+metadata:
+  name: transactionplane
+spec:
+  stack: chainsaw-transactionplane

--- a/tests/e2e/chainsaw/22-transactionplane-module/resources/worker-enabled.yaml
+++ b/tests/e2e/chainsaw/22-transactionplane-module/resources/worker-enabled.yaml
@@ -1,0 +1,9 @@
+apiVersion: formance.com/v1beta1
+kind: Settings
+metadata:
+  name: chainsaw-transactionplane-worker-enabled
+spec:
+  stacks:
+    - chainsaw-transactionplane
+  key: transactionplane.worker-enabled
+  value: "true"

--- a/tests/e2e/chainsaw/23-benthos-module/chainsaw-test.yaml
+++ b/tests/e2e/chainsaw/23-benthos-module/chainsaw-test.yaml
@@ -1,0 +1,88 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: benthos-module
+  labels:
+    suite: modules
+    feature: benthos-module
+spec:
+  concurrent: false
+  steps:
+    - name: benthos-renders-stream-configmaps-service-deployment-and-broker-env
+      try:
+        - apply:
+            file: resources/stack.yaml
+        - apply:
+            file: resources/serviceaccount.yaml
+        - apply:
+            file: resources/nats.yaml
+        - apply:
+            file: resources/settings.yaml
+        - apply:
+            file: resources/broker.yaml
+        - apply:
+            file: resources/stream.yaml
+        - script:
+            timeout: 5m
+            content: |
+              set -eu
+              kubectl rollout status deployment/nats -n chainsaw-benthos --timeout=2m
+              kubectl wait --for=jsonpath='{.status.ready}'=true broker/chainsaw-benthos --timeout=5m
+              kubectl wait --for=jsonpath='{.status.ready}'=true benthosstream/chainsaw-benthos-audit --timeout=2m
+              kubectl get configmap stream-chainsaw-benthos-audit -n chainsaw-benthos -o go-template='{{ index .data "stream.yaml" }}' | grep -F 'input:'
+        - apply:
+            file: resources/benthos.yaml
+        - script:
+            timeout: 5m
+            content: |
+              set -eu
+              assert_jsonpath() {
+                resource="$1"
+                path="$2"
+                expected="$3"
+                actual="$(kubectl get "$resource" -n chainsaw-benthos -o "jsonpath=${path}")"
+                if test "$actual" != "$expected"; then
+                  echo "expected ${resource} ${path} to be '${expected}', got '${actual}'" >&2
+                  exit 1
+                fi
+              }
+              kubectl wait --for=jsonpath='{.status.ready}'=true benthos/chainsaw-benthos --timeout=2m
+              kubectl wait --for=jsonpath='{.spec.template.spec.containers[0].image}'=public.ecr.aws/formance-internal/jeffail/benthos:v4.23.1-es deployment/benthos -n chainsaw-benthos --timeout=2m
+              kubectl wait --for=jsonpath='{.spec.ports[0].port}'=4195 service/benthos -n chainsaw-benthos --timeout=2m
+              assert_jsonpath deployment/benthos '{.spec.template.spec.serviceAccountName}' 'chainsaw-benthos-sa'
+              assert_jsonpath deployment/benthos '{.spec.template.spec.containers[0].ports[0].containerPort}' '4195'
+              assert_jsonpath service/benthos '{.spec.selector.app\.kubernetes\.io/name}' 'benthos'
+              test -n "$(kubectl get deployment benthos -n chainsaw-benthos -o jsonpath='{.spec.template.metadata.annotations.config-hash}')"
+              kubectl get configmap benthos-resources -n chainsaw-benthos -o go-template='{{ index .data "lookup.yaml" }}' | grep -F 'cache_resources:'
+              kubectl get configmap benthos-templates -n chainsaw-benthos -o go-template='{{ index .data "custom.yaml" }}' | grep -F 'name: custom_processor'
+              kubectl get deployment benthos -n chainsaw-benthos -o jsonpath='{range .spec.template.spec.containers[0].env[*]}{.name}={.value}{"\n"}{end}' > /tmp/chainsaw-benthos-env
+              grep -Fx 'TOPIC_PREFIX=chainsaw-benthos.' /tmp/chainsaw-benthos-env
+              grep -Fx 'STACK=chainsaw-benthos' /tmp/chainsaw-benthos-env
+              grep -Fx 'BROKER=nats' /tmp/chainsaw-benthos-env
+              grep -Fx 'NATS_URL=nats.chainsaw-benthos.svc.cluster.local:4222' /tmp/chainsaw-benthos-env
+              grep -Fx 'NATS_BIND=true' /tmp/chainsaw-benthos-env
+              grep -Fx 'AWS_IAM_ENABLED=true' /tmp/chainsaw-benthos-env
+              assert_jsonpath deployment/benthos '{.spec.template.spec.containers[0].command[0]}' '/benthos'
+              assert_jsonpath deployment/benthos '{.spec.template.spec.containers[0].command[2]}' '/resources/*.yaml'
+              assert_jsonpath deployment/benthos '{.spec.template.spec.containers[0].command[4]}' '/templates/*.yaml'
+              assert_jsonpath deployment/benthos '{.spec.template.spec.containers[0].command[8]}' '/streams/*.yaml'
+              kubectl get deployment benthos -n chainsaw-benthos -o jsonpath='{range .spec.template.spec.volumes[?(@.name=="streams")].projected.sources[*]}{.configMap.name}:{.configMap.items[0].path}{"\n"}{end}' > /tmp/chainsaw-benthos-stream-volumes
+              grep -Fx 'stream-chainsaw-benthos-audit:audit.yaml' /tmp/chainsaw-benthos-stream-volumes
+      catch:
+        - script:
+            timeout: 2m
+            content: ../../scripts/dump-diagnostics.sh benthos-module
+    - name: cleanup-broker-finalizer
+      try:
+        - script:
+            timeout: 2m
+            content: |
+              set -eu
+              if kubectl get broker chainsaw-benthos >/dev/null 2>&1; then
+                kubectl patch broker chainsaw-benthos --type=merge -p '{"metadata":{"finalizers":[]}}'
+                kubectl delete broker chainsaw-benthos --wait=true --timeout=2m
+              fi
+      catch:
+        - script:
+            timeout: 2m
+            content: ../../scripts/dump-diagnostics.sh benthos-module-cleanup

--- a/tests/e2e/chainsaw/23-benthos-module/resources/benthos.yaml
+++ b/tests/e2e/chainsaw/23-benthos-module/resources/benthos.yaml
@@ -1,0 +1,15 @@
+apiVersion: formance.com/v1beta1
+kind: Benthos
+metadata:
+  name: chainsaw-benthos
+spec:
+  stack: chainsaw-benthos
+  resources:
+    lookup.yaml: |
+      cache_resources: []
+  templates:
+    custom.yaml: |
+      name: custom_processor
+      type: processor
+      mapping: |
+        root = this

--- a/tests/e2e/chainsaw/23-benthos-module/resources/broker.yaml
+++ b/tests/e2e/chainsaw/23-benthos-module/resources/broker.yaml
@@ -1,0 +1,6 @@
+apiVersion: formance.com/v1beta1
+kind: Broker
+metadata:
+  name: chainsaw-benthos
+spec:
+  stack: chainsaw-benthos

--- a/tests/e2e/chainsaw/23-benthos-module/resources/nats.yaml
+++ b/tests/e2e/chainsaw/23-benthos-module/resources/nats.yaml
@@ -1,0 +1,50 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: nats
+  namespace: chainsaw-benthos
+spec:
+  selector:
+    app.kubernetes.io/name: nats
+  ports:
+    - name: client
+      port: 4222
+      targetPort: 4222
+    - name: monitoring
+      port: 8222
+      targetPort: 8222
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nats
+  namespace: chainsaw-benthos
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: nats
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: nats
+    spec:
+      containers:
+        - name: nats
+          image: nats:2.10-alpine
+          imagePullPolicy: IfNotPresent
+          args:
+            - -js
+            - -m
+            - "8222"
+          ports:
+            - containerPort: 4222
+              name: client
+            - containerPort: 8222
+              name: monitoring
+          readinessProbe:
+            tcpSocket:
+              port: 4222
+            initialDelaySeconds: 2
+            periodSeconds: 2
+            timeoutSeconds: 1

--- a/tests/e2e/chainsaw/23-benthos-module/resources/serviceaccount.yaml
+++ b/tests/e2e/chainsaw/23-benthos-module/resources/serviceaccount.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: chainsaw-benthos-sa
+  namespace: chainsaw-benthos
+  labels:
+    formance.com/stack: chainsaw-benthos

--- a/tests/e2e/chainsaw/23-benthos-module/resources/settings.yaml
+++ b/tests/e2e/chainsaw/23-benthos-module/resources/settings.yaml
@@ -1,0 +1,19 @@
+apiVersion: formance.com/v1beta1
+kind: Settings
+metadata:
+  name: chainsaw-benthos-broker-dsn
+spec:
+  stacks:
+    - chainsaw-benthos
+  key: broker.dsn
+  value: nats://nats.chainsaw-benthos.svc.cluster.local:4222?replicas=1
+---
+apiVersion: formance.com/v1beta1
+kind: Settings
+metadata:
+  name: chainsaw-benthos-service-account
+spec:
+  stacks:
+    - chainsaw-benthos
+  key: aws.service-account
+  value: chainsaw-benthos-sa

--- a/tests/e2e/chainsaw/23-benthos-module/resources/stack.yaml
+++ b/tests/e2e/chainsaw/23-benthos-module/resources/stack.yaml
@@ -1,0 +1,7 @@
+apiVersion: formance.com/v1beta1
+kind: Stack
+metadata:
+  name: chainsaw-benthos
+spec:
+  version: v3.0.0
+  dev: true

--- a/tests/e2e/chainsaw/23-benthos-module/resources/stream.yaml
+++ b/tests/e2e/chainsaw/23-benthos-module/resources/stream.yaml
@@ -1,0 +1,14 @@
+apiVersion: formance.com/v1beta1
+kind: BenthosStream
+metadata:
+  name: chainsaw-benthos-audit
+spec:
+  stack: chainsaw-benthos
+  name: audit
+  data: |
+    input:
+      generate:
+        interval: 1h
+        mapping: root.message = "chainsaw"
+    output:
+      drop: {}

--- a/tests/e2e/kind/cluster.yaml
+++ b/tests/e2e/kind/cluster.yaml
@@ -1,0 +1,4 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+  - role: control-plane

--- a/tests/e2e/scripts/build-load-image.sh
+++ b/tests/e2e/scripts/build-load-image.sh
@@ -23,6 +23,11 @@ if ! command -v kind >/dev/null 2>&1; then
   exit 1
 fi
 
+if ! command -v docker >/dev/null 2>&1; then
+  echo "docker is required to inspect, pull, and import images used by E2E tests" >&2
+  exit 1
+fi
+
 cd "${ROOT_DIR}"
 
 load_image_for_node_platform() {

--- a/tests/e2e/scripts/build-load-image.sh
+++ b/tests/e2e/scripts/build-load-image.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+KIND_CLUSTER_NAME="${KIND_CLUSTER_NAME:-formance-operator-e2e}"
+IMAGE_REPOSITORY="${IMAGE_REPOSITORY:-ghcr.io/formancehq/operator}"
+UTILS_IMAGE_REPOSITORY="${UTILS_IMAGE_REPOSITORY:-ghcr.io/formancehq/operator-utils}"
+IMAGE_TAG="${IMAGE_TAG:-e2e}"
+IMAGE="${IMAGE_REPOSITORY}:${IMAGE_TAG}"
+UTILS_IMAGE="${UTILS_IMAGE_REPOSITORY}:${IMAGE_TAG}"
+POSTGRES_IMAGE="${POSTGRES_IMAGE:-postgres:15-alpine}"
+NATS_IMAGE="${NATS_IMAGE:-nats:2.10-alpine}"
+NATS_BOX_IMAGE="${NATS_BOX_IMAGE:-natsio/nats-box:0.19.2}"
+EARTHLY_REPOSITORY="${EARTHLY_REPOSITORY:-ghcr.io}"
+
+if ! command -v earthly >/dev/null 2>&1; then
+  echo "earthly is required to build the operator image used by E2E tests" >&2
+  exit 1
+fi
+
+if ! command -v kind >/dev/null 2>&1; then
+  echo "kind is required to load the operator image into the E2E cluster" >&2
+  exit 1
+fi
+
+cd "${ROOT_DIR}"
+
+load_image_for_node_platform() {
+  local image="$1"
+  local os
+  local arch
+  local platform
+
+  os="$(docker image inspect "${image}" --format '{{.Os}}')"
+  arch="$(docker image inspect "${image}" --format '{{.Architecture}}')"
+  platform="${os}/${arch}"
+
+  for node in $(kind get nodes --name "${KIND_CLUSTER_NAME}"); do
+    docker save "${image}" | docker exec --privileged -i "${node}" \
+      ctr --namespace=k8s.io images import --platform "${platform}" --digests --snapshotter=overlayfs -
+  done
+}
+
+earthly +build-image --REPOSITORY="${EARTHLY_REPOSITORY}" --tag="${IMAGE_TAG}"
+earthly ./tools/utils+build-image --REPOSITORY="${EARTHLY_REPOSITORY}" --tag="${IMAGE_TAG}"
+docker image inspect "${POSTGRES_IMAGE}" >/dev/null 2>&1 || docker pull "${POSTGRES_IMAGE}"
+docker image inspect "${NATS_IMAGE}" >/dev/null 2>&1 || docker pull "${NATS_IMAGE}"
+docker image inspect "${NATS_BOX_IMAGE}" >/dev/null 2>&1 || docker pull "${NATS_BOX_IMAGE}"
+kind load docker-image "${IMAGE}" --name "${KIND_CLUSTER_NAME}"
+kind load docker-image "${UTILS_IMAGE}" --name "${KIND_CLUSTER_NAME}"
+load_image_for_node_platform "${POSTGRES_IMAGE}"
+load_image_for_node_platform "${NATS_IMAGE}"
+load_image_for_node_platform "${NATS_BOX_IMAGE}"

--- a/tests/e2e/scripts/cluster-down.sh
+++ b/tests/e2e/scripts/cluster-down.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+KIND_CLUSTER_NAME="${KIND_CLUSTER_NAME:-formance-operator-e2e}"
+
+if ! command -v kind >/dev/null 2>&1; then
+  echo "kind is required to delete the E2E cluster" >&2
+  exit 1
+fi
+
+if kind get clusters | grep -qx "${KIND_CLUSTER_NAME}"; then
+  kind delete cluster --name "${KIND_CLUSTER_NAME}"
+fi

--- a/tests/e2e/scripts/cluster-up.sh
+++ b/tests/e2e/scripts/cluster-up.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+KIND_CLUSTER_NAME="${KIND_CLUSTER_NAME:-formance-operator-e2e}"
+
+if ! command -v kind >/dev/null 2>&1; then
+  echo "kind is required to create the E2E cluster" >&2
+  exit 1
+fi
+
+if kind get clusters | grep -qx "${KIND_CLUSTER_NAME}"; then
+  echo "kind cluster ${KIND_CLUSTER_NAME} already exists"
+  exit 0
+fi
+
+kind create cluster \
+  --name "${KIND_CLUSTER_NAME}" \
+  --config "${ROOT_DIR}/tests/e2e/kind/cluster.yaml"

--- a/tests/e2e/scripts/cluster-up.sh
+++ b/tests/e2e/scripts/cluster-up.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 KIND_CLUSTER_NAME="${KIND_CLUSTER_NAME:-formance-operator-e2e}"
+KIND_NODE_IMAGE="${KIND_NODE_IMAGE:-}"
 
 if ! command -v kind >/dev/null 2>&1; then
   echo "kind is required to create the E2E cluster" >&2
@@ -14,6 +15,13 @@ if kind get clusters | grep -qx "${KIND_CLUSTER_NAME}"; then
   exit 0
 fi
 
-kind create cluster \
-  --name "${KIND_CLUSTER_NAME}" \
+kind_args=(
+  --name "${KIND_CLUSTER_NAME}"
   --config "${ROOT_DIR}/tests/e2e/kind/cluster.yaml"
+)
+
+if [[ -n "${KIND_NODE_IMAGE}" ]]; then
+  kind_args+=(--image "${KIND_NODE_IMAGE}")
+fi
+
+kind create cluster "${kind_args[@]}"

--- a/tests/e2e/scripts/dump-diagnostics.sh
+++ b/tests/e2e/scripts/dump-diagnostics.sh
@@ -5,6 +5,8 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 NAME="${1:-diagnostics}"
 STAMP="$(date -u +%Y%m%dT%H%M%SZ)"
 ARTIFACT_DIR="${ARTIFACT_DIR:-${ROOT_DIR}/tests/e2e/artifacts/${STAMP}-${NAME}}"
+OPERATOR_NAMESPACE="${OPERATOR_NAMESPACE:-formance-system}"
+OPERATOR_RELEASE="${OPERATOR_RELEASE:-formance-operator}"
 
 mkdir -p "${ARTIFACT_DIR}"
 
@@ -23,8 +25,8 @@ run formance-crds.yaml kubectl get crds -o yaml
 run all-resources.txt kubectl get all -A -o wide
 run formance-resources.yaml kubectl get stacks,settings,versions,auths,authclients,brokers,brokertopics,brokerconsumers,databases,gateways,gatewayhttpapis,ledgers,orchestrations,payments,reconciliations,resourcereferences,searches,stargates,transactionplanes,wallets,webhooks -A -o yaml
 run events.txt kubectl get events -A --sort-by=.lastTimestamp
-run operator-describe.txt kubectl describe deployment -n formance-system formance-operator
-run operator-logs.txt kubectl logs -n formance-system deployment/formance-operator --all-containers --tail=-1
+run operator-describe.txt kubectl describe deployment -n "${OPERATOR_NAMESPACE}" "${OPERATOR_RELEASE}"
+run operator-logs.txt kubectl logs -n "${OPERATOR_NAMESPACE}" "deployment/${OPERATOR_RELEASE}" --all-containers --tail=-1
 run pods-describe.txt kubectl describe pods -A
 run jobs.txt kubectl get jobs -A -o yaml
 

--- a/tests/e2e/scripts/dump-diagnostics.sh
+++ b/tests/e2e/scripts/dump-diagnostics.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -u
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+NAME="${1:-diagnostics}"
+STAMP="$(date -u +%Y%m%dT%H%M%SZ)"
+ARTIFACT_DIR="${ARTIFACT_DIR:-${ROOT_DIR}/tests/e2e/artifacts/${STAMP}-${NAME}}"
+
+mkdir -p "${ARTIFACT_DIR}"
+
+run() {
+  local file="$1"
+  shift
+  {
+    echo "$ $*"
+    "$@"
+  } >"${ARTIFACT_DIR}/${file}" 2>&1 || true
+}
+
+run namespaces.txt kubectl get namespaces -o wide
+run crds.txt kubectl get crds
+run formance-crds.yaml kubectl get crds -o yaml
+run all-resources.txt kubectl get all -A -o wide
+run formance-resources.yaml kubectl get stacks,settings,versions,auths,authclients,brokers,brokertopics,brokerconsumers,databases,gateways,gatewayhttpapis,ledgers,orchestrations,payments,reconciliations,resourcereferences,searches,stargates,transactionplanes,wallets,webhooks -A -o yaml
+run events.txt kubectl get events -A --sort-by=.lastTimestamp
+run operator-describe.txt kubectl describe deployment -n formance-system formance-operator
+run operator-logs.txt kubectl logs -n formance-system deployment/formance-operator --all-containers --tail=-1
+run pods-describe.txt kubectl describe pods -A
+run jobs.txt kubectl get jobs -A -o yaml
+
+echo "Diagnostics written to ${ARTIFACT_DIR}"

--- a/tests/e2e/scripts/install-operator.sh
+++ b/tests/e2e/scripts/install-operator.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+NAMESPACE="${OPERATOR_NAMESPACE:-formance-system}"
+RELEASE="${OPERATOR_RELEASE:-formance-operator}"
+CRDS_RELEASE="${OPERATOR_CRDS_RELEASE:-formance-operator-crds}"
+IMAGE_REPOSITORY="${IMAGE_REPOSITORY:-ghcr.io/formancehq/operator}"
+IMAGE_TAG="${IMAGE_TAG:-e2e}"
+TIMEOUT="${HELM_TIMEOUT:-10m}"
+
+if ! command -v helm >/dev/null 2>&1; then
+  echo "helm is required to install the operator for E2E tests" >&2
+  exit 1
+fi
+
+if ! command -v kubectl >/dev/null 2>&1; then
+  echo "kubectl is required to install the operator for E2E tests" >&2
+  exit 1
+fi
+
+cd "${ROOT_DIR}"
+
+helm upgrade --install "${CRDS_RELEASE}" ./helm/crds \
+  --namespace "${NAMESPACE}" \
+  --create-namespace \
+  --wait \
+  --timeout "${TIMEOUT}"
+
+helm dependency update ./helm/operator
+
+helm upgrade --install "${RELEASE}" ./helm/operator \
+  --namespace "${NAMESPACE}" \
+  --create-namespace \
+  --wait \
+  --timeout "${TIMEOUT}" \
+  --set operator-crds.create=false \
+  --set image.repository="${IMAGE_REPOSITORY}" \
+  --set image.tag="${IMAGE_TAG}" \
+  --set image.pullPolicy=IfNotPresent \
+  --set operator.disableWebhooks=false \
+  --set operator.dev=true \
+  --set operator.enableLeaderElection=false \
+  --set global.licence.createSecret=false \
+  --set operator.utils.tag="${IMAGE_TAG}"
+
+kubectl rollout status "deployment/${RELEASE}" \
+  --namespace "${NAMESPACE}" \
+  --timeout "${TIMEOUT}"


### PR DESCRIPTION
## Summary
- add the Chainsaw E2E suite and supporting kind cluster scripts
- wire the E2E workflow and upload Chainsaw artifacts from CI
- add kind to the Nix dev shell so CI can run just e2e on clean runners

## Verification
- nixpkgs-fmt flake.nix
- nix --extra-experimental-features nix-command --extra-experimental-features flakes eval .#devShells.x86_64-linux.default.inputDerivation.name
- nix --extra-experimental-features nix-command --extra-experimental-features flakes develop --impure --command kind --version