### PR TITLE
fix(operator): avoid encoded postgres secret collision

### DIFF
--- a/docs/09-Configuration reference/settings.catalog.json
+++ b/docs/09-Configuration reference/settings.catalog.json
@@ -43,7 +43,7 @@
       "key": "clear-database",
       "valueType": "bool",
       "sources": [
-        "internal/resources/databases/init.go:122"
+        "internal/resources/databases/init.go:139"
       ]
     },
     {
@@ -519,7 +519,7 @@
         }
       ],
       "sources": [
-        "internal/resources/databases/env.go:79"
+        "internal/resources/databases/env.go:80"
       ]
     },
     {

--- a/internal/resources/databases/env.go
+++ b/internal/resources/databases/env.go
@@ -33,11 +33,12 @@ func GetPostgresEnvVars(ctx core.Context, stack *v1beta1.Stack, database *v1beta
 			secret := database.Status.URI.Query().Get("secret")
 			postgresURIUsernameEnv = "POSTGRES_URL_ENCODED_USERNAME"
 			postgresURIPasswordEnv = "POSTGRES_URL_ENCODED_PASSWORD"
+			encodedSecretName := getEncodedPostgresCredentialsSecretName(database, secret)
 			ret = append(ret,
 				core.EnvFromSecret("POSTGRES_USERNAME", secret, postgresCredentialsUsernameKey),
 				core.EnvFromSecret("POSTGRES_PASSWORD", secret, postgresCredentialsPasswordKey),
-				core.EnvFromSecret("POSTGRES_URL_ENCODED_USERNAME", getEncodedPostgresCredentialsSecretName(database), postgresCredentialsUsernameKey),
-				core.EnvFromSecret("POSTGRES_URL_ENCODED_PASSWORD", getEncodedPostgresCredentialsSecretName(database), postgresCredentialsPasswordKey),
+				core.EnvFromSecret("POSTGRES_URL_ENCODED_USERNAME", encodedSecretName, postgresCredentialsUsernameKey),
+				core.EnvFromSecret("POSTGRES_URL_ENCODED_PASSWORD", encodedSecretName, postgresCredentialsPasswordKey),
 			)
 		}
 		ret = append(ret,

--- a/internal/resources/databases/env_test.go
+++ b/internal/resources/databases/env_test.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	"github.com/formancehq/operator/v3/api/formance.com/v1beta1"
 	"github.com/formancehq/operator/v3/internal/core"
@@ -116,6 +117,10 @@ func (t testContext) GetPlatform() core.Platform {
 }
 
 func newTestContext(t *testing.T, objects ...client.Object) testContext {
+	return newTestContextWithInterceptor(t, interceptor.Funcs{}, objects...)
+}
+
+func newTestContextWithInterceptor(t *testing.T, interceptorFuncs interceptor.Funcs, objects ...client.Object) testContext {
 	t.Helper()
 
 	scheme := runtime.NewScheme()
@@ -134,6 +139,7 @@ func newTestContext(t *testing.T, objects ...client.Object) testContext {
 			keys := strings.Split(settings.Spec.Key, ".")
 			return []string{fmt.Sprint(len(keys))}
 		}).
+		WithInterceptorFuncs(interceptorFuncs).
 		Build()
 
 	return testContext{
@@ -188,6 +194,52 @@ func TestGetPostgresEnvVarsUsesEncodedSecretForURI(t *testing.T) {
 		envByName["POSTGRES_NO_DATABASE_URI"].Value,
 	)
 	require.Equal(t, "$(POSTGRES_NO_DATABASE_URI)/$(POSTGRES_DATABASE)", envByName["POSTGRES_URI"].Value)
+}
+
+func TestGetPostgresEnvVarsAvoidsEncodedSecretNameCollision(t *testing.T) {
+	t.Parallel()
+
+	ctx := newTestContext(t)
+	stack := &v1beta1.Stack{
+		ObjectMeta: metav1.ObjectMeta{Name: "stack"},
+	}
+	sourceSecretName := "stack-ledger-postgres-uri-credentials"
+	postgresURI, err := v1beta1.ParseURL("postgresql://postgres:5432?secret=" + sourceSecretName)
+	require.NoError(t, err)
+	database := &v1beta1.Database{
+		ObjectMeta: metav1.ObjectMeta{Name: "stack-ledger"},
+		Spec: v1beta1.DatabaseSpec{
+			Service: "ledger",
+		},
+		Status: v1beta1.DatabaseStatus{
+			URI:      postgresURI,
+			Database: "ledger",
+		},
+	}
+
+	envVars, err := GetPostgresEnvVars(ctx, stack, database)
+	require.NoError(t, err)
+
+	envByName := make(map[string]corev1.EnvVar, len(envVars))
+	for _, envVar := range envVars {
+		envByName[envVar.Name] = envVar
+	}
+
+	require.Equal(t, sourceSecretName, envByName["POSTGRES_USERNAME"].ValueFrom.SecretKeyRef.Name)
+	require.Equal(t, sourceSecretName, envByName["POSTGRES_PASSWORD"].ValueFrom.SecretKeyRef.Name)
+	require.NotEqual(t, sourceSecretName, envByName["POSTGRES_URL_ENCODED_USERNAME"].ValueFrom.SecretKeyRef.Name)
+	require.NotEqual(t,
+		fmt.Sprintf("%s-%s", database.Name, collisionSafeEncodedPostgresCredentialsSecretSuffix),
+		envByName["POSTGRES_URL_ENCODED_USERNAME"].ValueFrom.SecretKeyRef.Name,
+	)
+	require.Equal(t,
+		envByName["POSTGRES_URL_ENCODED_USERNAME"].ValueFrom.SecretKeyRef.Name,
+		envByName["POSTGRES_URL_ENCODED_PASSWORD"].ValueFrom.SecretKeyRef.Name,
+	)
+	require.Equal(t,
+		"postgresql://$(POSTGRES_URL_ENCODED_USERNAME):$(POSTGRES_URL_ENCODED_PASSWORD)@$(POSTGRES_HOST):$(POSTGRES_PORT)",
+		envByName["POSTGRES_NO_DATABASE_URI"].Value,
+	)
 }
 
 func TestGetPostgresEnvVarsEscapesInlineCredentialsForURIUserinfo(t *testing.T) {

--- a/internal/resources/databases/init.go
+++ b/internal/resources/databases/init.go
@@ -61,11 +61,15 @@ func Reconcile(ctx core.Context, stack *v1beta1.Stack, database *v1beta1.Databas
 			return err
 		}
 	} else {
-		err = resourcereferences.Delete(ctx, database, "postgres")
+		previousPostgresCredentialsSecret, err := getPostgresCredentialsSecretReference(ctx, database)
 		if err != nil {
 			return err
 		}
-		if err := deleteEncodedPostgresCredentialsSecret(ctx, stack, database); err != nil {
+		if err := deleteEncodedPostgresCredentialsSecret(ctx, stack, database, previousPostgresCredentialsSecret); err != nil {
+			return err
+		}
+		err = resourcereferences.Delete(ctx, database, "postgres")
+		if err != nil {
 			return err
 		}
 	}
@@ -114,7 +118,20 @@ func Reconcile(ctx core.Context, stack *v1beta1.Stack, database *v1beta1.Databas
 	return nil
 }
 
+func getPostgresCredentialsSecretReference(ctx core.Context, database *v1beta1.Database) (string, error) {
+	reference := &v1beta1.ResourceReference{}
+	if err := ctx.GetClient().Get(ctx, types.NamespacedName{
+		Name: fmt.Sprintf("%s-postgres", database.Name),
+	}, reference); err != nil {
+		return "", client.IgnoreNotFound(err)
+	}
+	return reference.Spec.Name, nil
+}
+
 func Delete(ctx core.Context, database *v1beta1.Database) error {
+	if err := remediatePostgresCredentialsSecretBeforeDatabaseDelete(ctx, database); err != nil {
+		return err
+	}
 	if database.Status.URI == nil {
 		return nil
 	}
@@ -137,6 +154,9 @@ func Delete(ctx core.Context, database *v1beta1.Database) error {
 	}, stack); err != nil {
 		return err
 	}
+	if err := reconcileEncodedPostgresCredentialsSecretBeforeDatabaseDelete(ctx, stack, database); err != nil {
+		return err
+	}
 
 	if err := handleDatabaseJob(ctx, stack, database, "drop-database", "db", "drop"); err != nil {
 		return err
@@ -146,6 +166,49 @@ func Delete(ctx core.Context, database *v1beta1.Database) error {
 	logger.Info("Database deleted.")
 
 	return nil
+}
+
+func remediatePostgresCredentialsSecretBeforeDatabaseDelete(ctx core.Context, database *v1beta1.Database) error {
+	if database.Spec.Stack == "" {
+		return nil
+	}
+	sourceSecretName, err := getPostgresCredentialsSecretReference(ctx, database)
+	if err != nil {
+		return err
+	}
+	sourceSecretNames := make([]string, 0, 2)
+	if sourceSecretName != "" {
+		sourceSecretNames = append(sourceSecretNames, sourceSecretName)
+	}
+	if database.Status.URI != nil {
+		sourceSecretNameFromStatus := database.Status.URI.Query().Get("secret")
+		if sourceSecretNameFromStatus != "" {
+			sourceSecretNames = append(sourceSecretNames, sourceSecretNameFromStatus)
+		}
+	}
+	stack := &v1beta1.Stack{}
+	stack.Name = database.Spec.Stack
+	sourceSecretNames = dedupePostgresCredentialsSecretNames(sourceSecretNames)
+	if len(sourceSecretNames) == 0 {
+		return deleteDefaultEncodedPostgresCredentialsSecretWithoutSource(ctx, stack, database, getEncodedPostgresCredentialsSecretName(database))
+	}
+	for _, sourceSecretName := range sourceSecretNames {
+		if err := removeSourceSecretControllerReferenceByName(ctx, stack, database, sourceSecretName); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func reconcileEncodedPostgresCredentialsSecretBeforeDatabaseDelete(ctx core.Context, stack *v1beta1.Stack, database *v1beta1.Database) error {
+	if database.Status.URI == nil {
+		return nil
+	}
+	sourceSecretName := database.Status.URI.Query().Get("secret")
+	if sourceSecretName == "" {
+		return nil
+	}
+	return reconcileEncodedPostgresCredentialsSecret(ctx, stack, database, sourceSecretName)
 }
 
 func handleDatabaseJob(ctx core.Context, stack *v1beta1.Stack, database *v1beta1.Database, name string, args ...string) error {

--- a/internal/resources/databases/secret.go
+++ b/internal/resources/databases/secret.go
@@ -1,11 +1,16 @@
 package databases
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	"github.com/formancehq/operator/v3/api/formance.com/v1beta1"
 	"github.com/formancehq/operator/v3/internal/core"
@@ -15,11 +20,48 @@ const (
 	postgresCredentialsUsernameKey = "username"
 	postgresCredentialsPasswordKey = "password"
 
-	encodedPostgresCredentialsSecretSuffix = "postgres-uri-credentials"
+	encodedPostgresCredentialsSecretSuffix              = "postgres-uri-credentials"
+	collisionSafeEncodedPostgresCredentialsSecretSuffix = "encoded-postgres-uri-credentials"
+	encodedPostgresCredentialsSecretAnnotation          = "formance.com/encoded-postgres-credentials-secret"
 )
 
-func getEncodedPostgresCredentialsSecretName(database *v1beta1.Database) string {
-	return fmt.Sprintf("%s-%s", database.Name, encodedPostgresCredentialsSecretSuffix)
+func getEncodedPostgresCredentialsSecretName(database *v1beta1.Database, sourceSecretName ...string) string {
+	name := fmt.Sprintf("%s-%s", database.Name, encodedPostgresCredentialsSecretSuffix)
+	if len(sourceSecretName) > 0 && sourceSecretName[0] == name {
+		return fmt.Sprintf("%s-%s-%s", database.Name, collisionSafeEncodedPostgresCredentialsSecretSuffix, hashPostgresCredentialsSecretName(sourceSecretName[0]))
+	}
+	return name
+}
+
+func hashPostgresCredentialsSecretName(secretName string) string {
+	hash := sha256.Sum256([]byte(secretName))
+	return hex.EncodeToString(hash[:])[:8]
+}
+
+func getEncodedPostgresCredentialsSecretCandidateNames(database *v1beta1.Database, sourceSecretName ...string) []string {
+	defaultName := fmt.Sprintf("%s-%s", database.Name, encodedPostgresCredentialsSecretSuffix)
+	names := []string{
+		defaultName,
+		fmt.Sprintf("%s-%s", database.Name, collisionSafeEncodedPostgresCredentialsSecretSuffix),
+		getEncodedPostgresCredentialsSecretName(database, defaultName),
+	}
+	if len(sourceSecretName) > 0 && sourceSecretName[0] != "" {
+		names = append(names, getEncodedPostgresCredentialsSecretName(database, sourceSecretName[0]))
+	}
+	return dedupePostgresCredentialsSecretNames(names)
+}
+
+func dedupePostgresCredentialsSecretNames(names []string) []string {
+	ret := make([]string, 0, len(names))
+	seen := make(map[string]struct{}, len(names))
+	for _, name := range names {
+		if _, ok := seen[name]; ok {
+			continue
+		}
+		seen[name] = struct{}{}
+		ret = append(ret, name)
+	}
+	return ret
 }
 
 func reconcileEncodedPostgresCredentialsSecret(ctx core.Context, stack *v1beta1.Stack, database *v1beta1.Database, secretName string) error {
@@ -29,6 +71,9 @@ func reconcileEncodedPostgresCredentialsSecret(ctx core.Context, stack *v1beta1.
 		Name:      secretName,
 	}, sourceSecret); err != nil {
 		return errors.Wrap(err, "getting postgres credentials secret")
+	}
+	if err := removeSourceSecretControllerReference(ctx, database, sourceSecret); err != nil {
+		return err
 	}
 
 	username, ok := sourceSecret.Data[postgresCredentialsUsernameKey]
@@ -40,24 +85,142 @@ func reconcileEncodedPostgresCredentialsSecret(ctx core.Context, stack *v1beta1.
 		return fmt.Errorf("postgres credentials secret %s/%s is missing %q", stack.Name, secretName, postgresCredentialsPasswordKey)
 	}
 
+	encodedSecretName := getEncodedPostgresCredentialsSecretName(database, secretName)
+	if err := ensureEncodedPostgresCredentialsSecretCanBeWritten(ctx, stack, database, encodedSecretName); err != nil {
+		return err
+	}
 	_, _, err := core.CreateOrUpdate[*corev1.Secret](ctx, types.NamespacedName{
 		Namespace: stack.Name,
-		Name:      getEncodedPostgresCredentialsSecretName(database),
+		Name:      encodedSecretName,
 	}, func(secret *corev1.Secret) error {
 		secret.Type = corev1.SecretTypeOpaque
+		if secret.Annotations == nil {
+			secret.Annotations = map[string]string{}
+		}
+		secret.Annotations[encodedPostgresCredentialsSecretAnnotation] = "true"
 		secret.Data = map[string][]byte{
 			postgresCredentialsUsernameKey: []byte(escapePostgresCredentialForURI(string(username))),
 			postgresCredentialsPasswordKey: []byte(escapePostgresCredentialForURI(string(password))),
 		}
 		return nil
 	}, core.WithController[*corev1.Secret](ctx.GetScheme(), database))
-	return errors.Wrap(err, "reconciling encoded postgres credentials secret")
+	if err != nil {
+		return errors.Wrap(err, "reconciling encoded postgres credentials secret")
+	}
+
+	return deleteStaleEncodedPostgresCredentialsSecrets(ctx, stack, database, secretName, encodedSecretName)
 }
 
-func deleteEncodedPostgresCredentialsSecret(ctx core.Context, stack *v1beta1.Stack, database *v1beta1.Database) error {
-	err := core.DeleteIfExists[*corev1.Secret](ctx, types.NamespacedName{
+func ensureEncodedPostgresCredentialsSecretCanBeWritten(ctx core.Context, stack *v1beta1.Stack, database *v1beta1.Database, encodedSecretName string) error {
+	secret := &corev1.Secret{}
+	if err := ctx.GetClient().Get(ctx, types.NamespacedName{
 		Namespace: stack.Name,
-		Name:      getEncodedPostgresCredentialsSecretName(database),
-	})
-	return errors.Wrap(err, "deleting encoded postgres credentials secret")
+		Name:      encodedSecretName,
+	}, secret); err != nil {
+		return client.IgnoreNotFound(err)
+	}
+	if metav1.IsControlledBy(secret, database) {
+		return nil
+	}
+	return fmt.Errorf("encoded postgres credentials secret %s/%s already exists and is not controlled by database %s", stack.Name, encodedSecretName, database.Name)
+}
+
+func removeSourceSecretControllerReference(ctx core.Context, database *v1beta1.Database, sourceSecret *corev1.Secret) error {
+	if !metav1.IsControlledBy(sourceSecret, database) {
+		return nil
+	}
+	patch := client.MergeFrom(sourceSecret.DeepCopy())
+	if err := controllerutil.RemoveControllerReference(database, sourceSecret, ctx.GetScheme()); err != nil {
+		return errors.Wrap(err, "removing stale database controller reference from postgres credentials secret")
+	}
+	if err := ctx.GetClient().Patch(ctx, sourceSecret, patch); err != nil {
+		return errors.Wrap(err, "patching postgres credentials secret owner references")
+	}
+	return nil
+}
+
+func deleteEncodedPostgresCredentialsSecret(ctx core.Context, stack *v1beta1.Stack, database *v1beta1.Database, sourceSecretName string) error {
+	for _, name := range getEncodedPostgresCredentialsSecretCandidateNames(database, sourceSecretName) {
+		if name == sourceSecretName {
+			if err := removeSourceSecretControllerReferenceByName(ctx, stack, database, name); err != nil {
+				return errors.Wrap(err, "removing stale postgres credentials secret controller reference")
+			}
+			continue
+		}
+		if sourceSecretName == "" && name == getEncodedPostgresCredentialsSecretName(database) {
+			if err := deleteOrRemediateDefaultPostgresCredentialsSecretWithoutSource(ctx, stack, database, name); err != nil {
+				return err
+			}
+			continue
+		}
+		if err := deleteEncodedPostgresCredentialsSecretIfControlled(ctx, stack, database, name); err != nil {
+			return errors.Wrap(err, "deleting encoded postgres credentials secret")
+		}
+	}
+	return nil
+}
+
+func removeSourceSecretControllerReferenceByName(ctx core.Context, stack *v1beta1.Stack, database *v1beta1.Database, name string) error {
+	secret := &corev1.Secret{}
+	if err := ctx.GetClient().Get(ctx, types.NamespacedName{
+		Namespace: stack.Name,
+		Name:      name,
+	}, secret); err != nil {
+		return client.IgnoreNotFound(err)
+	}
+	return removeSourceSecretControllerReference(ctx, database, secret)
+}
+
+func deleteOrRemediateDefaultPostgresCredentialsSecretWithoutSource(ctx core.Context, stack *v1beta1.Stack, database *v1beta1.Database, name string) error {
+	return handleDefaultPostgresCredentialsSecretWithoutSource(ctx, stack, database, name, true)
+}
+
+func deleteDefaultEncodedPostgresCredentialsSecretWithoutSource(ctx core.Context, stack *v1beta1.Stack, database *v1beta1.Database, name string) error {
+	return handleDefaultPostgresCredentialsSecretWithoutSource(ctx, stack, database, name, false)
+}
+
+func handleDefaultPostgresCredentialsSecretWithoutSource(ctx core.Context, stack *v1beta1.Stack, database *v1beta1.Database, name string, remediateUnannotated bool) error {
+	secret := &corev1.Secret{}
+	if err := ctx.GetClient().Get(ctx, types.NamespacedName{
+		Namespace: stack.Name,
+		Name:      name,
+	}, secret); err != nil {
+		return client.IgnoreNotFound(err)
+	}
+	if secret.Annotations[encodedPostgresCredentialsSecretAnnotation] == "true" {
+		if !metav1.IsControlledBy(secret, database) {
+			return nil
+		}
+		return ctx.GetClient().Delete(ctx, secret)
+	}
+	if !remediateUnannotated {
+		return nil
+	}
+	return removeSourceSecretControllerReference(ctx, database, secret)
+}
+
+func deleteStaleEncodedPostgresCredentialsSecrets(ctx core.Context, stack *v1beta1.Stack, database *v1beta1.Database, sourceSecretName, desiredSecretName string) error {
+	for _, name := range getEncodedPostgresCredentialsSecretCandidateNames(database, sourceSecretName) {
+		if name == sourceSecretName || name == desiredSecretName {
+			continue
+		}
+		if err := deleteEncodedPostgresCredentialsSecretIfControlled(ctx, stack, database, name); err != nil {
+			return errors.Wrap(err, "deleting stale encoded postgres credentials secret")
+		}
+	}
+	return nil
+}
+
+func deleteEncodedPostgresCredentialsSecretIfControlled(ctx core.Context, stack *v1beta1.Stack, database *v1beta1.Database, name string) error {
+	secret := &corev1.Secret{}
+	if err := ctx.GetClient().Get(ctx, types.NamespacedName{
+		Namespace: stack.Name,
+		Name:      name,
+	}, secret); err != nil {
+		return client.IgnoreNotFound(err)
+	}
+	if !metav1.IsControlledBy(secret, database) {
+		return nil
+	}
+	return ctx.GetClient().Delete(ctx, secret)
 }

--- a/internal/resources/databases/secret_test.go
+++ b/internal/resources/databases/secret_test.go
@@ -1,12 +1,19 @@
 package databases
 
 import (
+	"context"
+	"errors"
+	"net/url"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	"github.com/formancehq/operator/v3/api/formance.com/v1beta1"
 )
@@ -48,6 +55,869 @@ func TestReconcileEncodedPostgresCredentialsSecret(t *testing.T) {
 	}, encodedSecret))
 	require.Equal(t, []byte("user%5Ename"), encodedSecret.Data[postgresCredentialsUsernameKey])
 	require.Equal(t, []byte("p%5Ess%20word"), encodedSecret.Data[postgresCredentialsPasswordKey])
+	require.Equal(t, "true", encodedSecret.Annotations[encodedPostgresCredentialsSecretAnnotation])
 	require.Len(t, encodedSecret.OwnerReferences, 1)
 	require.Equal(t, database.Name, encodedSecret.OwnerReferences[0].Name)
+}
+
+func TestReconcileEncodedPostgresCredentialsSecretAvoidsSourceSecretNameCollision(t *testing.T) {
+	t.Parallel()
+
+	stack := &v1beta1.Stack{
+		ObjectMeta: metav1.ObjectMeta{Name: "stack"},
+	}
+	database := &v1beta1.Database{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: v1beta1.GroupVersion.String(),
+			Kind:       "Database",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "stack-ledger",
+			UID:  types.UID("database-uid"),
+		},
+	}
+	sourceSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: stack.Name,
+			Name:      "stack-ledger-postgres-uri-credentials",
+		},
+		Data: map[string][]byte{
+			postgresCredentialsUsernameKey: []byte("user^name"),
+			postgresCredentialsPasswordKey: []byte("p^ss word"),
+		},
+	}
+	ctx := newTestContext(t, sourceSecret)
+
+	require.NoError(t, reconcileEncodedPostgresCredentialsSecret(ctx, stack, database, sourceSecret.Name))
+
+	preservedSourceSecret := &corev1.Secret{}
+	require.NoError(t, ctx.GetClient().Get(ctx, types.NamespacedName{
+		Namespace: stack.Name,
+		Name:      sourceSecret.Name,
+	}, preservedSourceSecret))
+	require.Equal(t, []byte("user^name"), preservedSourceSecret.Data[postgresCredentialsUsernameKey])
+	require.Equal(t, []byte("p^ss word"), preservedSourceSecret.Data[postgresCredentialsPasswordKey])
+
+	encodedSecret := &corev1.Secret{}
+	require.NoError(t, ctx.GetClient().Get(ctx, types.NamespacedName{
+		Namespace: stack.Name,
+		Name:      getEncodedPostgresCredentialsSecretName(database, sourceSecret.Name),
+	}, encodedSecret))
+	require.NotEqual(t, sourceSecret.Name, encodedSecret.Name)
+	require.Equal(t, []byte("user%5Ename"), encodedSecret.Data[postgresCredentialsUsernameKey])
+	require.Equal(t, []byte("p%5Ess%20word"), encodedSecret.Data[postgresCredentialsPasswordKey])
+
+	require.NoError(t, reconcileEncodedPostgresCredentialsSecret(ctx, stack, database, sourceSecret.Name))
+
+	require.NoError(t, ctx.GetClient().Get(ctx, types.NamespacedName{
+		Namespace: stack.Name,
+		Name:      sourceSecret.Name,
+	}, preservedSourceSecret))
+	require.Equal(t, []byte("user^name"), preservedSourceSecret.Data[postgresCredentialsUsernameKey])
+	require.Equal(t, []byte("p^ss word"), preservedSourceSecret.Data[postgresCredentialsPasswordKey])
+
+	require.NoError(t, ctx.GetClient().Get(ctx, types.NamespacedName{
+		Namespace: stack.Name,
+		Name:      encodedSecret.Name,
+	}, encodedSecret))
+	require.Equal(t, []byte("user%5Ename"), encodedSecret.Data[postgresCredentialsUsernameKey])
+	require.Equal(t, []byte("p%5Ess%20word"), encodedSecret.Data[postgresCredentialsPasswordKey])
+}
+
+func TestReconcileEncodedPostgresCredentialsSecretKeepsUncontrolledLegacyFallbackSecret(t *testing.T) {
+	t.Parallel()
+
+	stack := &v1beta1.Stack{
+		ObjectMeta: metav1.ObjectMeta{Name: "stack"},
+	}
+	database := &v1beta1.Database{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: v1beta1.GroupVersion.String(),
+			Kind:       "Database",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "stack-ledger",
+			UID:  types.UID("database-uid"),
+		},
+	}
+	sourceSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: stack.Name,
+			Name:      "stack-ledger-postgres-uri-credentials",
+		},
+		Data: map[string][]byte{
+			postgresCredentialsUsernameKey: []byte("user^name"),
+			postgresCredentialsPasswordKey: []byte("p^ss word"),
+		},
+	}
+	legacyFallbackSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: stack.Name,
+			Name:      "stack-ledger-encoded-postgres-uri-credentials",
+		},
+		Data: map[string][]byte{
+			postgresCredentialsUsernameKey: []byte("legacy-user"),
+			postgresCredentialsPasswordKey: []byte("legacy-password"),
+		},
+	}
+	ctx := newTestContext(t, sourceSecret, legacyFallbackSecret)
+
+	require.NoError(t, reconcileEncodedPostgresCredentialsSecret(ctx, stack, database, sourceSecret.Name))
+
+	preservedLegacySecret := &corev1.Secret{}
+	require.NoError(t, ctx.GetClient().Get(ctx, types.NamespacedName{
+		Namespace: stack.Name,
+		Name:      legacyFallbackSecret.Name,
+	}, preservedLegacySecret))
+	require.Empty(t, preservedLegacySecret.OwnerReferences)
+	require.Equal(t, []byte("legacy-user"), preservedLegacySecret.Data[postgresCredentialsUsernameKey])
+	require.Equal(t, []byte("legacy-password"), preservedLegacySecret.Data[postgresCredentialsPasswordKey])
+
+	encodedSecret := &corev1.Secret{}
+	require.NoError(t, ctx.GetClient().Get(ctx, types.NamespacedName{
+		Namespace: stack.Name,
+		Name:      getEncodedPostgresCredentialsSecretName(database, sourceSecret.Name),
+	}, encodedSecret))
+	require.NotEqual(t, sourceSecret.Name, encodedSecret.Name)
+	require.NotEqual(t, legacyFallbackSecret.Name, encodedSecret.Name)
+	require.Equal(t, []byte("user%5Ename"), encodedSecret.Data[postgresCredentialsUsernameKey])
+	require.Equal(t, []byte("p%5Ess%20word"), encodedSecret.Data[postgresCredentialsPasswordKey])
+}
+
+func TestReconcileEncodedPostgresCredentialsSecretRejectsUncontrolledEncodedSecretTarget(t *testing.T) {
+	t.Parallel()
+
+	stack := &v1beta1.Stack{
+		ObjectMeta: metav1.ObjectMeta{Name: "stack"},
+	}
+	database := &v1beta1.Database{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: v1beta1.GroupVersion.String(),
+			Kind:       "Database",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "stack-ledger",
+			UID:  types.UID("database-uid"),
+		},
+	}
+	sourceSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: stack.Name,
+			Name:      "stack-ledger-postgres-uri-credentials",
+		},
+		Data: map[string][]byte{
+			postgresCredentialsUsernameKey: []byte("user^name"),
+			postgresCredentialsPasswordKey: []byte("p^ss word"),
+		},
+	}
+	existingTargetSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: stack.Name,
+			Name:      getEncodedPostgresCredentialsSecretName(database, sourceSecret.Name),
+		},
+		Data: map[string][]byte{
+			postgresCredentialsUsernameKey: []byte("existing-user"),
+			postgresCredentialsPasswordKey: []byte("existing-password"),
+		},
+	}
+	ctx := newTestContext(t, sourceSecret, existingTargetSecret)
+
+	err := reconcileEncodedPostgresCredentialsSecret(ctx, stack, database, sourceSecret.Name)
+	require.ErrorContains(t, err, "already exists and is not controlled")
+
+	preservedTargetSecret := &corev1.Secret{}
+	require.NoError(t, ctx.GetClient().Get(ctx, types.NamespacedName{
+		Namespace: stack.Name,
+		Name:      existingTargetSecret.Name,
+	}, preservedTargetSecret))
+	require.Empty(t, preservedTargetSecret.OwnerReferences)
+	require.Equal(t, []byte("existing-user"), preservedTargetSecret.Data[postgresCredentialsUsernameKey])
+	require.Equal(t, []byte("existing-password"), preservedTargetSecret.Data[postgresCredentialsPasswordKey])
+}
+
+func TestReconcileEncodedPostgresCredentialsSecretRemovesStaleSourceSecretControllerReference(t *testing.T) {
+	t.Parallel()
+
+	stack := &v1beta1.Stack{
+		ObjectMeta: metav1.ObjectMeta{Name: "stack"},
+	}
+	database := &v1beta1.Database{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: v1beta1.GroupVersion.String(),
+			Kind:       "Database",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "stack-ledger",
+			UID:  types.UID("database-uid"),
+		},
+	}
+	sourceSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: stack.Name,
+			Name:      "stack-ledger-postgres-uri-credentials",
+		},
+		Data: map[string][]byte{
+			postgresCredentialsUsernameKey: []byte("user^name"),
+			postgresCredentialsPasswordKey: []byte("p^ss word"),
+		},
+	}
+	ctx := newTestContext(t)
+	require.NoError(t, controllerutil.SetControllerReference(database, sourceSecret, ctx.GetScheme()))
+	require.NoError(t, ctx.GetClient().Create(ctx, sourceSecret))
+
+	require.NoError(t, reconcileEncodedPostgresCredentialsSecret(ctx, stack, database, sourceSecret.Name))
+
+	preservedSourceSecret := &corev1.Secret{}
+	require.NoError(t, ctx.GetClient().Get(ctx, types.NamespacedName{
+		Namespace: stack.Name,
+		Name:      sourceSecret.Name,
+	}, preservedSourceSecret))
+	require.Empty(t, preservedSourceSecret.OwnerReferences)
+	require.Equal(t, []byte("user^name"), preservedSourceSecret.Data[postgresCredentialsUsernameKey])
+	require.Equal(t, []byte("p^ss word"), preservedSourceSecret.Data[postgresCredentialsPasswordKey])
+
+	encodedSecret := &corev1.Secret{}
+	require.NoError(t, ctx.GetClient().Get(ctx, types.NamespacedName{
+		Namespace: stack.Name,
+		Name:      getEncodedPostgresCredentialsSecretName(database, sourceSecret.Name),
+	}, encodedSecret))
+	require.Equal(t, []byte("user%5Ename"), encodedSecret.Data[postgresCredentialsUsernameKey])
+	require.Equal(t, []byte("p%5Ess%20word"), encodedSecret.Data[postgresCredentialsPasswordKey])
+	require.Len(t, encodedSecret.OwnerReferences, 1)
+	require.Equal(t, database.Name, encodedSecret.OwnerReferences[0].Name)
+}
+
+func TestReconcileEncodedPostgresCredentialsSecretDeletesStaleControlledEncodedSecret(t *testing.T) {
+	t.Parallel()
+
+	stack := &v1beta1.Stack{
+		ObjectMeta: metav1.ObjectMeta{Name: "stack"},
+	}
+	database := &v1beta1.Database{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: v1beta1.GroupVersion.String(),
+			Kind:       "Database",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "stack-ledger",
+			UID:  types.UID("database-uid"),
+		},
+	}
+	sourceSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: stack.Name,
+			Name:      "postgres",
+		},
+		Data: map[string][]byte{
+			postgresCredentialsUsernameKey: []byte("user^name"),
+			postgresCredentialsPasswordKey: []byte("p^ss word"),
+		},
+	}
+	staleEncodedSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: stack.Name,
+			Name:      "stack-ledger-encoded-postgres-uri-credentials",
+		},
+		Data: map[string][]byte{
+			postgresCredentialsUsernameKey: []byte("old-user"),
+			postgresCredentialsPasswordKey: []byte("old-password"),
+		},
+	}
+	staleHashedEncodedSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: stack.Name,
+			Name:      getEncodedPostgresCredentialsSecretName(database, getEncodedPostgresCredentialsSecretName(database)),
+		},
+		Data: map[string][]byte{
+			postgresCredentialsUsernameKey: []byte("old-hashed-user"),
+			postgresCredentialsPasswordKey: []byte("old-hashed-password"),
+		},
+	}
+	ctx := newTestContext(t)
+	require.NoError(t, controllerutil.SetControllerReference(database, staleEncodedSecret, ctx.GetScheme()))
+	require.NoError(t, controllerutil.SetControllerReference(database, staleHashedEncodedSecret, ctx.GetScheme()))
+	require.NoError(t, ctx.GetClient().Create(ctx, sourceSecret))
+	require.NoError(t, ctx.GetClient().Create(ctx, staleEncodedSecret))
+	require.NoError(t, ctx.GetClient().Create(ctx, staleHashedEncodedSecret))
+
+	require.NoError(t, reconcileEncodedPostgresCredentialsSecret(ctx, stack, database, sourceSecret.Name))
+
+	currentEncodedSecret := &corev1.Secret{}
+	require.NoError(t, ctx.GetClient().Get(ctx, types.NamespacedName{
+		Namespace: stack.Name,
+		Name:      getEncodedPostgresCredentialsSecretName(database, sourceSecret.Name),
+	}, currentEncodedSecret))
+	require.Equal(t, []byte("user%5Ename"), currentEncodedSecret.Data[postgresCredentialsUsernameKey])
+	require.Equal(t, []byte("p%5Ess%20word"), currentEncodedSecret.Data[postgresCredentialsPasswordKey])
+
+	err := ctx.GetClient().Get(ctx, types.NamespacedName{
+		Namespace: stack.Name,
+		Name:      staleEncodedSecret.Name,
+	}, &corev1.Secret{})
+	require.True(t, apierrors.IsNotFound(err))
+
+	err = ctx.GetClient().Get(ctx, types.NamespacedName{
+		Namespace: stack.Name,
+		Name:      staleHashedEncodedSecret.Name,
+	}, &corev1.Secret{})
+	require.True(t, apierrors.IsNotFound(err))
+}
+
+func TestDeleteEncodedPostgresCredentialsSecretKeepsUncontrolledSourceSecret(t *testing.T) {
+	t.Parallel()
+
+	stack := &v1beta1.Stack{
+		ObjectMeta: metav1.ObjectMeta{Name: "stack"},
+	}
+	database := &v1beta1.Database{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: v1beta1.GroupVersion.String(),
+			Kind:       "Database",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "stack-ledger",
+			UID:  types.UID("database-uid"),
+		},
+	}
+	sourceSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: stack.Name,
+			Name:      "stack-ledger-postgres-uri-credentials",
+		},
+		Data: map[string][]byte{
+			postgresCredentialsUsernameKey: []byte("user^name"),
+			postgresCredentialsPasswordKey: []byte("p^ss word"),
+		},
+	}
+	ctx := newTestContext(t, sourceSecret)
+
+	require.NoError(t, deleteEncodedPostgresCredentialsSecret(ctx, stack, database, sourceSecret.Name))
+
+	preservedSourceSecret := &corev1.Secret{}
+	require.NoError(t, ctx.GetClient().Get(ctx, types.NamespacedName{
+		Namespace: stack.Name,
+		Name:      sourceSecret.Name,
+	}, preservedSourceSecret))
+	require.Equal(t, []byte("user^name"), preservedSourceSecret.Data[postgresCredentialsUsernameKey])
+	require.Equal(t, []byte("p^ss word"), preservedSourceSecret.Data[postgresCredentialsPasswordKey])
+}
+
+func TestDeleteEncodedPostgresCredentialsSecretRemovesStaleSourceSecretControllerReference(t *testing.T) {
+	t.Parallel()
+
+	stack := &v1beta1.Stack{
+		ObjectMeta: metav1.ObjectMeta{Name: "stack"},
+	}
+	database := &v1beta1.Database{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: v1beta1.GroupVersion.String(),
+			Kind:       "Database",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "stack-ledger",
+			UID:  types.UID("database-uid"),
+		},
+	}
+	sourceSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: stack.Name,
+			Name:      "stack-ledger-postgres-uri-credentials",
+		},
+		Data: map[string][]byte{
+			postgresCredentialsUsernameKey: []byte("user^name"),
+			postgresCredentialsPasswordKey: []byte("p^ss word"),
+		},
+	}
+	ctx := newTestContext(t)
+	require.NoError(t, controllerutil.SetControllerReference(database, sourceSecret, ctx.GetScheme()))
+	require.NoError(t, ctx.GetClient().Create(ctx, sourceSecret))
+
+	require.NoError(t, deleteEncodedPostgresCredentialsSecret(ctx, stack, database, sourceSecret.Name))
+
+	preservedSourceSecret := &corev1.Secret{}
+	require.NoError(t, ctx.GetClient().Get(ctx, types.NamespacedName{
+		Namespace: stack.Name,
+		Name:      sourceSecret.Name,
+	}, preservedSourceSecret))
+	require.Empty(t, preservedSourceSecret.OwnerReferences)
+	require.Equal(t, []byte("user^name"), preservedSourceSecret.Data[postgresCredentialsUsernameKey])
+	require.Equal(t, []byte("p^ss word"), preservedSourceSecret.Data[postgresCredentialsPasswordKey])
+}
+
+func TestDeleteEncodedPostgresCredentialsSecretPreservesDefaultCandidateWhenSourceReferenceIsMissing(t *testing.T) {
+	t.Parallel()
+
+	stack := &v1beta1.Stack{
+		ObjectMeta: metav1.ObjectMeta{Name: "stack"},
+	}
+	database := &v1beta1.Database{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: v1beta1.GroupVersion.String(),
+			Kind:       "Database",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "stack-ledger",
+			UID:  types.UID("database-uid"),
+		},
+	}
+	possibleSourceSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: stack.Name,
+			Name:      "stack-ledger-postgres-uri-credentials",
+		},
+		Data: map[string][]byte{
+			postgresCredentialsUsernameKey: []byte("user^name"),
+			postgresCredentialsPasswordKey: []byte("p^ss word"),
+		},
+	}
+	ctx := newTestContext(t)
+	require.NoError(t, controllerutil.SetControllerReference(database, possibleSourceSecret, ctx.GetScheme()))
+	require.NoError(t, ctx.GetClient().Create(ctx, possibleSourceSecret))
+
+	require.NoError(t, deleteEncodedPostgresCredentialsSecret(ctx, stack, database, ""))
+
+	preservedSourceSecret := &corev1.Secret{}
+	require.NoError(t, ctx.GetClient().Get(ctx, types.NamespacedName{
+		Namespace: stack.Name,
+		Name:      possibleSourceSecret.Name,
+	}, preservedSourceSecret))
+	require.Empty(t, preservedSourceSecret.OwnerReferences)
+	require.Equal(t, []byte("user^name"), preservedSourceSecret.Data[postgresCredentialsUsernameKey])
+	require.Equal(t, []byte("p^ss word"), preservedSourceSecret.Data[postgresCredentialsPasswordKey])
+}
+
+func TestDeleteRemovesAnnotatedEncodedSecretWhenSourceReferenceAndStatusURIAreMissing(t *testing.T) {
+	t.Parallel()
+
+	database := &v1beta1.Database{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: v1beta1.GroupVersion.String(),
+			Kind:       "Database",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "stack-ledger",
+			UID:  types.UID("database-uid"),
+		},
+		Spec: v1beta1.DatabaseSpec{
+			StackDependency: v1beta1.StackDependency{
+				Stack: "stack",
+			},
+		},
+	}
+	encodedSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: database.Spec.Stack,
+			Name:      getEncodedPostgresCredentialsSecretName(database),
+			Annotations: map[string]string{
+				encodedPostgresCredentialsSecretAnnotation: "true",
+			},
+		},
+		Data: map[string][]byte{
+			postgresCredentialsUsernameKey: []byte("user%5Ename"),
+			postgresCredentialsPasswordKey: []byte("p%5Ess%20word"),
+		},
+	}
+	ctx := newTestContext(t)
+	require.NoError(t, controllerutil.SetControllerReference(database, encodedSecret, ctx.GetScheme()))
+	require.NoError(t, ctx.GetClient().Create(ctx, encodedSecret))
+
+	require.NoError(t, Delete(ctx, database))
+
+	err := ctx.GetClient().Get(ctx, types.NamespacedName{
+		Namespace: database.Spec.Stack,
+		Name:      encodedSecret.Name,
+	}, &corev1.Secret{})
+	require.True(t, apierrors.IsNotFound(err))
+}
+
+func TestDeleteKeepsUnannotatedDefaultSecretOwnerReferenceWhenSourceReferenceAndStatusURIAreMissing(t *testing.T) {
+	t.Parallel()
+
+	database := &v1beta1.Database{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: v1beta1.GroupVersion.String(),
+			Kind:       "Database",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "stack-ledger",
+			UID:  types.UID("database-uid"),
+		},
+		Spec: v1beta1.DatabaseSpec{
+			StackDependency: v1beta1.StackDependency{
+				Stack: "stack",
+			},
+		},
+	}
+	defaultSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: database.Spec.Stack,
+			Name:      getEncodedPostgresCredentialsSecretName(database),
+		},
+		Data: map[string][]byte{
+			postgresCredentialsUsernameKey: []byte("user"),
+			postgresCredentialsPasswordKey: []byte("password"),
+		},
+	}
+	ctx := newTestContext(t)
+	require.NoError(t, controllerutil.SetControllerReference(database, defaultSecret, ctx.GetScheme()))
+	require.NoError(t, ctx.GetClient().Create(ctx, defaultSecret))
+
+	require.NoError(t, Delete(ctx, database))
+
+	preservedDefaultSecret := &corev1.Secret{}
+	require.NoError(t, ctx.GetClient().Get(ctx, types.NamespacedName{
+		Namespace: database.Spec.Stack,
+		Name:      defaultSecret.Name,
+	}, preservedDefaultSecret))
+	require.True(t, metav1.IsControlledBy(preservedDefaultSecret, database))
+}
+
+func TestDeleteEncodedPostgresCredentialsSecretDeletesControlledEncodedSecretWithKnownSource(t *testing.T) {
+	t.Parallel()
+
+	stack := &v1beta1.Stack{
+		ObjectMeta: metav1.ObjectMeta{Name: "stack"},
+	}
+	database := &v1beta1.Database{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: v1beta1.GroupVersion.String(),
+			Kind:       "Database",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "stack-ledger",
+			UID:  types.UID("database-uid"),
+		},
+	}
+	encodedSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: stack.Name,
+			Name:      "stack-ledger-postgres-uri-credentials",
+		},
+		Data: map[string][]byte{
+			postgresCredentialsUsernameKey: []byte("user%5Ename"),
+			postgresCredentialsPasswordKey: []byte("p%5Ess%20word"),
+		},
+	}
+	ctx := newTestContext(t)
+	require.NoError(t, controllerutil.SetControllerReference(database, encodedSecret, ctx.GetScheme()))
+	require.NoError(t, ctx.GetClient().Create(ctx, encodedSecret))
+
+	require.NoError(t, deleteEncodedPostgresCredentialsSecret(ctx, stack, database, "postgres"))
+
+	err := ctx.GetClient().Get(ctx, types.NamespacedName{
+		Namespace: stack.Name,
+		Name:      encodedSecret.Name,
+	}, &corev1.Secret{})
+	require.True(t, apierrors.IsNotFound(err))
+}
+
+func TestReconcileKeepsPostgresResourceReferenceWhenEncodedSecretDeleteFails(t *testing.T) {
+	t.Parallel()
+
+	oldPostgresURI, err := v1beta1.ParseURL("postgresql://postgres:5432?secret=postgres")
+	require.NoError(t, err)
+	stack := &v1beta1.Stack{
+		ObjectMeta: metav1.ObjectMeta{Name: "stack"},
+	}
+	database := &v1beta1.Database{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: v1beta1.GroupVersion.String(),
+			Kind:       "Database",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "stack-ledger",
+			UID:  types.UID("database-uid"),
+		},
+		Spec: v1beta1.DatabaseSpec{
+			StackDependency: v1beta1.StackDependency{
+				Stack: stack.Name,
+			},
+			Service: "ledger",
+		},
+		Status: v1beta1.DatabaseStatus{
+			Status: v1beta1.Status{
+				Ready: true,
+			},
+			URI:      oldPostgresURI,
+			Database: "ledger",
+		},
+	}
+	postgresURISetting := &v1beta1.Settings{
+		ObjectMeta: metav1.ObjectMeta{Name: "postgres-uri"},
+		Spec: v1beta1.SettingsSpec{
+			Stacks: []string{stack.Name},
+			Key:    "postgres.ledger.uri",
+			Value:  "postgresql://postgres:5432",
+		},
+	}
+	resourceReference := &v1beta1.ResourceReference{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "stack-ledger-postgres",
+		},
+		Spec: v1beta1.ResourceReferenceSpec{
+			Name: "postgres",
+		},
+	}
+	encodedSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: stack.Name,
+			Name:      getEncodedPostgresCredentialsSecretName(database),
+		},
+		Data: map[string][]byte{
+			postgresCredentialsUsernameKey: []byte("user%5Ename"),
+			postgresCredentialsPasswordKey: []byte("p%5Ess%20word"),
+		},
+	}
+	ctx := newTestContextWithInterceptor(t, interceptor.Funcs{
+		Delete: func(ctx context.Context, interceptedClient client.WithWatch, obj client.Object, opts ...client.DeleteOption) error {
+			if obj.GetNamespace() == encodedSecret.Namespace && obj.GetName() == encodedSecret.Name {
+				return errors.New("delete encoded postgres credentials secret failed")
+			}
+			return interceptedClient.Delete(ctx, obj, opts...)
+		},
+	}, stack, postgresURISetting, resourceReference)
+	require.NoError(t, controllerutil.SetControllerReference(database, encodedSecret, ctx.GetScheme()))
+	require.NoError(t, ctx.GetClient().Create(ctx, encodedSecret))
+
+	err = Reconcile(ctx, stack, database)
+	require.ErrorContains(t, err, "delete encoded postgres credentials secret failed")
+
+	preservedResourceReference := &v1beta1.ResourceReference{}
+	require.NoError(t, ctx.GetClient().Get(ctx, types.NamespacedName{
+		Name: resourceReference.Name,
+	}, preservedResourceReference))
+	require.Equal(t, "postgres", preservedResourceReference.Spec.Name)
+
+	preservedEncodedSecret := &corev1.Secret{}
+	require.NoError(t, ctx.GetClient().Get(ctx, types.NamespacedName{
+		Namespace: stack.Name,
+		Name:      encodedSecret.Name,
+	}, preservedEncodedSecret))
+}
+
+func TestReconcileEncodedPostgresCredentialsSecretBeforeDatabaseDeleteCreatesCollisionSafeSecret(t *testing.T) {
+	t.Parallel()
+
+	stack := &v1beta1.Stack{
+		ObjectMeta: metav1.ObjectMeta{Name: "stack"},
+	}
+	databaseURI, err := v1beta1.ParseURL("postgresql://postgres:5432?secret=stack-ledger-postgres-uri-credentials")
+	require.NoError(t, err)
+	database := &v1beta1.Database{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: v1beta1.GroupVersion.String(),
+			Kind:       "Database",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "stack-ledger",
+			UID:  types.UID("database-uid"),
+		},
+		Status: v1beta1.DatabaseStatus{
+			URI: databaseURI,
+		},
+	}
+	sourceSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: stack.Name,
+			Name:      "stack-ledger-postgres-uri-credentials",
+		},
+		Data: map[string][]byte{
+			postgresCredentialsUsernameKey: []byte("user^name"),
+			postgresCredentialsPasswordKey: []byte("p^ss word"),
+		},
+	}
+	ctx := newTestContext(t, sourceSecret)
+
+	require.NoError(t, reconcileEncodedPostgresCredentialsSecretBeforeDatabaseDelete(ctx, stack, database))
+
+	encodedSecret := &corev1.Secret{}
+	require.NoError(t, ctx.GetClient().Get(ctx, types.NamespacedName{
+		Namespace: stack.Name,
+		Name:      getEncodedPostgresCredentialsSecretName(database, sourceSecret.Name),
+	}, encodedSecret))
+	require.NotEqual(t, sourceSecret.Name, encodedSecret.Name)
+	require.Equal(t, "true", encodedSecret.Annotations[encodedPostgresCredentialsSecretAnnotation])
+	require.Equal(t, []byte("user%5Ename"), encodedSecret.Data[postgresCredentialsUsernameKey])
+	require.Equal(t, []byte("p%5Ess%20word"), encodedSecret.Data[postgresCredentialsPasswordKey])
+}
+
+func TestDeleteRemediatesStaleSourceSecretControllerReferenceBeforeClearDatabaseCheck(t *testing.T) {
+	t.Parallel()
+
+	postgresURI, err := url.Parse("postgresql://postgres:5432?secret=stack-ledger-postgres-uri-credentials")
+	require.NoError(t, err)
+	database := &v1beta1.Database{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: v1beta1.GroupVersion.String(),
+			Kind:       "Database",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "stack-ledger",
+			UID:  types.UID("database-uid"),
+		},
+		Spec: v1beta1.DatabaseSpec{
+			StackDependency: v1beta1.StackDependency{
+				Stack: "stack",
+			},
+		},
+		Status: v1beta1.DatabaseStatus{
+			URI: &v1beta1.URI{URL: postgresURI},
+		},
+	}
+	sourceSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: database.Spec.Stack,
+			Name:      "stack-ledger-postgres-uri-credentials",
+		},
+		Data: map[string][]byte{
+			postgresCredentialsUsernameKey: []byte("user^name"),
+			postgresCredentialsPasswordKey: []byte("p^ss word"),
+		},
+	}
+	ctx := newTestContext(t)
+	require.NoError(t, controllerutil.SetControllerReference(database, sourceSecret, ctx.GetScheme()))
+	require.NoError(t, ctx.GetClient().Create(ctx, sourceSecret))
+
+	require.NoError(t, Delete(ctx, database))
+
+	preservedSourceSecret := &corev1.Secret{}
+	require.NoError(t, ctx.GetClient().Get(ctx, types.NamespacedName{
+		Namespace: database.Spec.Stack,
+		Name:      sourceSecret.Name,
+	}, preservedSourceSecret))
+	require.Empty(t, preservedSourceSecret.OwnerReferences)
+	require.Equal(t, []byte("user^name"), preservedSourceSecret.Data[postgresCredentialsUsernameKey])
+	require.Equal(t, []byte("p^ss word"), preservedSourceSecret.Data[postgresCredentialsPasswordKey])
+}
+
+func TestRemediatePostgresCredentialsSecretBeforeDatabaseDeleteUsesResourceReference(t *testing.T) {
+	t.Parallel()
+
+	database := &v1beta1.Database{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: v1beta1.GroupVersion.String(),
+			Kind:       "Database",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "stack-ledger",
+			UID:  types.UID("database-uid"),
+		},
+		Spec: v1beta1.DatabaseSpec{
+			StackDependency: v1beta1.StackDependency{
+				Stack: "stack",
+			},
+		},
+	}
+	sourceSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: database.Spec.Stack,
+			Name:      "stack-ledger-postgres-uri-credentials",
+		},
+		Data: map[string][]byte{
+			postgresCredentialsUsernameKey: []byte("user^name"),
+			postgresCredentialsPasswordKey: []byte("p^ss word"),
+		},
+	}
+	resourceReference := &v1beta1.ResourceReference{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "stack-ledger-postgres",
+		},
+		Spec: v1beta1.ResourceReferenceSpec{
+			Name: sourceSecret.Name,
+		},
+	}
+	ctx := newTestContext(t)
+	require.NoError(t, controllerutil.SetControllerReference(database, sourceSecret, ctx.GetScheme()))
+	require.NoError(t, ctx.GetClient().Create(ctx, sourceSecret))
+	require.NoError(t, ctx.GetClient().Create(ctx, resourceReference))
+
+	require.NoError(t, remediatePostgresCredentialsSecretBeforeDatabaseDelete(ctx, database))
+
+	preservedSourceSecret := &corev1.Secret{}
+	require.NoError(t, ctx.GetClient().Get(ctx, types.NamespacedName{
+		Namespace: database.Spec.Stack,
+		Name:      sourceSecret.Name,
+	}, preservedSourceSecret))
+	require.Empty(t, preservedSourceSecret.OwnerReferences)
+	require.Equal(t, []byte("user^name"), preservedSourceSecret.Data[postgresCredentialsUsernameKey])
+	require.Equal(t, []byte("p^ss word"), preservedSourceSecret.Data[postgresCredentialsPasswordKey])
+}
+
+func TestRemediatePostgresCredentialsSecretBeforeDatabaseDeleteUsesResourceReferenceAndStatusURI(t *testing.T) {
+	t.Parallel()
+
+	postgresURI, err := url.Parse("postgresql://postgres:5432?secret=stack-ledger-postgres-uri-credentials")
+	require.NoError(t, err)
+	database := &v1beta1.Database{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: v1beta1.GroupVersion.String(),
+			Kind:       "Database",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "stack-ledger",
+			UID:  types.UID("database-uid"),
+		},
+		Spec: v1beta1.DatabaseSpec{
+			StackDependency: v1beta1.StackDependency{
+				Stack: "stack",
+			},
+		},
+		Status: v1beta1.DatabaseStatus{
+			URI: &v1beta1.URI{URL: postgresURI},
+		},
+	}
+	statusSourceSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: database.Spec.Stack,
+			Name:      "stack-ledger-postgres-uri-credentials",
+		},
+		Data: map[string][]byte{
+			postgresCredentialsUsernameKey: []byte("old-user"),
+			postgresCredentialsPasswordKey: []byte("old-password"),
+		},
+	}
+	referenceSourceSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: database.Spec.Stack,
+			Name:      "postgres-current",
+		},
+		Data: map[string][]byte{
+			postgresCredentialsUsernameKey: []byte("current-user"),
+			postgresCredentialsPasswordKey: []byte("current-password"),
+		},
+	}
+	resourceReference := &v1beta1.ResourceReference{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "stack-ledger-postgres",
+		},
+		Spec: v1beta1.ResourceReferenceSpec{
+			Name: referenceSourceSecret.Name,
+		},
+	}
+	ctx := newTestContext(t)
+	require.NoError(t, controllerutil.SetControllerReference(database, statusSourceSecret, ctx.GetScheme()))
+	require.NoError(t, controllerutil.SetControllerReference(database, referenceSourceSecret, ctx.GetScheme()))
+	require.NoError(t, ctx.GetClient().Create(ctx, statusSourceSecret))
+	require.NoError(t, ctx.GetClient().Create(ctx, referenceSourceSecret))
+	require.NoError(t, ctx.GetClient().Create(ctx, resourceReference))
+
+	require.NoError(t, remediatePostgresCredentialsSecretBeforeDatabaseDelete(ctx, database))
+
+	preservedStatusSourceSecret := &corev1.Secret{}
+	require.NoError(t, ctx.GetClient().Get(ctx, types.NamespacedName{
+		Namespace: database.Spec.Stack,
+		Name:      statusSourceSecret.Name,
+	}, preservedStatusSourceSecret))
+	require.Empty(t, preservedStatusSourceSecret.OwnerReferences)
+	require.Equal(t, []byte("old-user"), preservedStatusSourceSecret.Data[postgresCredentialsUsernameKey])
+	require.Equal(t, []byte("old-password"), preservedStatusSourceSecret.Data[postgresCredentialsPasswordKey])
+
+	preservedReferenceSourceSecret := &corev1.Secret{}
+	require.NoError(t, ctx.GetClient().Get(ctx, types.NamespacedName{
+		Namespace: database.Spec.Stack,
+		Name:      referenceSourceSecret.Name,
+	}, preservedReferenceSourceSecret))
+	require.Empty(t, preservedReferenceSourceSecret.OwnerReferences)
+	require.Equal(t, []byte("current-user"), preservedReferenceSourceSecret.Data[postgresCredentialsUsernameKey])
+	require.Equal(t, []byte("current-password"), preservedReferenceSourceSecret.Data[postgresCredentialsPasswordKey])
 }


