### PR TITLE
fix(webhooks): subscribe to reconciliation events

### DIFF
--- a/api/formance.com/v1beta1/reconciliation_types.go
+++ b/api/formance.com/v1beta1/reconciliation_types.go
@@ -17,8 +17,11 @@ limitations under the License.
 package v1beta1
 
 import (
+	"golang.org/x/mod/semver"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
+
+const ReconciliationV3Version = "v3.0.0-0"
 
 type ReconciliationSpec struct {
 	StackDependency  `json:",inline"`
@@ -74,6 +77,16 @@ func (in *Reconciliation) GetVersion() string {
 	return in.Spec.Version
 }
 
+func (in Reconciliation) isEventPublisher() {}
+
+func (in Reconciliation) PublishesEvents(version string) bool {
+	return IsReconciliationV3(version)
+}
+
+func IsReconciliationV3(version string) bool {
+	return !semver.IsValid(version) || semver.Compare(version, ReconciliationV3Version) >= 0
+}
+
 func (a Reconciliation) IsDebug() bool {
 	return a.Spec.Debug
 }
@@ -98,3 +111,5 @@ type ReconciliationList struct {
 func init() {
 	SchemeBuilder.Register(&Reconciliation{}, &ReconciliationList{})
 }
+
+var _ VersionedEventPublisher = (*Reconciliation)(nil)

--- a/api/formance.com/v1beta1/reconciliation_types_test.go
+++ b/api/formance.com/v1beta1/reconciliation_types_test.go
@@ -1,0 +1,23 @@
+package v1beta1
+
+import "testing"
+
+func TestReconciliationPublishesEvents(t *testing.T) {
+	tests := map[string]bool{
+		"v2.3.1":         false,
+		"v3.0.0-0":       true,
+		"v3.0.0-alpha.1": true,
+		"v3.0.0-rc.1":    true,
+		"v3.0.0":         true,
+		"main":           true,
+	}
+
+	reconciliation := Reconciliation{}
+	for version, expected := range tests {
+		t.Run(version, func(t *testing.T) {
+			if got := reconciliation.PublishesEvents(version); got != expected {
+				t.Fatalf("PublishesEvents(%q) = %v, want %v", version, got, expected)
+			}
+		})
+	}
+}

--- a/api/formance.com/v1beta1/shared.go
+++ b/api/formance.com/v1beta1/shared.go
@@ -19,6 +19,15 @@ type EventPublisher interface {
 	isEventPublisher()
 }
 
+// VersionedEventPublisher is an event publisher whose availability depends on
+// the effective module version resolved by the operator.
+// +kubebuilder:object:generate=false
+type VersionedEventPublisher interface {
+	EventPublisher
+	Module
+	PublishesEvents(version string) bool
+}
+
 type DevProperties struct {
 	// +optional
 	// Allow to enable debug mode on the module

--- a/internal/core/publisher.go
+++ b/internal/core/publisher.go
@@ -4,6 +4,8 @@ import (
 	"reflect"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/formancehq/operator/v3/api/formance.com/v1beta1"
@@ -11,6 +13,7 @@ import (
 
 func ListEventPublishers(ctx Context, stackName string) ([]unstructured.Unstructured, error) {
 	ret := make([]unstructured.Unstructured, 0)
+	var stack *v1beta1.Stack
 	for gvk, rtype := range ctx.GetScheme().AllKnownTypes() {
 		object, ok := reflect.New(rtype).Interface().(client.Object)
 		if !ok {
@@ -18,6 +21,7 @@ func ListEventPublishers(ctx Context, stackName string) ([]unstructured.Unstruct
 		}
 
 		if _, ok := object.(v1beta1.EventPublisher); ok {
+			_, isVersionedPublisher := object.(v1beta1.VersionedEventPublisher)
 			us := &unstructured.UnstructuredList{}
 			us.SetGroupVersionKind(gvk)
 
@@ -29,6 +33,30 @@ func ListEventPublishers(ctx Context, stackName string) ([]unstructured.Unstruct
 
 			for _, item := range us.Items {
 				item.SetGroupVersionKind(gvk)
+
+				if isVersionedPublisher {
+					typedObject := reflect.New(rtype).Interface().(client.Object)
+					if err := runtime.DefaultUnstructuredConverter.FromUnstructured(item.Object, typedObject); err != nil {
+						return nil, err
+					}
+					versionedPublisher := typedObject.(v1beta1.VersionedEventPublisher)
+
+					if stack == nil {
+						stack = &v1beta1.Stack{}
+						if err := ctx.GetClient().Get(ctx, types.NamespacedName{Name: stackName}, stack); err != nil {
+							return nil, err
+						}
+					}
+
+					version, err := GetModuleVersion(ctx, stack, versionedPublisher)
+					if err != nil {
+						return nil, err
+					}
+					if !versionedPublisher.PublishesEvents(version) {
+						continue
+					}
+				}
+
 				ret = append(ret, item)
 			}
 		}

--- a/internal/core/publisher_test.go
+++ b/internal/core/publisher_test.go
@@ -1,0 +1,104 @@
+package core
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/formancehq/operator/v3/api/formance.com/v1beta1"
+)
+
+func TestListEventPublishersFiltersVersionedPublishers(t *testing.T) {
+	tests := map[string]struct {
+		reconciliationVersion string
+		expectedServices      []string
+	}{
+		"v2 reconciliation is excluded": {
+			reconciliationVersion: "v2.3.1",
+			expectedServices:      []string{"Ledger", "Payments"},
+		},
+		"v3 prerelease reconciliation is included": {
+			reconciliationVersion: "v3.0.0-alpha.1",
+			expectedServices:      []string{"Ledger", "Payments", "Reconciliation"},
+		},
+		"main reconciliation is included": {
+			reconciliationVersion: "main",
+			expectedServices:      []string{"Ledger", "Payments", "Reconciliation"},
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			scheme := runtime.NewScheme()
+			require.NoError(t, v1beta1.AddToScheme(scheme))
+
+			stack := &v1beta1.Stack{
+				ObjectMeta: metav1.ObjectMeta{Name: "stack"},
+				Spec:       v1beta1.StackSpec{VersionsFromFile: "default"},
+			}
+			versions := &v1beta1.Versions{
+				ObjectMeta: metav1.ObjectMeta{Name: "default"},
+				Spec: map[string]string{
+					"ledger":         "v2.3.1",
+					"payments":       "v2.3.1",
+					"reconciliation": tt.reconciliationVersion,
+				},
+			}
+			ledger := &v1beta1.Ledger{
+				ObjectMeta: metav1.ObjectMeta{Name: "stack"},
+				Spec: v1beta1.LedgerSpec{
+					StackDependency: v1beta1.StackDependency{Stack: stack.Name},
+				},
+			}
+			payments := &v1beta1.Payments{
+				ObjectMeta: metav1.ObjectMeta{Name: "stack"},
+				Spec: v1beta1.PaymentsSpec{
+					StackDependency: v1beta1.StackDependency{Stack: stack.Name},
+				},
+			}
+			reconciliation := &v1beta1.Reconciliation{
+				ObjectMeta: metav1.ObjectMeta{Name: "stack"},
+				Spec: v1beta1.ReconciliationSpec{
+					StackDependency: v1beta1.StackDependency{Stack: stack.Name},
+				},
+			}
+
+			stackIndex := func(object client.Object) []string {
+				if value, found, err := unstructured.NestedString(object.(*unstructured.Unstructured).Object, "spec", "stack"); err == nil && found {
+					return []string{value}
+				}
+				return nil
+			}
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(stack, versions, ledger, payments, reconciliation).
+				WithIndex(&v1beta1.Ledger{}, "stack", stackIndex).
+				WithIndex(&v1beta1.Payments{}, "stack", stackIndex).
+				WithIndex(&v1beta1.Reconciliation{}, "stack", stackIndex).
+				WithIndex(&v1beta1.Orchestration{}, "stack", stackIndex).
+				WithIndex(&v1beta1.TransactionPlane{}, "stack", stackIndex).
+				Build()
+
+			ctx := testContext{
+				Context:   context.Background(),
+				client:    fakeClient,
+				apiReader: fakeClient,
+				scheme:    scheme,
+			}
+			publishers, err := ListEventPublishers(ctx, stack.Name)
+			require.NoError(t, err)
+
+			services := make([]string, 0, len(publishers))
+			for _, publisher := range publishers {
+				services = append(services, publisher.GetKind())
+			}
+			require.ElementsMatch(t, tt.expectedServices, services)
+		})
+	}
+}

--- a/internal/resources/reconciliations/init.go
+++ b/internal/resources/reconciliations/init.go
@@ -18,7 +18,6 @@ package reconciliations
 
 import (
 	"github.com/pkg/errors"
-	"golang.org/x/mod/semver"
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 
@@ -111,7 +110,7 @@ func Reconcile(ctx Context, stack *v1beta1.Stack, reconciliation *v1beta1.Reconc
 }
 
 func usesV3Topology(version string) bool {
-	return !semver.IsValid(version) || semver.Compare(version, "v3.0.0-0") >= 0
+	return v1beta1.IsReconciliationV3(version)
 }
 
 func init() {

--- a/internal/resources/reconciliations/init_test.go
+++ b/internal/resources/reconciliations/init_test.go
@@ -12,6 +12,7 @@ func TestUsesV3Topology(t *testing.T) {
 	tests := map[string]bool{
 		"v2.3.1":         false,
 		"v2.3.1-rc.1":    false,
+		"v3.0.0-0":       true,
 		"v3.0.0-alpha.1": true,
 		"v3.0.0-rc.1":    true,
 		"v3.0.0":         true,

--- a/internal/resources/webhooks/init.go
+++ b/internal/resources/webhooks/init.go
@@ -89,6 +89,7 @@ func init() {
 			WithWatchSettings[*v1beta1.Webhooks](),
 			WithWatchDependency[*v1beta1.Webhooks](&v1beta1.Ledger{}),
 			WithWatchDependency[*v1beta1.Webhooks](&v1beta1.Payments{}),
+			WithWatchDependency[*v1beta1.Webhooks](&v1beta1.Reconciliation{}),
 			databases.Watch[*v1beta1.Webhooks](),
 			brokers.Watch[*v1beta1.Webhooks](),
 		),


### PR DESCRIPTION
## What changed

- add optional version-aware event publisher discovery
- register Reconciliation as an event publisher from `v3.0.0-0`
- include alpha, RC, stable, and non-SemVer development versions such as `main`
- keep Reconciliation v2 excluded from Webhooks subscriptions
- reconcile Webhooks when the Reconciliation module changes
- share the Reconciliation v3 threshold between topology and event publication

## Why

Reconciliation v3 publishes `reconciliation.alert.*` events to its standard message-bus topic. The Operator configured the Reconciliation publisher, but did not expose Reconciliation through the generic `EventPublisher` discovery used to build Webhooks consumers. As a result, Webhooks subscribed only to Ledger and Payments and could never receive Reconciliation events.

The version gate is optional so existing publishers such as Ledger, Payments, Orchestration, and TransactionPlane keep their current behavior.

## Validation

- generated manifests and objects successfully
- `go fmt ./...`
- `go vet ./...`
- `CGO_ENABLED=0 go test ./api/formance.com/v1beta1 ./internal/core ./internal/resources/reconciliations ./internal/resources/webhooks ./internal/resources/brokerconsumers`
- controller suite: 134/134 specs passed in serial envtest mode

The parallel all-suite run exposed an envtest concurrency flake in `internal/tests`; the isolated serial rerun passed all specs.