### PR TITLE
fix(connectivity): watch ledger Credentials so pending reconcile is retriggered

### DIFF
--- a/internal/resources/connectivities/init.go
+++ b/internal/resources/connectivities/init.go
@@ -17,6 +17,7 @@ limitations under the License.
 package connectivities
 
 import (
+	"context"
 	"fmt"
 	"maps"
 	"slices"
@@ -33,7 +34,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/formancehq/operator/v3/api/formance.com/v1beta1"
 	. "github.com/formancehq/operator/v3/internal/core"
@@ -73,6 +76,13 @@ var (
 		Version: "v1alpha1",
 		Kind:    "Credentials",
 	}
+
+	// ledgerCredentialsWatchAvailable records whether, at controller start-up,
+	// the ledger Credentials CRD was present so the reconciler could register a
+	// watch on it. When true, changes to the connectivity-<stack> Credentials
+	// (notably its status.phase flipping to Ready) re-trigger the owning
+	// Connectivity's reconcile.
+	ledgerCredentialsWatchAvailable bool
 )
 
 var connectivityRequiredVerbs = []string{"get", "list", "watch", "create", "update", "patch", "delete"}
@@ -512,12 +522,106 @@ func canAccessConnectivityResource(ctx Context, gvk schema.GroupVersionKind, res
 	return true
 }
 