### PR DESCRIPTION
## Summary
- avoid overwriting a user-provided Postgres credentials Secret when its name collides with the derived encoded credentials Secret name
- keep the existing derived Secret name for non-conflicting deployments, and use a collision-safe name only when needed
- only delete encoded credentials Secrets controlled by the Database reconciler, so cleanup cannot remove an uncontrolled source Secret
- add regression tests for env rendering, Secret reconciliation idempotence, and cleanup behavior

## Root cause
`v3.12.0` introduced a derived Secret named `<database>-postgres-uri-credentials` for URL-encoded Postgres credentials. A real deployment can already use that exact name as the source Secret referenced by `?secret=...` (for example `formance-ledger-postgres-uri-credentials`). In that case, the Database reconciler writes encoded credentials back into the source Secret it just read, turning its input into its output and causing repeated reconciliations/rollouts around Ledger deployments.

## Helm / release context
`formance-1.15.0` resolves `regions` to `3.12.0`, which resolves the Operator chart to `3.12.0`; that is how the Operator change from #484 reached users. No Helm template change is needed for the fix itself, but a follow-up Operator release and Helm dependency refresh will be needed to ship it through the umbrella chart.

## Validation
- `CGO_ENABLED=0 go test ./internal/resources/databases -run 'Test(GetPostgresEnvVarsAvoidsEncodedSecretNameCollision|ReconcileEncodedPostgresCredentialsSecretAvoidsSourceSecretNameCollision|DeleteEncodedPostgresCredentialsSecretKeepsUncontrolledSourceSecret)' -count=1 -v`
- `KUBEBUILDER_ASSETS="$(pwd)/bin/k8s/1.32.0-darwin-arm64" CGO_ENABLED=0 go test ./...`
- `nix develop -c just pre-commit`

## Operational checks
- `prod-eu-west-1-hosting`: Operator is still `v3.11.2`; Ledger databases use `?secret=...`, so it is exposed if upgraded to `3.12.0` before this fix.
- `staging-eu-west-1-hosting`: Operator is on the post-`v3.12.0` image, but visible Ledger databases use inline credentials, so it does not exercise the affected `?secret=...` path.
- No matching `object has been modified` / `POSTGRES_URL_ENCODED` / `postgres-uri-credentials` loop was found in the last 24h of our prod/staging hosting operator logs.
