### PR TITLE
fix: scope Versions minimum validation and expose MCP at API root

### DIFF
--- a/internal/core/version.go
+++ b/internal/core/version.go
@@ -19,8 +19,8 @@ var ErrNoVersionFound = errors.New("no version found")
 // MinimumStackVersion is the minimum Stack version the operator supports deploying.
 const MinimumStackVersion = "v2.2.0"
 
-// ValidateMinimumVersion checks that a resolved version meets the minimum requirement.
-// Non-semver versions (dev tags, SHA refs) are allowed through.
+// ValidateMinimumVersion checks that a Versions resource name meets the minimum requirement.
+// Non-semver names (dev tags, SHA refs) are allowed through.
 func ValidateMinimumVersion(version string) error {
 	if strings.TrimPrefix(version, "v") == "0.0.0-e2e" {
 		return nil
@@ -75,11 +75,14 @@ func ResolveModuleVersion(ctx Context, stack *v1beta1.Stack, module v1beta1.Modu
 }
 
 func GetModuleVersion(ctx Context, stack *v1beta1.Stack, module v1beta1.Module) (string, error) {
+	if module.GetVersion() == "" && stack.Spec.Version == "" && stack.Spec.VersionsFromFile != "" {
+		if err := ValidateMinimumVersion(stack.Spec.VersionsFromFile); err != nil {
+			return "", err
+		}
+	}
+
 	version, err := ResolveModuleVersion(ctx, stack, module)
 	if err != nil {
-		return "", err
-	}
-	if err := ValidateMinimumVersion(version); err != nil {
 		return "", err
 	}
 

--- a/internal/resources/mcps/init.go
+++ b/internal/resources/mcps/init.go
@@ -39,7 +39,6 @@ func Reconcile(ctx Context, stack *v1beta1.Stack, mcp *v1beta1.MCP, version stri
 		gatewayhttpapis.WithHealthCheckEndpoint("_healthcheck"),
 		gatewayhttpapis.WithRules(
 			v1beta1.GatewayHTTPAPIRule{
-				Path:    "/mcp",
 				Methods: []string{http.MethodPost},
 			},
 			v1beta1.GatewayHTTPAPIRule{

--- a/internal/tests/mcp_controller_test.go
+++ b/internal/tests/mcp_controller_test.go
@@ -112,7 +112,6 @@ var _ = Describe("MCPController", func() {
 				return httpAPI.Spec.Rules
 			}).Should(ConsistOf(
 				v1beta1.GatewayHTTPAPIRule{
-					Path:    "/mcp",
 					Methods: []string{"POST"},
 				},
 				v1beta1.GatewayHTTPAPIRule{
@@ -132,7 +131,7 @@ var _ = Describe("MCPController", func() {
 				g.Expect(LoadResource(stack.Name, "gateway", cm)).To(Succeed())
 				return cm.Data["Caddyfile"]
 			}).Should(SatisfyAll(
-				ContainSubstring("handle /api/mcp/mcp*"),
+				ContainSubstring("handle /api/mcp*"),
 				ContainSubstring("handle /api/mcp/.well-known/oauth-protected-resource*"),
 				ContainSubstring("handle /api/mcp/_healthcheck*"),
 				ContainSubstring("reverse_proxy mcp:8080"),

--- a/internal/tests/stack_controller_test.go
+++ b/internal/tests/stack_controller_test.go
@@ -110,6 +110,32 @@ var _ = Describe("StackController", func() {
 				Expect(version).To(Equal("1234"))
 			})
 		})
+		Context("with a semver pod version lower than the minimum Versions resource version", func() {
+			BeforeEach(func() {
+				stack.Spec.Version = "v0.2.0"
+			})
+			It("should resolve a module to the specified pod version", func() {
+				version, err := core.GetModuleVersion(TestContext(), stack, &v1beta1.Ledger{})
+				Expect(err).To(Succeed())
+				Expect(version).To(Equal("v0.2.0"))
+			})
+		})
+		Context("with a module pod version lower than the minimum Versions resource version", func() {
+			BeforeEach(func() {
+				stack.Spec.Version = "v2.2.0"
+			})
+			It("should resolve a module to its explicit pod version", func() {
+				version, err := core.GetModuleVersion(TestContext(), stack, &v1beta1.Ledger{
+					Spec: v1beta1.LedgerSpec{
+						ModuleProperties: v1beta1.ModuleProperties{
+							Version: "v0.2.0",
+						},
+					},
+				})
+				Expect(err).To(Succeed())
+				Expect(version).To(Equal("v0.2.0"))
+			})
+		})
 		Context("with version file specified", func() {
 			var versions *v1beta1.Versions
 			BeforeEach(func() {
@@ -144,6 +170,33 @@ var _ = Describe("StackController", func() {
 						g.Expect(err).To(Succeed())
 						return version
 					}).Should(Equal("5678"))
+				})
+			})
+			Context("with a supported Versions resource name and lower module pod version", func() {
+				BeforeEach(func() {
+					versions.Name = "v2.2.0"
+					versions.Spec["ledger"] = "v0.2.0"
+					stack.Spec.VersionsFromFile = versions.Name
+				})
+				It("should resolve to the pod version from the Versions resource", func() {
+					Eventually(func(g Gomega) string {
+						version, err := core.GetModuleVersion(TestContext(), stack, &v1beta1.Ledger{})
+						g.Expect(err).To(Succeed())
+						return version
+					}).Should(Equal("v0.2.0"))
+				})
+			})
+			Context("with an unsupported Versions resource name", func() {
+				BeforeEach(func() {
+					versions.Name = "v2.1.0"
+					versions.Spec["ledger"] = "v9.9.9"
+					stack.Spec.VersionsFromFile = versions.Name
+				})
+				It("should reject the Versions resource", func() {
+					_, err := core.GetModuleVersion(TestContext(), stack, &v1beta1.Ledger{})
+					Expect(err).To(HaveOccurred())
+					Expect(err.Error()).To(ContainSubstring("not supported"))
+					Expect(err.Error()).To(ContainSubstring(core.MinimumStackVersion))
 				})
 			})
 		})


### PR DESCRIPTION
## Summary
- restrict the v2.2.0 minimum check to `spec.versionsFromFile` when resolving module versions from a `Versions` resource
- allow module/pod image versions such as `v0.2.0` from stack, module override, or Versions content
- add regression coverage for supported/unsupported Versions resource names and lower pod versions

## Tests
- `go test ./internal/core`
- `KUBEBUILDER_ASSETS="$(bin/setup-envtest use 1.32.0 --bin-dir "$(pwd)/bin" -p path)" go test ./internal/tests`
- `KUBEBUILDER_ASSETS="$(bin/setup-envtest use 1.32.0 --bin-dir "$(pwd)/bin" -p path)" go test ./...`