### PR TITLE
chore(helm): prepare v3.11.0 charts

### DIFF
--- a/helm/crds/Chart.yaml
+++ b/helm/crds/Chart.yaml
@@ -13,9 +13,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: "3.9.6"
+version: "3.11.0"
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v3.9.6"
+appVersion: "v3.11.0"

--- a/helm/operator/Chart.lock
+++ b/helm/operator/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: operator-crds
   repository: file://../crds
-  version: 3.9.6
-digest: sha256:2a8dc1b07799a8edc94ed5388ee7167079af628cffe740d537f45c897443da98
-generated: "2026-05-22T16:26:37.800918+02:00"
+  version: 3.11.0
+digest: sha256:0aedca966b9012bcbe6d94659626212fd251654787e56e9c18ce6fe2c49c01b1
+generated: "2026-05-25T17:07:24.582004+02:00"

--- a/helm/operator/Chart.yaml
+++ b/helm/operator/Chart.yaml
@@ -13,12 +13,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: "3.9.6"
+version: "3.11.0"
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v3.9.6"
+appVersion: "v3.11.0"
 dependencies:
 - name: operator-crds
   version: "3.X"


### PR DESCRIPTION
## Summary
- Bump operator and operator-crds chart versions to 3.11.0
- Bump chart appVersions to v3.11.0
- Regenerate operator Chart.lock after the local operator-crds dependency update

## Validation
- just helm-update
- just helm-validate

Note: this PR is based only on main. GatewayGRPCAPI remains in its separate PR.