### PR TITLE
fix: encode postgres secret credentials in database uri

### DIFF
--- a/docs/09-Configuration reference/settings.catalog.json
+++ b/docs/09-Configuration reference/settings.catalog.json
@@ -43,7 +43,7 @@
       "key": "clear-database",
       "valueType": "bool",
       "sources": [
-        "internal/resources/databases/init.go:112"
+        "internal/resources/databases/init.go:122"
       ]
     },
     {
@@ -519,7 +519,7 @@
         }
       ],
       "sources": [
-        "internal/resources/databases/env.go:72"
+        "internal/resources/databases/env.go:79"
       ]
     },
     {
@@ -637,7 +637,7 @@
       "key": "postgres.\u003cmodule-name\u003e.uri",
       "valueType": "uri",
       "sources": [
-        "internal/resources/databases/init.go:49"
+        "internal/resources/databases/init.go:50"
       ]
     },
     {

--- a/internal/resources/databases/env.go
+++ b/internal/resources/databases/env.go
@@ -3,6 +3,7 @@ package databases
 import (
 	"net/url"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/pkg/errors"
@@ -20,23 +21,29 @@ func GetPostgresEnvVars(ctx core.Context, stack *v1beta1.Stack, database *v1beta
 		core.Env("POSTGRES_DATABASE", database.Status.Database),
 	}
 	if database.Status.URI.User.Username() != "" || database.Status.URI.Query().Get("secret") != "" {
+		postgresURIUsernameEnv := "POSTGRES_USERNAME"
+		postgresURIPasswordEnv := "POSTGRES_PASSWORD"
 		if database.Status.URI.User.Username() != "" {
 			password, _ := database.Status.URI.User.Password()
 			ret = append(ret,
-				core.Env("POSTGRES_USERNAME", database.Status.URI.User.Username()),
-				core.Env("POSTGRES_PASSWORD", url.QueryEscape(password)),
+				core.Env("POSTGRES_USERNAME", escapePostgresCredentialForURI(database.Status.URI.User.Username())),
+				core.Env("POSTGRES_PASSWORD", escapePostgresCredentialForURI(password)),
 			)
 		} else {
 			secret := database.Status.URI.Query().Get("secret")
+			postgresURIUsernameEnv = "POSTGRES_URL_ENCODED_USERNAME"
+			postgresURIPasswordEnv = "POSTGRES_URL_ENCODED_PASSWORD"
 			ret = append(ret,
-				core.EnvFromSecret("POSTGRES_USERNAME", secret, "username"),
-				core.EnvFromSecret("POSTGRES_PASSWORD", secret, "password"),
+				core.EnvFromSecret("POSTGRES_USERNAME", secret, postgresCredentialsUsernameKey),
+				core.EnvFromSecret("POSTGRES_PASSWORD", secret, postgresCredentialsPasswordKey),
+				core.EnvFromSecret("POSTGRES_URL_ENCODED_USERNAME", getEncodedPostgresCredentialsSecretName(database), postgresCredentialsUsernameKey),
+				core.EnvFromSecret("POSTGRES_URL_ENCODED_PASSWORD", getEncodedPostgresCredentialsSecretName(database), postgresCredentialsPasswordKey),
 			)
 		}
 		ret = append(ret,
 			core.Env("POSTGRES_NO_DATABASE_URI", core.ComputeEnvVar("postgresql://%s:%s@%s:%s",
-				"POSTGRES_USERNAME",
-				"POSTGRES_PASSWORD",
+				postgresURIUsernameEnv,
+				postgresURIPasswordEnv,
 				"POSTGRES_HOST",
 				"POSTGRES_PORT",
 			)),
@@ -104,6 +111,12 @@ func GetPostgresEnvVars(ctx core.Context, stack *v1beta1.Stack, database *v1beta
 	}
 
 	return ret, nil
+}
+
+// escapePostgresCredentialForURI escapes credentials for URI userinfo, where
+// spaces must be encoded as %20 rather than query-string-style plus signs.
+func escapePostgresCredentialForURI(credential string) string {
+	return strings.TrimPrefix(url.UserPassword("", credential).String(), ":")
 }
 
 // BuildPostgresQueryString takes the raw URI query params, filters internal

--- a/internal/resources/databases/env_test.go
+++ b/internal/resources/databases/env_test.go
@@ -1,10 +1,21 @@
 package databases
 
 import (
+	"context"
+	"fmt"
 	"net/url"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/formancehq/operator/v3/api/formance.com/v1beta1"
+	"github.com/formancehq/operator/v3/internal/core"
 )
 
 func TestBuildPostgresQueryString(t *testing.T) {
@@ -77,6 +88,179 @@ func TestBuildPostgresQueryString(t *testing.T) {
 				require.NoError(t, err)
 				require.Equal(t, expectedParams, actualParams)
 			}
+		})
+	}
+}
+
+type testContext struct {
+	context.Context
+	client    client.Client
+	apiReader client.Reader
+	scheme    *runtime.Scheme
+}
+
+func (t testContext) GetClient() client.Client {
+	return t.client
+}
+
+func (t testContext) GetScheme() *runtime.Scheme {
+	return t.scheme
+}
+
+func (t testContext) GetAPIReader() client.Reader {
+	return t.apiReader
+}
+
+func (t testContext) GetPlatform() core.Platform {
+	return core.Platform{}
+}
+
+func newTestContext(t *testing.T, objects ...client.Object) testContext {
+	t.Helper()
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, v1beta1.AddToScheme(scheme))
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(objects...).
+		WithIndex(&v1beta1.Settings{}, "stack", func(obj client.Object) []string {
+			settings := obj.(*v1beta1.Settings)
+			return settings.Spec.Stacks
+		}).
+		WithIndex(&v1beta1.Settings{}, "keylen", func(obj client.Object) []string {
+			settings := obj.(*v1beta1.Settings)
+			keys := strings.Split(settings.Spec.Key, ".")
+			return []string{fmt.Sprint(len(keys))}
+		}).
+		Build()
+
+	return testContext{
+		Context:   context.Background(),
+		client:    fakeClient,
+		apiReader: fakeClient,
+		scheme:    scheme,
+	}
+}
+
+func TestGetPostgresEnvVarsUsesEncodedSecretForURI(t *testing.T) {
+	t.Parallel()
+
+	ctx := newTestContext(t)
+	stack := &v1beta1.Stack{
+		ObjectMeta: metav1.ObjectMeta{Name: "stack"},
+	}
+	postgresURI, err := v1beta1.ParseURL("postgresql://postgres:5432?secret=postgres")
+	require.NoError(t, err)
+	database := &v1beta1.Database{
+		ObjectMeta: metav1.ObjectMeta{Name: "stack-ledger"},
+		Spec: v1beta1.DatabaseSpec{
+			Service: "ledger",
+		},
+		Status: v1beta1.DatabaseStatus{
+			URI:      postgresURI,
+			Database: "ledger",
+		},
+	}
+
+	envVars, err := GetPostgresEnvVars(ctx, stack, database)
+	require.NoError(t, err)
+
+	envByName := make(map[string]corev1.EnvVar, len(envVars))
+	for _, envVar := range envVars {
+		envByName[envVar.Name] = envVar
+	}
+
+	require.Equal(t, "postgres", envByName["POSTGRES_USERNAME"].ValueFrom.SecretKeyRef.Name)
+	require.Equal(t, postgresCredentialsUsernameKey, envByName["POSTGRES_USERNAME"].ValueFrom.SecretKeyRef.Key)
+	require.Equal(t, "postgres", envByName["POSTGRES_PASSWORD"].ValueFrom.SecretKeyRef.Name)
+	require.Equal(t, postgresCredentialsPasswordKey, envByName["POSTGRES_PASSWORD"].ValueFrom.SecretKeyRef.Key)
+
+	encodedSecretName := getEncodedPostgresCredentialsSecretName(database)
+	require.Equal(t, encodedSecretName, envByName["POSTGRES_URL_ENCODED_USERNAME"].ValueFrom.SecretKeyRef.Name)
+	require.Equal(t, postgresCredentialsUsernameKey, envByName["POSTGRES_URL_ENCODED_USERNAME"].ValueFrom.SecretKeyRef.Key)
+	require.Equal(t, encodedSecretName, envByName["POSTGRES_URL_ENCODED_PASSWORD"].ValueFrom.SecretKeyRef.Name)
+	require.Equal(t, postgresCredentialsPasswordKey, envByName["POSTGRES_URL_ENCODED_PASSWORD"].ValueFrom.SecretKeyRef.Key)
+
+	require.Equal(t,
+		"postgresql://$(POSTGRES_URL_ENCODED_USERNAME):$(POSTGRES_URL_ENCODED_PASSWORD)@$(POSTGRES_HOST):$(POSTGRES_PORT)",
+		envByName["POSTGRES_NO_DATABASE_URI"].Value,
+	)
+	require.Equal(t, "$(POSTGRES_NO_DATABASE_URI)/$(POSTGRES_DATABASE)", envByName["POSTGRES_URI"].Value)
+}
+
+func TestGetPostgresEnvVarsEscapesInlineCredentialsForURIUserinfo(t *testing.T) {
+	t.Parallel()
+
+	ctx := newTestContext(t)
+	stack := &v1beta1.Stack{
+		ObjectMeta: metav1.ObjectMeta{Name: "stack"},
+	}
+	postgresURI, err := v1beta1.ParseURL("postgresql://user%20name:p%5Ess%20word@postgres:5432")
+	require.NoError(t, err)
+	database := &v1beta1.Database{
+		ObjectMeta: metav1.ObjectMeta{Name: "stack-ledger"},
+		Spec: v1beta1.DatabaseSpec{
+			Service: "ledger",
+		},
+		Status: v1beta1.DatabaseStatus{
+			URI:      postgresURI,
+			Database: "ledger",
+		},
+	}
+
+	envVars, err := GetPostgresEnvVars(ctx, stack, database)
+	require.NoError(t, err)
+
+	envByName := make(map[string]corev1.EnvVar, len(envVars))
+	for _, envVar := range envVars {
+		envByName[envVar.Name] = envVar
+	}
+
+	require.Equal(t, "user%20name", envByName["POSTGRES_USERNAME"].Value)
+	require.Equal(t, "p%5Ess%20word", envByName["POSTGRES_PASSWORD"].Value)
+	require.Equal(t,
+		"postgresql://$(POSTGRES_USERNAME):$(POSTGRES_PASSWORD)@$(POSTGRES_HOST):$(POSTGRES_PORT)",
+		envByName["POSTGRES_NO_DATABASE_URI"].Value,
+	)
+}
+
+func TestEscapePostgresCredentialForURI(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name       string
+		credential string
+		expected   string
+	}{
+		{
+			name:       "space",
+			credential: "p ss",
+			expected:   "p%20ss",
+		},
+		{
+			name:       "plus",
+			credential: "p+ss",
+			expected:   "p+ss",
+		},
+		{
+			name:       "authority delimiters",
+			credential: "p@ss:word",
+			expected:   "p%40ss%3Aword",
+		},
+		{
+			name:       "caret",
+			credential: "p^ss",
+			expected:   "p%5Ess",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			require.Equal(t, tc.expected, escapePostgresCredentialForURI(tc.credential))
 		})
 	}
 }

