### PR TITLE
fix(ledger): give ledger v3 raft TLS secret a dedicated name (deduplicate gateway ingress secret / stop reissue race)

### DIFF
--- a/internal/resources/ledgers/v3_tls.go
+++ b/internal/resources/ledgers/v3_tls.go
@@ -122,7 +122,16 @@ func ledgerV3IssuerName(stackName string) string {
 }
 
 func ledgerV3TLSName(stackName string) string {
-	return stackName + "-tls"
+	// Must be unique to the ledger v3 raft cluster. The bare "<stack>-tls"
+	// name collides with the gateway ingress TLS secret
+	// (internal/resources/gateways/ingress.go names it "<gateway>-tls", and
+	// the gateway is named after the stack). When gateway ingress TLS is
+	// enabled, both this self-signed Certificate and the gateway ingress
+	// (ingress-shim / public issuer) target the same Secret and continuously
+	// reissue it, churning the keypair and breaking raft mTLS. The gateway
+	// consumes this backend cert by the GatewayBackendTLSSecretLabel, not by
+	// name, so a dedicated name is safe.
+	return stackName + "-ledger-v3-tls"
 }
 
 func ledgerV3CertificateSpec(stackName string) map[string]any {

--- a/internal/tests/ledger_v3_controller_test.go
+++ b/internal/tests/ledger_v3_controller_test.go
@@ -212,7 +212,7 @@ var _ = Describe("Ledger v3 controller", func() {
 		issuer := newLedgerV3Issuer()
 		certificate := newLedgerV3Certificate()
 		cluster := newLedgerV3Cluster()
-		tlsName := stack.Name + "-tls"
+		tlsName := stack.Name + "-ledger-v3-tls"
 
 		Eventually(func(g Gomega) {
 			g.Expect(Get(types.NamespacedName{Namespace: stack.Name, Name: stack.Name + "-selfsigned"}, issuer)).To(Succeed())
@@ -546,7 +546,7 @@ var _ = Describe("Ledger v3 controller", func() {
 
 	It("mirrors Cluster readiness on the Formance Ledger", func() {
 		certificate := newLedgerV3Certificate()
-		tlsName := stack.Name + "-tls"
+		tlsName := stack.Name + "-ledger-v3-tls"
 		Eventually(func(g Gomega) error {
 			g.Expect(Get(types.NamespacedName{Namespace: stack.Name, Name: tlsName}, certificate)).To(Succeed())
 			return nil
@@ -791,7 +791,7 @@ var _ = Describe("Ledger v3 controller", func() {
 				)))
 
 				certificate := newLedgerV3Certificate()
-				tlsName := stack.Name + "-tls"
+				tlsName := stack.Name + "-ledger-v3-tls"
 				Eventually(func(g Gomega) error {
 					g.Expect(Get(types.NamespacedName{Namespace: stack.Name, Name: tlsName}, certificate)).To(Succeed())
 					return nil
@@ -826,7 +826,7 @@ var _ = Describe("Ledger v3 controller", func() {
 					Name: "ledger-" + stack.Name,
 					Port: 8888,
 					TLS: &v1beta1.GatewayBackendTLS{
-						SecretName:  stack.Name + "-tls",
+						SecretName:  stack.Name + "-ledger-v3-tls",
 						CASecretKey: "ca.crt",
 						ServerName:  "ledger-" + stack.Name + "." + stack.Name + ".svc.cluster.local",
 					},
@@ -862,7 +862,7 @@ var _ = Describe("Ledger v3 controller", func() {
 				certificate := newLedgerV3Certificate()
 				issuer := newLedgerV3Issuer()
 				Eventually(func(g Gomega) {
-					g.Expect(Get(types.NamespacedName{Namespace: stack.Name, Name: stack.Name + "-tls"}, certificate)).To(Succeed())
+					g.Expect(Get(types.NamespacedName{Namespace: stack.Name, Name: stack.Name + "-ledger-v3-tls"}, certificate)).To(Succeed())
 					g.Expect(Get(types.NamespacedName{Namespace: stack.Name, Name: stack.Name + "-selfsigned"}, issuer)).To(Succeed())
 				}).Should(Succeed())
 
@@ -872,7 +872,7 @@ var _ = Describe("Ledger v3 controller", func() {
 					return Get(types.NamespacedName{Namespace: stack.Name, Name: stack.Name}, cluster)
 				}).Should(BeNotFound())
 				Eventually(func() error {
-					return Get(types.NamespacedName{Namespace: stack.Name, Name: stack.Name + "-tls"}, certificate)
+					return Get(types.NamespacedName{Namespace: stack.Name, Name: stack.Name + "-ledger-v3-tls"}, certificate)
 				}).Should(BeNotFound())
 				Eventually(func() error {
 					return Get(types.NamespacedName{Namespace: stack.Name, Name: stack.Name + "-selfsigned"}, issuer)


### PR DESCRIPTION
## Problem

`ledgerV3TLSName` returns `<stack>-tls` — the **same Secret name the gateway ingress already uses** for its own TLS certificate. `internal/resources/gateways/ingress.go` names the ingress secret `<gateway>-tls`, and the gateway is named after the stack, so both resolve to `<stack>-tls`.

When gateway ingress TLS is enabled (`gateway.ingress.tls.enabled=true`), this **duplicates an existing mechanism**: two independent cert-manager clients end up owning the *same* Secret —

- the ledger v3 `Certificate` (self-signed, per-stack `Issuer`), and
- the gateway ingress (ingress-shim, public `ClusterIssuer`)

Each controller observes the other's issuance as `IncorrectIssuer` and reissues → an unbounded **reissue race**:

- the Secret keypair rotates every 1–2 seconds (`CertificateRequest` count climbs into the hundreds),
- the ledger raft mTLS cert reloader repeatedly fails with `tls: private key does not match public key`,
- raft followers can't complete the mTLS handshake (`raft loop has not started`) and the cluster never forms quorum → stuck **Degraded**.

Clusters where gateway ingress TLS is **not** enabled don't collide, so the raft comes up fine — which is why this only manifests on stacks with gateway TLS on.

## Fix

Rename the raft TLS Secret to `<stack>-ledger-v3-tls` so it no longer collides with the gateway ingress Secret.

- The gateway consumes this backend certificate by the `GatewayBackendTLSSecretLabel` label — **not by name** (`internal/resources/gateways/init.go`) — so a dedicated name is safe.
- `ledgerV3TLSName` is the single source used by the `Certificate` name/`secretName`, the ledger pod mount (`v3.go`), the gateway backend ref (`v3_preview.go`) and the preview cleanup, so the rename propagates consistently in one place.
- Matches the name already expected in `v3_spec_test.go` (`stack0-ledger-v3-tls`).

## Test

- `go build ./...` ✅
- `go test ./internal/resources/ledgers/...` ✅
- Updated the hardcoded `<stack>-tls` expectations in `internal/tests/ledger_v3_controller_test.go`.
