### PR TITLE
fix(operator): reconcile dependents after deletion

### DIFF
--- a/docs/09-Configuration reference/settings.catalog.json
+++ b/docs/09-Configuration reference/settings.catalog.json
@@ -526,14 +526,14 @@
       "key": "namespace.annotations",
       "valueType": "map[string]string",
       "sources": [
-        "internal/resources/stacks/init.go:173"
+        "internal/resources/stacks/init.go:180"
       ]
     },
     {
       "key": "namespace.labels",
       "valueType": "map[string]string",
       "sources": [
-        "internal/resources/stacks/init.go:154"
+        "internal/resources/stacks/init.go:161"
       ]
     },
     {

--- a/internal/core/controllers.go
+++ b/internal/core/controllers.go
@@ -75,6 +75,10 @@ func ForStackDependency[T v1beta1.Dependent](ctrl StackDependentObjectController
 				return err
 			}
 		} else {
+			if err := ensureStackLabel(ctx, t); err != nil {
+				return err
+			}
+
 			if stack.GetAnnotations()[v1beta1.SkipLabel] == "true" {
 				t.GetConditions().
 					AppendOrReplace(v1beta1.Condition{
@@ -97,6 +101,27 @@ func ForStackDependency[T v1beta1.Dependent](ctrl StackDependentObjectController
 
 		return ctrl(ctx, stack, reconcilerOptions, t)
 	}
+}
+
+func ensureStackLabel[T v1beta1.Dependent](ctx Context, t T) error {
+	stackName := t.GetStack()
+	if stackName == "" {
+		return nil
+	}
+
+	labels := t.GetLabels()
+	if labels != nil && labels[v1beta1.StackLabel] == stackName {
+		return nil
+	}
+
+	patch := client.MergeFrom(t.DeepCopyObject().(T))
+	if labels == nil {
+		labels = map[string]string{}
+	}
+	labels[v1beta1.StackLabel] = stackName
+	t.SetLabels(labels)
+
+	return ctx.GetClient().Patch(ctx, t, patch)
 }
 
 type ModuleController[T v1beta1.Module] func(ctx Context, stack *v1beta1.Stack, reconcilerOptions *ReconcilerOptions[T], req T, version string) error

--- a/internal/core/stacks.go
+++ b/internal/core/stacks.go
@@ -35,6 +35,10 @@ func GetAllStackDependencies(ctx Context, stackName string, to any) error {
 
 	ret := reflect.ValueOf(slice)
 	for _, item := range list.Items {
+		if !item.GetDeletionTimestamp().IsZero() {
+			continue
+		}
+
 		t := reflect.New(objectType.Elem()).Interface().(client.Object)
 		if err := runtime.DefaultUnstructuredConverter.FromUnstructured(item.Object, t); err != nil {
 			panic(err)

--- a/internal/core/watch.go
+++ b/internal/core/watch.go
@@ -14,10 +14,14 @@ func WatchDependents(mgr Manager, t client.Object) func(ctx context.Context, obj
 	return func(ctx context.Context, object client.Object) []reconcile.Request {
 
 		slice := reflect.MakeSlice(reflect.SliceOf(reflect.TypeOf(t)), 0, 0).Interface()
+		stackName := stackNameFromObject(object)
+		if stackName == "" {
+			return nil
+		}
 
 		err := GetAllStackDependencies(
 			NewContext(mgr, ctx),
-			object.(v1beta1.Dependent).GetStack(), &slice)
+			stackName, &slice)
 		if err != nil {
 			return nil
 		}
@@ -29,6 +33,32 @@ func WatchDependents(mgr Manager, t client.Object) func(ctx context.Context, obj
 
 		return MapObjectToReconcileRequests(objects...)
 	}
+}
+
+func stackNameFromObject(object client.Object) string {
+	if dependent, ok := object.(v1beta1.Dependent); ok && dependent.GetStack() != "" {
+		return dependent.GetStack()
+	}
+
+	if labels := object.GetLabels(); labels != nil {
+		if stackName := labels[v1beta1.StackLabel]; stackName != "" && stackName != "any" {
+			return stackName
+		}
+	}
+
+	if annotations := object.GetAnnotations(); annotations != nil {
+		if stackName := annotations[v1beta1.StackLabel]; stackName != "" && stackName != "any" {
+			return stackName
+		}
+	}
+
+	for _, ownerReference := range object.GetOwnerReferences() {
+		if ownerReference.APIVersion == v1beta1.GroupVersion.String() && ownerReference.Kind == "Stack" {
+			return ownerReference.Name
+		}
+	}
+
+	return ""
 }
 
 func Watch(mgr Manager, t client.Object) func(ctx context.Context, object client.Object) []reconcile.Request {

--- a/internal/resources/stacks/init.go
+++ b/internal/resources/stacks/init.go
@@ -75,7 +75,14 @@ func setModulesCondition(ctx Context, stack *v1beta1.Stack) error {
 			return err
 		}
 
-		switch len(l.Items) {
+		items := l.Items[:0]
+		for _, item := range l.Items {
+			if item.GetDeletionTimestamp().IsZero() {
+				items = append(items, item)
+			}
+		}
+
+		switch len(items) {
 		case 0:
 			stack.GetConditions().Delete(v1beta1.ConditionPredicate(func(condition v1beta1.Condition) bool {
 				return condition.Type == ModuleReconciliation && condition.Reason == gvk.Kind && condition.ObservedGeneration == stack.Generation
@@ -102,7 +109,7 @@ func setModulesCondition(ctx Context, stack *v1beta1.Stack) error {
 			}
 
 			module := AnyModule{}
-			if err := runtime.DefaultUnstructuredConverter.FromUnstructured(l.Items[0].UnstructuredContent(), &module); err != nil {
+			if err := runtime.DefaultUnstructuredConverter.FromUnstructured(items[0].UnstructuredContent(), &module); err != nil {
 				panic(err)
 			}
 

--- a/internal/tests/gateway_controller_test.go
+++ b/internal/tests/gateway_controller_test.go
@@ -2,6 +2,7 @@ package tests_test
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
@@ -251,7 +252,7 @@ var _ = Describe("GatewayController", func() {
 				Expect(Create(anotherHttpService)).To(Succeed())
 			})
 			AfterEach(func() {
-				Expect(Delete(anotherHttpService)).To(Succeed())
+				Expect(client.IgnoreNotFound(Delete(anotherHttpService))).To(Succeed())
 			})
 			It("Should trigger deployment gateway with the new service", func() {
 				Eventually(func(g Gomega) []string {
@@ -265,6 +266,27 @@ var _ = Describe("GatewayController", func() {
 					g.Expect(LoadResource(stack.Name, "gateway", cm)).To(Succeed())
 					return cm.Data["Caddyfile"]
 				}).Should(MatchGoldenFile("gateway-controller", "configmap-with-ledger-and-another-service.yaml"))
+			})
+			It("Should remove deleted HTTPService from the gateway", func() {
+				Eventually(func(g Gomega) []string {
+					g.Expect(LoadResource("", gateway.Name, gateway))
+
+					return gateway.Status.SyncHTTPAPIs
+				}).Should(ContainElements(httpAPI.Spec.Name, anotherHttpService.Spec.Name))
+
+				Expect(Delete(anotherHttpService)).To(Succeed())
+
+				Eventually(func(g Gomega) []string {
+					g.Expect(LoadResource("", gateway.Name, gateway))
+
+					return gateway.Status.SyncHTTPAPIs
+				}, time.Minute).Should(ConsistOf(httpAPI.Spec.Name))
+
+				Eventually(func(g Gomega) string {
+					cm := &corev1.ConfigMap{}
+					g.Expect(LoadResource(stack.Name, "gateway", cm)).To(Succeed())
+					return cm.Data["Caddyfile"]
+				}, time.Minute).ShouldNot(ContainSubstring(anotherHttpService.Spec.Name))
 			})
 		})
 		Context("With a consumer on gateway", func() {


### PR DESCRIPTION
## Summary
- persist the stack label on dependent resources during reconciliation
- resolve dependency watch stack context from spec, labels, annotations, or Stack owner references
- ignore stack dependencies/modules that are already marked for deletion when reconciling active status
- add Gateway controller regression coverage for deleted HTTPService removal

## Root cause
The failing `main` CI run timed out in the `10-gatewayhttpapi-sync` scenario on Kubernetes 1.32 after deleting `chainsaw-httpapi-payments`. The Service was gone, but `Gateway.status.syncHTTPAPIs` still listed `ledger payments`, which means the Gateway was not reconciled with the deleted HTTP API removed.

Delete events can arrive without reliable dependent spec data, so `WatchDependents` could miss the stack name and skip enqueueing the Gateway reconcile. Also, an object that is already marked for deletion can still appear in list results until finalizers complete, so active Gateway and Stack status must not keep it in generated routes/status.

## Validation
- `just pre-commit`
- `KUBEBUILDER_ASSETS="$(setup-envtest use 1.32.0 -p path)" go test ./internal/tests -run TestAPIs -ginkgo.focus 'StackController|GatewayController' -count=1`\n- `just tests`\n- `./bin/chainsaw test tests/e2e/chainsaw/10-gatewayhttpapi-sync --config tests/e2e/chainsaw/.chainsaw.yaml --report-path /tmp/operator-ci-fix-132-artifacts` on Kind `kindest/node:v1.32.5`\n