--- a/internal/resources/databases/init.go
+++ b/internal/resources/databases/init.go
@@ -43,6 +43,7 @@ const (
 //+kubebuilder:rbac:groups=formance.com,resources=databases,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=formance.com,resources=databases/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=formance.com,resources=databases/finalizers,verbs=update
+//+kubebuilder:rbac:groups=core,resources=secrets,verbs=get;create;update;patch;delete
 
 func Reconcile(ctx core.Context, stack *v1beta1.Stack, database *v1beta1.Database) error {
 
@@ -53,11 +54,20 @@ func Reconcile(ctx core.Context, stack *v1beta1.Stack, database *v1beta1.Databas
 
 	if secret := databaseURL.Query().Get("secret"); secret != "" {
 		_, err = resourcereferences.Create(ctx, database, "postgres", secret, &v1.Secret{})
+		if err != nil {
+			return err
+		}
+		if err := reconcileEncodedPostgresCredentialsSecret(ctx, stack, database, secret); err != nil {
+			return err
+		}
 	} else {
 		err = resourcereferences.Delete(ctx, database, "postgres")
-	}
-	if err != nil {
-		return err
+		if err != nil {
+			return err
+		}
+		if err := deleteEncodedPostgresCredentialsSecret(ctx, stack, database); err != nil {
+			return err
+		}
 	}
 
 	awsRole, err := settings.GetAWSServiceAccount(ctx, stack.Name)
@@ -186,6 +196,7 @@ func init() {
 		core.WithResourceReconciler(Reconcile,
 			core.WithOwn[*v1beta1.Database](&batchv1.Job{}),
 			core.WithOwn[*v1beta1.Database](&v1beta1.ResourceReference{}),
+			core.WithOwn[*v1beta1.Database](&v1.Secret{}),
 			core.WithWatchSettings[*v1beta1.Database](),
 			core.WithFinalizer(databaseFinalizer, Delete),
 		),

--- a/internal/resources/databases/secret.go
+++ b/internal/resources/databases/secret.go
@@ -1,0 +1,63 @@
+package databases
+
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/formancehq/operator/v3/api/formance.com/v1beta1"
+	"github.com/formancehq/operator/v3/internal/core"
+)
+
+const (
+	postgresCredentialsUsernameKey = "username"
+	postgresCredentialsPasswordKey = "password"
+
+	encodedPostgresCredentialsSecretSuffix = "postgres-uri-credentials"
+)
+
+func getEncodedPostgresCredentialsSecretName(database *v1beta1.Database) string {
+	return fmt.Sprintf("%s-%s", database.Name, encodedPostgresCredentialsSecretSuffix)
+}
+
+func reconcileEncodedPostgresCredentialsSecret(ctx core.Context, stack *v1beta1.Stack, database *v1beta1.Database, secretName string) error {
+	sourceSecret := &corev1.Secret{}
+	if err := ctx.GetClient().Get(ctx, types.NamespacedName{
+		Namespace: stack.Name,
+		Name:      secretName,
+	}, sourceSecret); err != nil {
+		return errors.Wrap(err, "getting postgres credentials secret")
+	}
+
+	username, ok := sourceSecret.Data[postgresCredentialsUsernameKey]
+	if !ok {
+		return fmt.Errorf("postgres credentials secret %s/%s is missing %q", stack.Name, secretName, postgresCredentialsUsernameKey)
+	}
+	password, ok := sourceSecret.Data[postgresCredentialsPasswordKey]
+	if !ok {
+		return fmt.Errorf("postgres credentials secret %s/%s is missing %q", stack.Name, secretName, postgresCredentialsPasswordKey)
+	}
+
+	_, _, err := core.CreateOrUpdate[*corev1.Secret](ctx, types.NamespacedName{
+		Namespace: stack.Name,
+		Name:      getEncodedPostgresCredentialsSecretName(database),
+	}, func(secret *corev1.Secret) error {
+		secret.Type = corev1.SecretTypeOpaque
+		secret.Data = map[string][]byte{
+			postgresCredentialsUsernameKey: []byte(escapePostgresCredentialForURI(string(username))),
+			postgresCredentialsPasswordKey: []byte(escapePostgresCredentialForURI(string(password))),
+		}
+		return nil
+	}, core.WithController[*corev1.Secret](ctx.GetScheme(), database))
+	return errors.Wrap(err, "reconciling encoded postgres credentials secret")
+}
+
+func deleteEncodedPostgresCredentialsSecret(ctx core.Context, stack *v1beta1.Stack, database *v1beta1.Database) error {
+	err := core.DeleteIfExists[*corev1.Secret](ctx, types.NamespacedName{
+		Namespace: stack.Name,
+		Name:      getEncodedPostgresCredentialsSecretName(database),
+	})
+	return errors.Wrap(err, "deleting encoded postgres credentials secret")
+}

--- a/internal/resources/databases/secret_test.go
+++ b/internal/resources/databases/secret_test.go
@@ -1,0 +1,53 @@
+package databases
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/formancehq/operator/v3/api/formance.com/v1beta1"
+)
+
+func TestReconcileEncodedPostgresCredentialsSecret(t *testing.T) {
+	t.Parallel()
+
+	stack := &v1beta1.Stack{
+		ObjectMeta: metav1.ObjectMeta{Name: "stack"},
+	}
+	database := &v1beta1.Database{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: v1beta1.GroupVersion.String(),
+			Kind:       "Database",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "stack-ledger",
+			UID:  types.UID("database-uid"),
+		},
+	}
+	sourceSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: stack.Name,
+			Name:      "postgres",
+		},
+		Data: map[string][]byte{
+			postgresCredentialsUsernameKey: []byte("user^name"),
+			postgresCredentialsPasswordKey: []byte("p^ss word"),
+		},
+	}
+	ctx := newTestContext(t, sourceSecret)
+
+	require.NoError(t, reconcileEncodedPostgresCredentialsSecret(ctx, stack, database, sourceSecret.Name))
+
+	encodedSecret := &corev1.Secret{}
+	require.NoError(t, ctx.GetClient().Get(ctx, types.NamespacedName{
+		Namespace: stack.Name,
+		Name:      getEncodedPostgresCredentialsSecretName(database),
+	}, encodedSecret))
+	require.Equal(t, []byte("user%5Ename"), encodedSecret.Data[postgresCredentialsUsernameKey])
+	require.Equal(t, []byte("p%5Ess%20word"), encodedSecret.Data[postgresCredentialsPasswordKey])
+	require.Len(t, encodedSecret.OwnerReferences, 1)
+	require.Equal(t, database.Name, encodedSecret.OwnerReferences[0].Name)
+}


### PR DESCRIPTION
## Summary
- create an encoded PostgreSQL credentials Secret when database credentials come from a Kubernetes Secret
- use encoded username/password env vars when building `POSTGRES_URI`
- keep `POSTGRES_USERNAME` and `POSTGRES_PASSWORD` sourced from the original Secret for existing consumers

## Root cause
Database credentials loaded through `?secret=...` were injected raw and then interpolated into `postgresql://user:password@host:port`, so special URI characters such as `^` could break the resulting connection string.

Fixes #481

## Validation
- `CGO_ENABLED=0 go test ./internal/resources/databases`
- `KUBEBUILDER_ASSETS="$(pwd)/bin/k8s/1.32.0-darwin-arm64" CGO_ENABLED=0 go test ./...`
- `nix develop -c just pc`