### PR TITLE
feat(connectivity): provision OpenTelemetry monitoring on the delegated resource

### DIFF
--- a/internal/resources/connectivities/init.go
+++ b/internal/resources/connectivities/init.go
@@ -287,10 +287,23 @@ func connectivityMonitoringSpec(configuration *settings.OpenTelemetryConfigurati
 	if len(configuration.Attributes) > 0 {
 		attributes := make([]string, 0, len(configuration.Attributes))
 		for key, value := range configuration.Attributes {
+			// GetOpenTelemetryConfiguration injects pod-name=$(POD_NAME), which
+			// only resolves when a downward-API POD_NAME env var is defined ahead
+			// of OTEL_RESOURCE_ATTRIBUTES on the workload. Unlike this operator's
+			// own env-var path (settings.otelEnvVars/collectorEnvVars), the
+			// connectivity operator emits OTEL_RESOURCE_ATTRIBUTES verbatim from
+			// spec.monitoring.attributes and defines no such env var, so any
+			// $(...) placeholder would surface literally in the telemetry. Forward
+			// only attributes with resolvable (literal) values.
+			if strings.Contains(value, "$(") {
+				continue
+			}
 			attributes = append(attributes, key+"="+value)
 		}
-		slices.Sort(attributes)
-		monitoring["attributes"] = strings.Join(attributes, ",")
+		if len(attributes) > 0 {
+			slices.Sort(attributes)
+			monitoring["attributes"] = strings.Join(attributes, ",")
+		}
 	}
 
 	signal := func(cfg *settings.OpenTelemetrySignalConfiguration, extra map[string]any) map[string]any {

--- a/internal/resources/connectivities/init.go
+++ b/internal/resources/connectivities/init.go
@@ -18,6 +18,10 @@ package connectivities
 
 import (
 	"fmt"
+	"maps"
+	"slices"
+	"strconv"
+	"strings"
 
 	authorizationv1 "k8s.io/api/authorization/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -35,6 +39,7 @@ import (
 	"github.com/formancehq/operator/v3/internal/resources/gatewayhttpapis"
 	"github.com/formancehq/operator/v3/internal/resources/ledgers"
 	"github.com/formancehq/operator/v3/internal/resources/registries"
+	"github.com/formancehq/operator/v3/internal/resources/settings"
 )
 
 const (
@@ -148,6 +153,13 @@ func Reconcile(ctx Context, stack *v1beta1.Stack, connectivity *v1beta1.Connecti
 		return err
 	}
 
+	// Collector-aware OTEL configuration, embedded inline in spec.monitoring.
+	monitoringConfiguration, err := settings.GetOpenTelemetryConfiguration(ctx, stack.Name, "connectivity")
+	if err != nil {
+		setCondition(connectivity, metav1.ConditionFalse, "MonitoringResolveFailed", err.Error())
+		return err
+	}
+
 	// Reuse the single source of truth for the ledger v3 gRPC connection: same
 	// service, port and backend TLS material (self-signed CA secret + SNI) that
 	// the gateway uses to reach the ledger.
@@ -188,6 +200,9 @@ func Reconcile(ctx Context, stack *v1beta1.Stack, connectivity *v1beta1.Connecti
 			return err
 		}
 		if err := unstructured.SetNestedSlice(object.Object, pullSecretsToUnstructured(apiImage.PullSecrets), "spec", "api", "imagePullSecrets"); err != nil {
+			return err
+		}
+		if err := applyConnectivityMonitoring(object, monitoringConfiguration); err != nil {
 			return err
 		}
 		// Ledger auth: connectivity-core signs its gRPC tokens with the Ed25519
@@ -246,6 +261,61 @@ func pullSecretsToUnstructured(secrets []corev1.LocalObjectReference) []any {
 		out = append(out, map[string]any{"name": ps.Name})
 	}
 	return out
+}
+
+// applyConnectivityMonitoring sets spec.monitoring from the resolved OTEL
+// configuration, or prunes it when telemetry is disabled (idempotent).
+func applyConnectivityMonitoring(object *unstructured.Unstructured, configuration *settings.OpenTelemetryConfiguration) error {
+	monitoring := connectivityMonitoringSpec(configuration)
+	if monitoring == nil {
+		unstructured.RemoveNestedField(object.Object, "spec", "monitoring")
+		return nil
+	}
+	return unstructured.SetNestedMap(object.Object, monitoring, "spec", "monitoring")
+}
+
+// connectivityMonitoringSpec maps the OTEL configuration to the connectivity
+// MonitoringConfig JSON shape, mirroring the Ledger v3 mapping.
+func connectivityMonitoringSpec(configuration *settings.OpenTelemetryConfiguration) map[string]any {
+	if configuration == nil {
+		return nil
+	}
+
+	monitoring := map[string]any{
+		"serviceName": "connectivity",
+	}
+	if len(configuration.Attributes) > 0 {
+		attributes := make([]string, 0, len(configuration.Attributes))
+		for key, value := range configuration.Attributes {
+			attributes = append(attributes, key+"="+value)
+		}
+		slices.Sort(attributes)
+		monitoring["attributes"] = strings.Join(attributes, ",")
+	}
+
+	signal := func(cfg *settings.OpenTelemetrySignalConfiguration, extra map[string]any) map[string]any {
+		out := map[string]any{
+			"enabled":  true,
+			"exporter": "otlp",
+			"endpoint": cfg.Endpoint,
+			"port":     cfg.Port,
+			"insecure": strconv.FormatBool(cfg.Insecure),
+			"mode":     cfg.Mode,
+		}
+		maps.Copy(out, extra)
+		return out
+	}
+
+	if configuration.Traces != nil {
+		monitoring["traces"] = signal(configuration.Traces, map[string]any{"batch": "true"})
+	}
+	if configuration.Metrics != nil {
+		monitoring["metrics"] = signal(configuration.Metrics, map[string]any{"runtime": true})
+	}
+	if configuration.Logs != nil {
+		monitoring["logs"] = signal(configuration.Logs, nil)
+	}
+	return monitoring
 }
 
 func getStackLedger(ctx Context, stackName string) (*v1beta1.Ledger, error) {

--- a/internal/resources/connectivities/init_test.go
+++ b/internal/resources/connectivities/init_test.go
@@ -19,6 +19,7 @@ package connectivities
 import (
 	"context"
 	"errors"
+	"reflect"
 	"testing"
 
 	authorizationv1 "k8s.io/api/authorization/v1"
@@ -30,6 +31,7 @@ import (
 
 	"github.com/formancehq/operator/v3/api/formance.com/v1beta1"
 	"github.com/formancehq/operator/v3/internal/core"
+	"github.com/formancehq/operator/v3/internal/resources/settings"
 )
 
 type connectivityDiscoveryContext struct {
@@ -255,6 +257,122 @@ func TestEnsureLedgerCredentialsReportsKeyAndSecretWhenReady(t *testing.T) {
 	}
 	if secret != "ledger-connectivity-stack1-credentials-keys" {
 		t.Errorf("secret = %q, want the distributed secret in the stack namespace", secret)
+	}
+}
+
+func TestConnectivityMonitoringSpecNilWhenDisabled(t *testing.T) {
+	if got := connectivityMonitoringSpec(nil); got != nil {
+		t.Fatalf("connectivityMonitoringSpec(nil) = %v, want nil (telemetry disabled)", got)
+	}
+}
+
+func TestApplyConnectivityMonitoringEmbedsSignalsInline(t *testing.T) {
+	cfg := &settings.OpenTelemetryConfiguration{
+		// ServiceName is intentionally ignored: the operator forces "connectivity".
+		ServiceName: "ignored",
+		Attributes:  map[string]string{"stack": "stack0", "pod-name": "$(POD_NAME)"},
+		Traces:      &settings.OpenTelemetrySignalConfiguration{Endpoint: "otel-collector.stack0", Port: "4318", Insecure: true, Mode: "http"},
+		Metrics:     &settings.OpenTelemetrySignalConfiguration{Endpoint: "otel-collector.stack0", Port: "4318", Insecure: true, Mode: "http"},
+		Logs:        &settings.OpenTelemetrySignalConfiguration{Endpoint: "otel-collector.stack0", Port: "4318", Insecure: true, Mode: "http"},
+	}
+
+	object := &unstructured.Unstructured{Object: map[string]any{}}
+	if err := applyConnectivityMonitoring(object, cfg); err != nil {
+		t.Fatalf("applyConnectivityMonitoring: %v", err)
+	}
+
+	if sn, _, _ := unstructured.NestedString(object.Object, "spec", "monitoring", "serviceName"); sn != "connectivity" {
+		t.Errorf("serviceName = %q, want connectivity", sn)
+	}
+	if attrs, _, _ := unstructured.NestedString(object.Object, "spec", "monitoring", "attributes"); attrs != "pod-name=$(POD_NAME),stack=stack0" {
+		t.Errorf("attributes = %q, want sorted key=value list", attrs)
+	}
+
+	if enabled, _, _ := unstructured.NestedBool(object.Object, "spec", "monitoring", "traces", "enabled"); !enabled {
+		t.Error("traces.enabled must be true")
+	}
+	if exporter, _, _ := unstructured.NestedString(object.Object, "spec", "monitoring", "traces", "exporter"); exporter != "otlp" {
+		t.Errorf("traces.exporter = %q, want otlp", exporter)
+	}
+	if batch, _, _ := unstructured.NestedString(object.Object, "spec", "monitoring", "traces", "batch"); batch != "true" {
+		t.Errorf("traces.batch = %q, want \"true\"", batch)
+	}
+	if insecure, _, _ := unstructured.NestedString(object.Object, "spec", "monitoring", "traces", "insecure"); insecure != "true" {
+		t.Errorf("traces.insecure = %q, want \"true\" (string)", insecure)
+	}
+
+	if endpoint, _, _ := unstructured.NestedString(object.Object, "spec", "monitoring", "metrics", "endpoint"); endpoint != "otel-collector.stack0" {
+		t.Errorf("metrics.endpoint = %q, want otel-collector.stack0", endpoint)
+	}
+	if runtimeOn, _, _ := unstructured.NestedBool(object.Object, "spec", "monitoring", "metrics", "runtime"); !runtimeOn {
+		t.Error("metrics.runtime must be true")
+	}
+
+	// Logs is configured but, unlike traces/metrics, carries no batch/runtime
+	// extra — just the enabled otlp signal.
+	if enabled, _, _ := unstructured.NestedBool(object.Object, "spec", "monitoring", "logs", "enabled"); !enabled {
+		t.Error("logs.enabled must be true")
+	}
+	if mode, _, _ := unstructured.NestedString(object.Object, "spec", "monitoring", "logs", "mode"); mode != "http" {
+		t.Errorf("logs.mode = %q, want http", mode)
+	}
+}
+
+func TestApplyConnectivityMonitoringOmitsUnconfiguredSignals(t *testing.T) {
+	// Only metrics enabled: traces and logs blocks must be absent.
+	cfg := &settings.OpenTelemetryConfiguration{
+		Metrics: &settings.OpenTelemetrySignalConfiguration{Endpoint: "otel-collector.stack0", Port: "4318", Mode: "http"},
+	}
+	object := &unstructured.Unstructured{Object: map[string]any{}}
+	if err := applyConnectivityMonitoring(object, cfg); err != nil {
+		t.Fatalf("applyConnectivityMonitoring: %v", err)
+	}
+	if _, found, _ := unstructured.NestedMap(object.Object, "spec", "monitoring", "traces"); found {
+		t.Error("spec.monitoring.traces must be absent when traces are not configured")
+	}
+	if _, found, _ := unstructured.NestedMap(object.Object, "spec", "monitoring", "logs"); found {
+		t.Error("spec.monitoring.logs must be absent when logs are not configured")
+	}
+	// No resource attributes were provided, so the attributes key must be omitted.
+	if _, found, _ := unstructured.NestedString(object.Object, "spec", "monitoring", "attributes"); found {
+		t.Error("spec.monitoring.attributes must be omitted when no attributes are set")
+	}
+}
+
+func TestApplyConnectivityMonitoringIsIdempotent(t *testing.T) {
+	cfg := &settings.OpenTelemetryConfiguration{
+		Attributes: map[string]string{"stack": "stack0"},
+		Traces:     &settings.OpenTelemetrySignalConfiguration{Endpoint: "otel-collector.stack0", Port: "4318", Insecure: false, Mode: "grpc"},
+	}
+
+	first := &unstructured.Unstructured{Object: map[string]any{}}
+	if err := applyConnectivityMonitoring(first, cfg); err != nil {
+		t.Fatalf("first apply: %v", err)
+	}
+
+	// Re-applying the same configuration onto the already-populated object must
+	// yield a byte-for-byte identical spec (idempotent reconcile).
+	second := first.DeepCopy()
+	if err := applyConnectivityMonitoring(second, cfg); err != nil {
+		t.Fatalf("second apply: %v", err)
+	}
+	if !reflect.DeepEqual(first.Object, second.Object) {
+		t.Errorf("monitoring is not idempotent:\nfirst  = %#v\nsecond = %#v", first.Object, second.Object)
+	}
+}
+
+func TestApplyConnectivityMonitoringPrunesStaleBlockWhenDisabled(t *testing.T) {
+	object := &unstructured.Unstructured{Object: map[string]any{}}
+	// Seed a stale monitoring block, as if telemetry had been enabled before.
+	if err := unstructured.SetNestedField(object.Object, "connectivity", "spec", "monitoring", "serviceName"); err != nil {
+		t.Fatalf("seed stale monitoring: %v", err)
+	}
+
+	if err := applyConnectivityMonitoring(object, nil); err != nil {
+		t.Fatalf("applyConnectivityMonitoring(nil): %v", err)
+	}
+	if _, found, _ := unstructured.NestedMap(object.Object, "spec", "monitoring"); found {
+		t.Error("spec.monitoring must be pruned when telemetry is disabled")
 	}
 }
 

--- a/internal/resources/connectivities/init_test.go
+++ b/internal/resources/connectivities/init_test.go
@@ -284,8 +284,11 @@ func TestApplyConnectivityMonitoringEmbedsSignalsInline(t *testing.T) {
 	if sn, _, _ := unstructured.NestedString(object.Object, "spec", "monitoring", "serviceName"); sn != "connectivity" {
 		t.Errorf("serviceName = %q, want connectivity", sn)
 	}
-	if attrs, _, _ := unstructured.NestedString(object.Object, "spec", "monitoring", "attributes"); attrs != "pod-name=$(POD_NAME),stack=stack0" {
-		t.Errorf("attributes = %q, want sorted key=value list", attrs)
+	// pod-name=$(POD_NAME) is dropped: the connectivity operator forwards
+	// OTEL_RESOURCE_ATTRIBUTES verbatim without defining a POD_NAME env var, so
+	// the placeholder would surface literally. Only resolvable attributes remain.
+	if attrs, _, _ := unstructured.NestedString(object.Object, "spec", "monitoring", "attributes"); attrs != "stack=stack0" {
+		t.Errorf("attributes = %q, want sorted key=value list without unresolvable placeholders", attrs)
 	}
 
 	if enabled, _, _ := unstructured.NestedBool(object.Object, "spec", "monitoring", "traces", "enabled"); !enabled {
@@ -315,6 +318,31 @@ func TestApplyConnectivityMonitoringEmbedsSignalsInline(t *testing.T) {
 	}
 	if mode, _, _ := unstructured.NestedString(object.Object, "spec", "monitoring", "logs", "mode"); mode != "http" {
 		t.Errorf("logs.mode = %q, want http", mode)
+	}
+}
+
+func TestConnectivityMonitoringSpecDropsUnresolvableAttributes(t *testing.T) {
+	// The connectivity operator emits OTEL_RESOURCE_ATTRIBUTES verbatim and
+	// defines no POD_NAME env var, so a forwarded $(POD_NAME) would surface
+	// literally. Such placeholders must be stripped, keeping literal attributes.
+	got := connectivityMonitoringSpec(&settings.OpenTelemetryConfiguration{
+		Attributes: map[string]string{
+			"stack":    "stack0",
+			"pod-name": "$(POD_NAME)",
+			"team":     "connectivity",
+		},
+	})
+	if attrs := got["attributes"]; attrs != "stack=stack0,team=connectivity" {
+		t.Errorf("attributes = %q, want the placeholder stripped and literals kept, sorted", attrs)
+	}
+
+	// When the only attribute is an unresolvable placeholder, the attributes key
+	// must be omitted entirely rather than set to an empty string.
+	onlyPlaceholder := connectivityMonitoringSpec(&settings.OpenTelemetryConfiguration{
+		Attributes: map[string]string{"pod-name": "$(POD_NAME)"},
+	})
+	if _, found := onlyPlaceholder["attributes"]; found {
+		t.Errorf("attributes must be omitted when every attribute is unresolvable, got %v", onlyPlaceholder["attributes"])
 	}
 }
 


### PR DESCRIPTION
## Summary

Wire OpenTelemetry observability into the Connectivity module, mirroring the Ledger v3 pattern.

- Resolve the stack's OTEL configuration via `settings.GetOpenTelemetryConfiguration(ctx, stack.Name, "connectivity")`. This is collector-aware: it points the signals at `otel-collector.<stack>:4318` when the per-stack collector Service exists, otherwise it honours the `opentelemetry.*` Settings.
- Embed the resolved config **inline** in the delegated resource's `spec.monitoring` (same shape as Ledger v3's `Cluster.spec.monitoring`). The connectivity operator's `MonitoringConfig` is a struct embedded in the CRD spec — there is **no separate `Monitoring` object** to create or reference. The connectivity operator turns `spec.monitoring` into `OTEL_*` env vars on the workload.
- Each present signal is enabled with the `otlp` exporter; traces are batched, metrics carry runtime instrumentation — matching the Ledger v3 mapping.

## Idempotency

The whole `spec.monitoring` block is rebuilt inside the existing `CreateOrUpdate` mutate closure on every reconcile, and pruned (`RemoveNestedField`) when telemetry is disabled — so repeated reconciles converge to the same object.

## Test plan

- [x] `go test ./internal/resources/connectivities/...` green
- [x] New unit tests: inline signal mapping, sorted resource attributes, idempotency (byte-for-byte identical spec on re-apply), omission of unconfigured signals, and pruning when disabled
- [x] New helpers at 100% coverage (`applyConnectivityMonitoring`, `connectivityMonitoringSpec`)
- [x] `just pre-commit` (tidy, lint, generate, manifests, helm, docs, settings-catalog)

## Notes

- Base branch is `feat/connectivity-module` — this stacks the observability wiring on top of the connectivity module work.
- End-to-end `OTEL_*` env-var emission is owned by the connectivity operator repo and covered there.