+// withLedgerCredentialsWatch registers a watch on the cluster-scoped ledger
+// Credentials so that changes to the connectivity-<stack> Credentials re-trigger
+// the owning Connectivity's reconcile.
+//
+// Reconcile returns a PendingError while the Credentials is not yet Ready
+// (LedgerCredentialsPending), and the reconcile loop treats a PendingError as a
+// terminal ctrl.Result{} with no RequeueAfter (see core.reconcileObject). The
+// Credentials is provisioned by the ledger operator, is cluster-scoped, and is
+// owned by the Stack (not controller-owned by the namespaced Connectivity), so
+// neither WithOwn nor the standard requeue would re-trigger Connectivity when the
+// ledger operator flips the Credentials status.phase to Ready. Without this
+// watch the module can stall indefinitely on LedgerCredentialsPending.
+//
+// The Credentials is an external, unstructured GVK, so this uses a raw builder
+// watch (mirroring withConnectivityClusterWatch) rather than WithWatch, which
+// reflect-instantiates a typed WATCHED and cannot carry the GVK an unstructured
+// watch needs. The watch is gated on the Credentials CRD being installed so
+// controller setup never fails when the ledger operator is absent.
+func withLedgerCredentialsWatch() ReconcilerOption[*v1beta1.Connectivity] {
+	return func(options *ReconcilerOptions[*v1beta1.Connectivity]) {
+		options.Raws = append(options.Raws, func(ctx Context, b *builder.Builder) error {
+			crds := &apiextensionsv1.CustomResourceDefinitionList{}
+			if err := ctx.GetAPIReader().List(ctx, crds); err != nil {
+				ledgerCredentialsWatchAvailable = false
+				log.FromContext(ctx).Info("ledger Credentials watch unavailable; continuing without it", "error", err)
+				return nil
+			}
+			ledgerCredentialsWatchAvailable = watchLedgerCredentials(ctx, b, crds)
+			return nil
+		})
+	}
+}
+
+func watchLedgerCredentials(ctx Context, b *builder.Builder, crds *apiextensionsv1.CustomResourceDefinitionList) bool {
+	for _, crd := range crds.Items {
+		if crd.Spec.Group != ledgerCredentialsGVK.Group || crd.Spec.Names.Kind != ledgerCredentialsGVK.Kind {
+			continue
+		}
+		for _, version := range crd.Spec.Versions {
+			if version.Name != ledgerCredentialsGVK.Version || !version.Served {
+				continue
+			}
+			cred := &unstructured.Unstructured{}
+			cred.SetGroupVersionKind(ledgerCredentialsGVK)
+			// The raw builder callback receives a Context wrapping the manager;
+			// its client is long-lived, so it is safe to reuse for the mapping.
+			b.Watches(cred, handler.EnqueueRequestsFromMapFunc(func(_ context.Context, object client.Object) []reconcile.Request {
+				return mapLedgerCredentialsToConnectivity(ctx, object)
+			}))
+			log.FromContext(ctx).Info("ledger Credentials watch registered", "gvk", ledgerCredentialsGVK)
+			return true
+		}
+	}
+	log.FromContext(ctx).Info("ledger Credentials CRD is not available; connectivity will not watch credentials", "gvk", ledgerCredentialsGVK)
+	return false
+}
+
+// mapLedgerCredentialsToConnectivity maps a ledger Credentials event back to the
+// Connectivity module(s) that provisioned it. ensureLedgerCredentials names the
+// Credentials "connectivity-<stack>", so the stack is derived from that name and
+// the Connectivity in that stack is enqueued (there is one Connectivity per
+// stack). It returns nothing when the name is not a connectivity-owned
+// Credentials or when the stack has no Connectivity.
+func mapLedgerCredentialsToConnectivity(ctx Context, object client.Object) []reconcile.Request {
+	stack, ok := connectivityStackFromCredentials(object)
+	if !ok {
+		return nil
+	}
+	list := &v1beta1.ConnectivityList{}
+	if err := ctx.GetClient().List(ctx, list, client.MatchingFields{"stack": stack}); err != nil {
+		log.FromContext(ctx).Error(err, "listing Connectivity for ledger Credentials watch", "stack", stack)
+		return nil
+	}
+	items := make([]*v1beta1.Connectivity, len(list.Items))
+	for i := range list.Items {
+		items[i] = &list.Items[i]
+	}
+	return MapObjectToReconcileRequests(items...)
+}
+
+// connectivityStackFromCredentials derives the stack a connectivity-owned ledger
+// Credentials belongs to. ensureLedgerCredentials names it "connectivity-<stack>"
+// (and stamps spec.selector.matchLabels["formance.com/stack"]); requiring the
+// "connectivity-" name prefix keeps unrelated ledger Credentials from enqueueing
+// a Connectivity.
+func connectivityStackFromCredentials(object client.Object) (string, bool) {
+	stack, ok := strings.CutPrefix(object.GetName(), "connectivity-")
+	if !ok || stack == "" {
+		return "", false
+	}
+	return stack, true
+}
+
 func init() {
 	Init(
 		WithModuleReconciler(Reconcile,
 			WithFinalizer[*v1beta1.Connectivity]("delete-ledger-credentials", deleteLedgerCredentials),
 			WithOwn[*v1beta1.Connectivity](&v1beta1.GatewayHTTPAPI{}),
 			withConnectivityClusterWatch(),
+			withLedgerCredentialsWatch(),
 			WithWatchSettings[*v1beta1.Connectivity](),
 			WithWatchDependency[*v1beta1.Connectivity](&v1beta1.Ledger{}),
 		),

--- a/internal/resources/connectivities/init_test.go
+++ b/internal/resources/connectivities/init_test.go
@@ -469,6 +469,123 @@ func TestApplyConnectivityMonitoringPrunesStaleBlockWhenDisabled(t *testing.T) {
 	}
 }
 
+// newConnectivityMapContext builds a core.Context backed by a fake client that
+// indexes Connectivity by stack (as the manager does at runtime), for exercising
+// the ledger Credentials -> Connectivity watch mapping.
+func newConnectivityMapContext(t *testing.T, objs ...client.Object) credsTestContext {
+	t.Helper()
+	s := runtime.NewScheme()
+	if err := v1beta1.AddToScheme(s); err != nil {
+		t.Fatalf("add v1beta1 to scheme: %v", err)
+	}
+	c := fake.NewClientBuilder().
+		WithScheme(s).
+		WithIndex(&v1beta1.Connectivity{}, "stack", func(obj client.Object) []string {
+			return []string{obj.(*v1beta1.Connectivity).GetStack()}
+		}).
+		WithObjects(objs...).
+		Build()
+	return credsTestContext{Context: context.Background(), scheme: s, client: c}
+}
+
+func newConnectivity(name, stack string) *v1beta1.Connectivity {
+	c := &v1beta1.Connectivity{}
+	c.Name = name
+	c.Spec.Stack = stack
+	return c
+}
+
+func newLedgerCredentials(name string) *unstructured.Unstructured {
+	cred := &unstructured.Unstructured{}
+	cred.SetGroupVersionKind(ledgerCredentialsGVK)
+	cred.SetName(name)
+	return cred
+}
+
+func TestMapLedgerCredentialsToConnectivityEnqueuesMatchingConnectivity(t *testing.T) {
+	// One Connectivity per stack; only the one in the Credentials' stack must be
+	// enqueued.
+	ctx := newConnectivityMapContext(t,
+		newConnectivity("stack1", "stack1"),
+		newConnectivity("stack2", "stack2"),
+	)
+
+	requests := mapLedgerCredentialsToConnectivity(ctx, newLedgerCredentials("connectivity-stack1"))
+	if len(requests) != 1 {
+		t.Fatalf("expected exactly one reconcile request, got %d: %v", len(requests), requests)
+	}
+	if requests[0].Name != "stack1" {
+		t.Errorf("enqueued Connectivity %q, want stack1", requests[0].Name)
+	}
+}
+
+func TestMapLedgerCredentialsToConnectivityReturnsNothingWithoutMatchingConnectivity(t *testing.T) {
+	// A Connectivity exists, but not in the stack the Credentials belongs to.
+	ctx := newConnectivityMapContext(t, newConnectivity("stack1", "stack1"))
+
+	if requests := mapLedgerCredentialsToConnectivity(ctx, newLedgerCredentials("connectivity-stack9")); len(requests) != 0 {
+		t.Fatalf("expected no reconcile requests for a stack without Connectivity, got %v", requests)
+	}
+}
+
+func TestMapLedgerCredentialsToConnectivityIgnoresForeignCredentials(t *testing.T) {
+	// A ledger Credentials not provisioned by the connectivity module (no
+	// "connectivity-" name prefix) must never enqueue a Connectivity, even when a
+	// Connectivity would otherwise match by stack.
+	ctx := newConnectivityMapContext(t, newConnectivity("stack1", "stack1"))
+
+	if requests := mapLedgerCredentialsToConnectivity(ctx, newLedgerCredentials("some-other-credential")); requests != nil {
+		t.Fatalf("foreign Credentials must map to no Connectivity, got %v", requests)
+	}
+	// The bare prefix with an empty stack must also be rejected.
+	if _, ok := connectivityStackFromCredentials(newLedgerCredentials("connectivity-")); ok {
+		t.Fatal("a Credentials named exactly \"connectivity-\" must not resolve a stack")
+	}
+}
+
+func TestLedgerCredentialsWatchDisabledWhenCRDAbsent(t *testing.T) {
+	previous := ledgerCredentialsWatchAvailable
+	ledgerCredentialsWatchAvailable = true
+	t.Cleanup(func() { ledgerCredentialsWatchAvailable = previous })
+
+	options := core.ReconcilerOptions[*v1beta1.Connectivity]{}
+	withLedgerCredentialsWatch()(&options)
+	if len(options.Raws) != 1 {
+		t.Fatalf("withLedgerCredentialsWatch() registered %d raw builders, want 1", len(options.Raws))
+	}
+
+	// crdPresentReader advertises only the connectivity CRD, not the ledger
+	// Credentials CRD, so the watch must stay unregistered without touching the
+	// (nil) builder or failing setup.
+	ctx := connectivityDiscoveryContext{Context: context.Background(), reader: crdPresentReader{}}
+	if err := options.Raws[0](ctx, nil); err != nil {
+		t.Fatalf("absent ledger Credentials CRD must not fail controller setup: %v", err)
+	}
+	if ledgerCredentialsWatchAvailable {
+		t.Fatal("ledger Credentials watch remains enabled when the CRD is absent")
+	}
+}
+
+func TestLedgerCredentialsWatchDisabledWhenDiscoveryFails(t *testing.T) {
+	previous := ledgerCredentialsWatchAvailable
+	ledgerCredentialsWatchAvailable = true
+	t.Cleanup(func() { ledgerCredentialsWatchAvailable = previous })
+
+	options := core.ReconcilerOptions[*v1beta1.Connectivity]{}
+	withLedgerCredentialsWatch()(&options)
+
+	ctx := connectivityDiscoveryContext{
+		Context: context.Background(),
+		reader:  failingDiscoveryReader{err: errors.New("CRD discovery forbidden")},
+	}
+	if err := options.Raws[0](ctx, nil); err != nil {
+		t.Fatalf("discovery failure must not fail controller setup: %v", err)
+	}
+	if ledgerCredentialsWatchAvailable {
+		t.Fatal("ledger Credentials watch remains enabled after discovery failure")
+	}
+}
+
 func TestConnectivityReconcilePendingWhenCapabilityUnavailable(t *testing.T) {
 	previous := connectivityAvailable
 	connectivityAvailable = false


### PR DESCRIPTION
The Connectivity reconciler returns a PendingError while the cluster-scoped
ledger Credentials it provisions (connectivity-<stack>) is not yet Ready
(LedgerCredentialsPending). The reconcile loop treats a PendingError as a
terminal ctrl.Result{} with no RequeueAfter, and the Credentials is owned by
the Stack rather than the namespaced Connectivity, so nothing re-triggered the
module when the ledger operator flipped the Credentials status.phase to Ready:
the reconcile could stall indefinitely.

Register a raw builder watch on the ledger.formance.com/v1alpha1 Credentials
GVK (unstructured, mirroring withConnectivityClusterWatch) that maps a
Credentials event back to the Connectivity in the matching stack, derived from
the connectivity-<stack> name and listed via the stack field index. The watch
is gated on the Credentials CRD being installed so controller setup never fails
when the ledger operator is absent. RBAC already grants watch on credentials.

Add unit tests for the mapping (enqueues the matching Connectivity, returns
nothing for a stack without one, ignores foreign Credentials) and for the
capability gate (disabled when the CRD is absent or discovery fails).

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>