### PR TITLE
chore(helm): prepare v3.12.1 charts

### DIFF
--- a/helm/crds/Chart.yaml
+++ b/helm/crds/Chart.yaml
@@ -13,9 +13,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: "3.12.0"
+version: "3.12.1"
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v3.12.0"
+appVersion: "v3.12.1"

--- a/helm/operator/Chart.lock
+++ b/helm/operator/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: operator-crds
   repository: file://../crds
-  version: 3.12.0
-digest: sha256:a8303c3629ced645833c102622165b02d071c6bd015df8be5e3ec9eb716e90f3
-generated: "2026-07-02T14:18:22.396123+02:00"
+  version: 3.12.1
+digest: sha256:fc93d6068b4831109c346c284242e95a391a8617a0c3278efcd0f3225a6cc732
+generated: "2026-07-14T15:10:55.16729+02:00"

--- a/helm/operator/Chart.yaml
+++ b/helm/operator/Chart.yaml
@@ -13,12 +13,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: "3.12.0"
+version: "3.12.1"
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v3.12.0"
+appVersion: "v3.12.1"
 dependencies:
 - name: operator-crds
   version: "3.X"


### PR DESCRIPTION
## Summary

Prepares the Helm charts for the `v3.12.1` patch release.

- Bumps `operator` and `operator-crds` chart versions to `3.12.1`.
- Sets both chart application versions to `v3.12.1`.
- Regenerates the operator chart lockfile against `operator-crds` `3.12.1`.

## Impact

The release tag `v3.12.1` will publish the stable OCI charts from these versions.

## Validation

- `nix --extra-experimental-features "nix-command flakes" develop --impure --command just helm-update`
- `helm lint ./helm/crds --strict`
- `helm lint ./helm/operator --strict`
- `helm template operator ./helm/operator`
- `helm template operator-crds ./helm/crds`