### PR TITLE
fix(connectivity): tear down delegated resources when the ledger gate closes

### DIFF
--- a/internal/resources/connectivities/init.go
+++ b/internal/resources/connectivities/init.go
@@ -100,6 +100,18 @@ func Reconcile(ctx Context, stack *v1beta1.Stack, connectivity *v1beta1.Connecti
 	if !connectivityAvailable {
 		setCondition(connectivity, metav1.ConditionFalse, "OperatorUnavailable",
 			"connectivity operator unavailable: connectivity.formance.com Connectivity CRD is not installed")
+		// The connectivity operator is gone, so we can neither provision nor
+		// manage the delegated workload — but if the ledger hard gate is also
+		// closed we must still tear down the god-mode Credentials and the gateway
+		// route we own, otherwise a closed gate leaves them behind just because
+		// this capability check short-circuits before the ledger gates below.
+		// Gated on the gate being closed so a transient operator outage (with a
+		// healthy ledger) does not flap those resources.
+		if ledgerGateClosed(ctx, stack) {
+			if err := teardownDelegated(ctx, stack, connectivity); err != nil {
+				return err
+			}
+		}
 		return NewPendingError().WithMessage("connectivity operator unavailable: connectivity.formance.com Connectivity CRD is not installed")
 	}
 
@@ -312,10 +324,42 @@ func teardownDelegated(ctx Context, stack *v1beta1.Stack, connectivity *v1beta1.
 	// Credentials also cascades the ledger operator's key deregistration and the
 	// distributed private-key Secret, which stack-namespace GC never reclaims.
 	return errors.Join(
-		client.IgnoreNotFound(ctx.GetClient().Delete(ctx, delegated)),
-		client.IgnoreNotFound(ctx.GetClient().Delete(ctx, httpAPI)),
+		ignoreAbsent(ctx.GetClient().Delete(ctx, delegated)),
+		ignoreAbsent(ctx.GetClient().Delete(ctx, httpAPI)),
 		deleteLedgerCredentials(ctx, connectivity),
 	)
+}
+
+// ignoreAbsent drops NotFound and NoMatch (the whole CRD is not installed)
+// errors, so a teardown delete is a no-op when the resource — or its API — is
+// already gone. This matters on the capability-unavailable path, where the
+// connectivity CRD may have been removed after startup.
+func ignoreAbsent(err error) error {
+	if apimeta.IsNoMatchError(err) {
+		return nil
+	}
+	return client.IgnoreNotFound(err)
+}
+
+// ledgerGateClosed reports whether the ledger prerequisite is definitively gone
+// — the module was removed, or resolves to a non-v3 version — which are the hard
+// gates that warrant tearing down the delegated resources. It mirrors the gate
+// decisions in Reconcile and deliberately returns false on transient states (an
+// unresolvable version, a not-yet-ready ledger) and on any lookup error, so the
+// workload is never flapped on a blip.
+func ledgerGateClosed(ctx Context, stack *v1beta1.Stack) bool {
+	ledger, err := getStackLedger(ctx, stack.Name)
+	if err != nil {
+		return false
+	}
+	if ledger == nil {
+		return true
+	}
+	ledgerVersion, err := ResolveModuleVersion(ctx, stack, ledger)
+	if err != nil {
+		return false
+	}
+	return !ledgers.IsV3(ledgerVersion)
 }
 
 // connectivityAPIBackendRef points the gateway at the connectivity-api Service

--- a/internal/resources/connectivities/init.go
+++ b/internal/resources/connectivities/init.go
@@ -111,6 +111,14 @@ func Reconcile(ctx Context, stack *v1beta1.Stack, connectivity *v1beta1.Connecti
 	}
 	if ledger == nil {
 		setCondition(connectivity, metav1.ConditionFalse, "LedgerNotFound", "stack has no Ledger module")
+		// Hard gate: the Ledger module has been removed from the stack. This is a
+		// definitive loss of the prerequisite (not a momentary blip), so tear down
+		// any previously provisioned delegated Connectivity + GatewayHTTPAPI rather
+		// than leaving the workload running and exposed through the gateway with no
+		// ledger to ingest into.
+		if err := teardownDelegated(ctx, stack, connectivity); err != nil {
+			return err
+		}
 		return NewPendingError().WithMessage("connectivity requires a Ledger module on the stack")
 	}
 
@@ -120,15 +128,32 @@ func Reconcile(ctx Context, stack *v1beta1.Stack, connectivity *v1beta1.Connecti
 	ledgerVersion, err := ResolveModuleVersion(ctx, stack, ledger)
 	if err != nil {
 		setCondition(connectivity, metav1.ConditionFalse, "LedgerVersionUnresolved", err.Error())
+		// Transient: we could not resolve the ledger version (e.g. a referenced
+		// Versions file not yet present). This is an error *resolving* the
+		// prerequisite, not a definitive downgrade below v3, so we deliberately do
+		// NOT tear down the delegated resources here — flapping the workload on a
+		// transient resolution hiccup would be worse than briefly keeping it up.
 		return NewPendingError().WithMessage("cannot resolve the ledger version: %s", err.Error())
 	}
 	if !ledgers.IsV3(ledgerVersion) {
 		setCondition(connectivity, metav1.ConditionFalse, "LedgerNotV3",
 			fmt.Sprintf("connectivity requires a Ledger v3 (found %q)", ledgerVersion))
+		// Hard gate: the ledger version resolved but is not v3 (i.e. a real
+		// downgrade). Connectivity binds to the ledger v3 gRPC surface, so the
+		// prerequisite no longer holds — tear down the delegated Connectivity +
+		// GatewayHTTPAPI before returning pending.
+		if err := teardownDelegated(ctx, stack, connectivity); err != nil {
+			return err
+		}
 		return NewPendingError().WithMessage("connectivity requires a Ledger v3")
 	}
 	if !ledger.IsReady() {
 		setCondition(connectivity, metav1.ConditionFalse, "LedgerNotReady", "waiting for the ledger to be ready")
+		// Transient: the ledger exists and is v3 but is momentarily not ready.
+		// Unlike the hard gates above (LedgerNotFound / LedgerNotV3), the
+		// prerequisite still holds, so we deliberately do NOT tear down the
+		// delegated resources — doing so on every ledger readiness blip would flap
+		// the connectivity workload. Leave it in place and just report pending.
 		return NewPendingError().WithMessage("waiting for the ledger to be ready")
 	}
 
@@ -253,6 +278,34 @@ func Reconcile(ctx Context, stack *v1beta1.Stack, connectivity *v1beta1.Connecti
 
 	setCondition(connectivity, metav1.ConditionTrue, "Ready", "Connectivity is ready")
 	return nil
+}
+
+// teardownDelegated deletes the delegated Connectivity resource and the
+// GatewayHTTPAPI provisioned for the stack. It is invoked when a hard/persistent
+// ledger gate closes (the Ledger module was removed, or its version resolved to
+// something below v3) so the connectivity workload is not left running and
+// exposed through the gateway once its prerequisite no longer holds. There is no
+// automatic pruning of these module-owned objects on a normal reconcile
+// early-return — controller-runtime garbage collection only removes them when
+// the Connectivity CR itself is deleted — so the teardown must be explicit.
+//
+// Deletes use client.IgnoreNotFound so the helper is idempotent and safe to call
+// on every reconcile while the gate stays closed (including when the resources
+// were never created). The names/scopes mirror how they are provisioned in
+// Reconcile: the delegated Connectivity is namespaced (name == namespace ==
+// stack name) and the GatewayHTTPAPI is cluster-scoped ("<stack>-connectivity").
+func teardownDelegated(ctx Context, stack *v1beta1.Stack, connectivity *v1beta1.Connectivity) error {
+	delegated := &unstructured.Unstructured{}
+	delegated.SetGroupVersionKind(connectivityGVK)
+	delegated.SetNamespace(stack.Name)
+	delegated.SetName(stack.Name)
+	if err := client.IgnoreNotFound(ctx.GetClient().Delete(ctx, delegated)); err != nil {
+		return err
+	}
+
+	httpAPI := &v1beta1.GatewayHTTPAPI{}
+	httpAPI.SetName(GetObjectName(connectivity.GetStack(), LowerCaseKind(ctx, connectivity)))
+	return client.IgnoreNotFound(ctx.GetClient().Delete(ctx, httpAPI))
 }
 
 // connectivityAPIBackendRef points the gateway at the connectivity-api Service

--- a/internal/resources/connectivities/init.go
+++ b/internal/resources/connectivities/init.go
@@ -18,6 +18,7 @@ package connectivities
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"maps"
 	"slices"
@@ -299,13 +300,22 @@ func teardownDelegated(ctx Context, stack *v1beta1.Stack, connectivity *v1beta1.
 	delegated.SetGroupVersionKind(connectivityGVK)
 	delegated.SetNamespace(stack.Name)
 	delegated.SetName(stack.Name)
-	if err := client.IgnoreNotFound(ctx.GetClient().Delete(ctx, delegated)); err != nil {
-		return err
-	}
 
 	httpAPI := &v1beta1.GatewayHTTPAPI{}
 	httpAPI.SetName(GetObjectName(connectivity.GetStack(), LowerCaseKind(ctx, connectivity)))
-	return client.IgnoreNotFound(ctx.GetClient().Delete(ctx, httpAPI))
+
+	// Attempt every deletion independently rather than bailing on the first
+	// error: a failure to delete one resource must not leave the public gateway
+	// route or the god-mode Credentials behind, since the point of the hard
+	// teardown is to stop exposing the workload — and its credential — once the
+	// ledger prerequisite no longer holds. Deleting the cluster-scoped
+	// Credentials also cascades the ledger operator's key deregistration and the
+	// distributed private-key Secret, which stack-namespace GC never reclaims.
+	return errors.Join(
+		client.IgnoreNotFound(ctx.GetClient().Delete(ctx, delegated)),
+		client.IgnoreNotFound(ctx.GetClient().Delete(ctx, httpAPI)),
+		deleteLedgerCredentials(ctx, connectivity),
+	)
 }
 
 // connectivityAPIBackendRef points the gateway at the connectivity-api Service

--- a/internal/resources/connectivities/init_test.go
+++ b/internal/resources/connectivities/init_test.go
@@ -586,6 +586,149 @@ func TestLedgerCredentialsWatchDisabledWhenDiscoveryFails(t *testing.T) {
 	}
 }
 
+// newReconcileTestContext builds a core.Context backed by a fake client whose
+// scheme knows the v1beta1 types, the delegated connectivity GVK and the ledger
+// Credentials GVK (as unstructured), and whose client indexes Ledgers by their
+// "stack" field so getStackLedger's List(MatchingFields{"stack": ...}) resolves.
+func newReconcileTestContext(t *testing.T, objs ...client.Object) credsTestContext {
+	t.Helper()
+	s := runtime.NewScheme()
+	if err := v1beta1.AddToScheme(s); err != nil {
+		t.Fatalf("add v1beta1 to scheme: %v", err)
+	}
+	s.AddKnownTypeWithName(connectivityGVK, &unstructured.Unstructured{})
+	s.AddKnownTypeWithName(connectivityGVK.GroupVersion().WithKind(connectivityGVK.Kind+"List"), &unstructured.UnstructuredList{})
+	s.AddKnownTypeWithName(ledgerCredentialsGVK, &unstructured.Unstructured{})
+	s.AddKnownTypeWithName(ledgerCredentialsGVK.GroupVersion().WithKind(ledgerCredentialsGVK.Kind+"List"), &unstructured.UnstructuredList{})
+	return credsTestContext{
+		Context: context.Background(),
+		scheme:  s,
+		client: fake.NewClientBuilder().WithScheme(s).
+			WithIndex(&v1beta1.Ledger{}, "stack", func(obj client.Object) []string {
+				return []string{obj.(*v1beta1.Ledger).Spec.Stack}
+			}).
+			WithObjects(objs...).Build(),
+	}
+}
+
+// newDelegatedConnectivity returns the delegated Connectivity resource as it is
+// provisioned by Reconcile: namespaced, with name == namespace == stack name.
+func newDelegatedConnectivity(stackName string) *unstructured.Unstructured {
+	object := &unstructured.Unstructured{}
+	object.SetGroupVersionKind(connectivityGVK)
+	object.SetNamespace(stackName)
+	object.SetName(stackName)
+	return object
+}
+
+// delegatedConnectivityExists reports whether the delegated Connectivity for the
+// stack is still present in the cluster.
+func delegatedConnectivityExists(t *testing.T, ctx credsTestContext, stackName string) bool {
+	t.Helper()
+	got := &unstructured.Unstructured{}
+	got.SetGroupVersionKind(connectivityGVK)
+	err := ctx.GetClient().Get(ctx, client.ObjectKey{Namespace: stackName, Name: stackName}, got)
+	return err == nil
+}
+
+// gatewayHTTPAPIExists reports whether the connectivity GatewayHTTPAPI
+// ("<stack>-connectivity", cluster-scoped) is still present in the cluster.
+func gatewayHTTPAPIExists(t *testing.T, ctx credsTestContext, stackName string) bool {
+	t.Helper()
+	got := &v1beta1.GatewayHTTPAPI{}
+	err := ctx.GetClient().Get(ctx, client.ObjectKey{Name: stackName + "-connectivity"}, got)
+	return err == nil
+}
+
+func TestConnectivityReconcileTearsDownDelegatedWhenLedgerNotV3(t *testing.T) {
+	previous := connectivityAvailable
+	connectivityAvailable = true
+	t.Cleanup(func() { connectivityAvailable = previous })
+
+	// A v2 (non-v3) ledger: a real downgrade below the connectivity prerequisite.
+	ledger := &v1beta1.Ledger{}
+	ledger.Name = "stack0-ledger"
+	ledger.Spec.Stack = "stack0"
+	ledger.Spec.Version = "v2.0.0"
+	ledger.Status.Ready = true
+
+	// Pre-provisioned delegated resources, as if connectivity had been running
+	// before the ledger was downgraded.
+	delegated := newDelegatedConnectivity("stack0")
+	httpAPI := &v1beta1.GatewayHTTPAPI{}
+	httpAPI.Name = "stack0-connectivity"
+
+	ctx := newReconcileTestContext(t, ledger, delegated, httpAPI)
+
+	stack := &v1beta1.Stack{}
+	stack.Name = "stack0"
+	connectivity := &v1beta1.Connectivity{}
+	connectivity.Name = "stack0"
+	connectivity.Spec.Stack = "stack0"
+
+	err := Reconcile(ctx, stack, connectivity, "v1.0.0")
+	if err == nil {
+		t.Fatal("Reconcile() must return a pending error when the ledger is not v3")
+	}
+	if !core.IsApplicationError(err) {
+		t.Fatalf("Reconcile() returned %v, want an application (pending) error", err)
+	}
+	if len(connectivity.Status.Conditions) == 0 || connectivity.Status.Conditions[0].Reason != "LedgerNotV3" {
+		t.Fatalf("expected a LedgerNotV3 condition, got %#v", connectivity.Status.Conditions)
+	}
+
+	if delegatedConnectivityExists(t, ctx, "stack0") {
+		t.Error("delegated Connectivity must be torn down when the ledger is not v3")
+	}
+	if gatewayHTTPAPIExists(t, ctx, "stack0") {
+		t.Error("GatewayHTTPAPI must be torn down when the ledger is not v3")
+	}
+}
+
+func TestConnectivityReconcileKeepsDelegatedWhenLedgerV3NotReady(t *testing.T) {
+	previous := connectivityAvailable
+	connectivityAvailable = true
+	t.Cleanup(func() { connectivityAvailable = previous })
+
+	// A v3 ledger that is momentarily not ready: the prerequisite still holds, so
+	// this is a transient gate that must NOT flap the workload.
+	ledger := &v1beta1.Ledger{}
+	ledger.Name = "stack0-ledger"
+	ledger.Spec.Stack = "stack0"
+	ledger.Spec.Version = "v3.0.0"
+	ledger.Status.Ready = false
+
+	delegated := newDelegatedConnectivity("stack0")
+	httpAPI := &v1beta1.GatewayHTTPAPI{}
+	httpAPI.Name = "stack0-connectivity"
+
+	ctx := newReconcileTestContext(t, ledger, delegated, httpAPI)
+
+	stack := &v1beta1.Stack{}
+	stack.Name = "stack0"
+	connectivity := &v1beta1.Connectivity{}
+	connectivity.Name = "stack0"
+	connectivity.Spec.Stack = "stack0"
+
+	err := Reconcile(ctx, stack, connectivity, "v1.0.0")
+	if err == nil {
+		t.Fatal("Reconcile() must return a pending error when the ledger is not ready")
+	}
+	if !core.IsApplicationError(err) {
+		t.Fatalf("Reconcile() returned %v, want an application (pending) error", err)
+	}
+	if len(connectivity.Status.Conditions) == 0 || connectivity.Status.Conditions[0].Reason != "LedgerNotReady" {
+		t.Fatalf("expected a LedgerNotReady condition, got %#v", connectivity.Status.Conditions)
+	}
+
+	if !delegatedConnectivityExists(t, ctx, "stack0") {
+		t.Error("delegated Connectivity must NOT be torn down on a transient ledger-not-ready gate")
+	}
+	if !gatewayHTTPAPIExists(t, ctx, "stack0") {
+		t.Error("GatewayHTTPAPI must NOT be torn down on a transient ledger-not-ready gate")
+	}
+}
+
 func TestConnectivityReconcilePendingWhenCapabilityUnavailable(t *testing.T) {
 	previous := connectivityAvailable
 	connectivityAvailable = false

--- a/internal/resources/connectivities/init_test.go
+++ b/internal/resources/connectivities/init_test.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	"github.com/formancehq/operator/v3/api/formance.com/v1beta1"
 	"github.com/formancehq/operator/v3/internal/core"
@@ -640,6 +641,25 @@ func gatewayHTTPAPIExists(t *testing.T, ctx credsTestContext, stackName string) 
 	return err == nil
 }
 
+// newLedgerCredentialsForStack returns the cluster-scoped god-mode Credentials
+// as ensureLedgerCredentials provisions it: named "connectivity-<stack>".
+func newLedgerCredentialsForStack(stackName string) *unstructured.Unstructured {
+	cred := &unstructured.Unstructured{}
+	cred.SetGroupVersionKind(ledgerCredentialsGVK)
+	cred.SetName("connectivity-" + stackName)
+	return cred
+}
+
+// credentialsExist reports whether the cluster-scoped god-mode Credentials for
+// the stack is still present in the cluster.
+func credentialsExist(t *testing.T, ctx credsTestContext, stackName string) bool {
+	t.Helper()
+	got := &unstructured.Unstructured{}
+	got.SetGroupVersionKind(ledgerCredentialsGVK)
+	err := ctx.GetClient().Get(ctx, client.ObjectKey{Name: "connectivity-" + stackName}, got)
+	return err == nil
+}
+
 func TestConnectivityReconcileTearsDownDelegatedWhenLedgerNotV3(t *testing.T) {
 	previous := connectivityAvailable
 	connectivityAvailable = true
@@ -657,8 +677,9 @@ func TestConnectivityReconcileTearsDownDelegatedWhenLedgerNotV3(t *testing.T) {
 	delegated := newDelegatedConnectivity("stack0")
 	httpAPI := &v1beta1.GatewayHTTPAPI{}
 	httpAPI.Name = "stack0-connectivity"
+	cred := newLedgerCredentialsForStack("stack0")
 
-	ctx := newReconcileTestContext(t, ledger, delegated, httpAPI)
+	ctx := newReconcileTestContext(t, ledger, delegated, httpAPI, cred)
 
 	stack := &v1beta1.Stack{}
 	stack.Name = "stack0"
@@ -683,6 +704,9 @@ func TestConnectivityReconcileTearsDownDelegatedWhenLedgerNotV3(t *testing.T) {
 	if gatewayHTTPAPIExists(t, ctx, "stack0") {
 		t.Error("GatewayHTTPAPI must be torn down when the ledger is not v3")
 	}
+	if credentialsExist(t, ctx, "stack0") {
+		t.Error("god-mode Credentials must be torn down when the ledger is not v3")
+	}
 }
 
 func TestConnectivityReconcileKeepsDelegatedWhenLedgerV3NotReady(t *testing.T) {
@@ -701,8 +725,9 @@ func TestConnectivityReconcileKeepsDelegatedWhenLedgerV3NotReady(t *testing.T) {
 	delegated := newDelegatedConnectivity("stack0")
 	httpAPI := &v1beta1.GatewayHTTPAPI{}
 	httpAPI.Name = "stack0-connectivity"
+	cred := newLedgerCredentialsForStack("stack0")
 
-	ctx := newReconcileTestContext(t, ledger, delegated, httpAPI)
+	ctx := newReconcileTestContext(t, ledger, delegated, httpAPI, cred)
 
 	stack := &v1beta1.Stack{}
 	stack.Name = "stack0"
@@ -727,6 +752,9 @@ func TestConnectivityReconcileKeepsDelegatedWhenLedgerV3NotReady(t *testing.T) {
 	if !gatewayHTTPAPIExists(t, ctx, "stack0") {
 		t.Error("GatewayHTTPAPI must NOT be torn down on a transient ledger-not-ready gate")
 	}
+	if !credentialsExist(t, ctx, "stack0") {
+		t.Error("god-mode Credentials must NOT be torn down on a transient ledger-not-ready gate")
+	}
 }
 
 func TestConnectivityReconcilePendingWhenCapabilityUnavailable(t *testing.T) {
@@ -749,5 +777,42 @@ func TestConnectivityReconcilePendingWhenCapabilityUnavailable(t *testing.T) {
 	}
 	if len(connectivity.Status.Conditions) == 0 {
 		t.Fatal("Reconcile() must record a condition when the capability is unavailable")
+	}
+}
+
+// A failure to delete one resource during the hard teardown must not leave the
+// others behind: the public GatewayHTTPAPI and the god-mode Credentials still
+// have to be removed even when the delegated Connectivity delete fails (e.g. its
+// CRD/API was removed after startup), and the failure must surface.
+func TestTeardownDelegatedAttemptsEveryDeletion(t *testing.T) {
+	httpAPI := &v1beta1.GatewayHTTPAPI{}
+	httpAPI.Name = "stack0-connectivity"
+	cred := newLedgerCredentialsForStack("stack0")
+
+	base := newReconcileTestContext(t, httpAPI, cred)
+	failing := interceptor.NewClient(base.client.(client.WithWatch), interceptor.Funcs{
+		Delete: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.DeleteOption) error {
+			if obj.GetObjectKind().GroupVersionKind() == connectivityGVK {
+				return apierrors.NewInternalError(errors.New("delegated Connectivity delete failed"))
+			}
+			return c.Delete(ctx, obj, opts...)
+		},
+	})
+	ctx := credsTestContext{Context: context.Background(), client: failing, scheme: base.scheme}
+
+	stack := &v1beta1.Stack{}
+	stack.Name = "stack0"
+	connectivity := &v1beta1.Connectivity{}
+	connectivity.Name = "stack0"
+	connectivity.Spec.Stack = "stack0"
+
+	if err := teardownDelegated(ctx, stack, connectivity); err == nil {
+		t.Fatal("teardownDelegated must surface the delegated Connectivity delete failure")
+	}
+	if gatewayHTTPAPIExists(t, ctx, "stack0") {
+		t.Error("GatewayHTTPAPI must still be torn down when the delegated Connectivity delete fails")
+	}
+	if credentialsExist(t, ctx, "stack0") {
+		t.Error("god-mode Credentials must still be torn down when the delegated Connectivity delete fails")
 	}
 }

--- a/internal/resources/connectivities/init_test.go
+++ b/internal/resources/connectivities/init_test.go
@@ -766,8 +766,9 @@ func TestConnectivityReconcilePendingWhenCapabilityUnavailable(t *testing.T) {
 	stack.Name = "stack0"
 	connectivity := &v1beta1.Connectivity{}
 	connectivity.Name = "stack0"
+	connectivity.Spec.Stack = "stack0"
 
-	ctx := connectivityDiscoveryContext{Context: context.Background()}
+	ctx := newReconcileTestContext(t)
 	err := Reconcile(ctx, stack, connectivity, "v1.0.0")
 	if err == nil {
 		t.Fatal("Reconcile() must return a pending error when the capability is unavailable")
@@ -777,6 +778,75 @@ func TestConnectivityReconcilePendingWhenCapabilityUnavailable(t *testing.T) {
 	}
 	if len(connectivity.Status.Conditions) == 0 {
 		t.Fatal("Reconcile() must record a condition when the capability is unavailable")
+	}
+}
+
+// When the connectivity operator becomes unavailable after resources were
+// provisioned AND the ledger hard gate has since closed, the capability
+// short-circuit must not skip the teardown: the gateway route and god-mode
+// Credentials still have to be removed.
+func TestConnectivityReconcileTearsDownWhenCapabilityUnavailableAndLedgerGateClosed(t *testing.T) {
+	previous := connectivityAvailable
+	connectivityAvailable = false
+	t.Cleanup(func() { connectivityAvailable = previous })
+
+	// No ledger on the stack: the hard gate is closed.
+	httpAPI := &v1beta1.GatewayHTTPAPI{}
+	httpAPI.Name = "stack0-connectivity"
+	cred := newLedgerCredentialsForStack("stack0")
+
+	ctx := newReconcileTestContext(t, httpAPI, cred)
+
+	stack := &v1beta1.Stack{}
+	stack.Name = "stack0"
+	connectivity := &v1beta1.Connectivity{}
+	connectivity.Name = "stack0"
+	connectivity.Spec.Stack = "stack0"
+
+	if err := Reconcile(ctx, stack, connectivity, "v1.0.0"); !core.IsApplicationError(err) {
+		t.Fatalf("Reconcile() returned %v, want an application (pending) error", err)
+	}
+	if gatewayHTTPAPIExists(t, ctx, "stack0") {
+		t.Error("GatewayHTTPAPI must be torn down when the capability is unavailable and the ledger gate is closed")
+	}
+	if credentialsExist(t, ctx, "stack0") {
+		t.Error("god-mode Credentials must be torn down when the capability is unavailable and the ledger gate is closed")
+	}
+}
+
+// A transient connectivity-operator outage with a healthy v3 ledger (gate still
+// open) must NOT flap the already-provisioned resources.
+func TestConnectivityReconcileKeepsResourcesWhenCapabilityUnavailableButLedgerV3(t *testing.T) {
+	previous := connectivityAvailable
+	connectivityAvailable = false
+	t.Cleanup(func() { connectivityAvailable = previous })
+
+	ledger := &v1beta1.Ledger{}
+	ledger.Name = "stack0-ledger"
+	ledger.Spec.Stack = "stack0"
+	ledger.Spec.Version = "v3.0.0"
+	ledger.Status.Ready = true
+
+	httpAPI := &v1beta1.GatewayHTTPAPI{}
+	httpAPI.Name = "stack0-connectivity"
+	cred := newLedgerCredentialsForStack("stack0")
+
+	ctx := newReconcileTestContext(t, ledger, httpAPI, cred)
+
+	stack := &v1beta1.Stack{}
+	stack.Name = "stack0"
+	connectivity := &v1beta1.Connectivity{}
+	connectivity.Name = "stack0"
+	connectivity.Spec.Stack = "stack0"
+
+	if err := Reconcile(ctx, stack, connectivity, "v1.0.0"); !core.IsApplicationError(err) {
+		t.Fatalf("Reconcile() returned %v, want an application (pending) error", err)
+	}
+	if !gatewayHTTPAPIExists(t, ctx, "stack0") {
+		t.Error("GatewayHTTPAPI must be kept while the ledger gate is still open")
+	}
+	if !credentialsExist(t, ctx, "stack0") {
+		t.Error("Credentials must be kept while the ledger gate is still open")
 	}
 }
 


### PR DESCRIPTION
When a stack had already provisioned the delegated Connectivity and its
GatewayHTTPAPI, closing a hard Ledger gate on a later reconcile only set a
pending condition and returned; the delegated workload kept running and stayed
exposed through the gateway even though its prerequisite no longer held.

Introduce teardownDelegated(ctx, stack, connectivity), which idempotently
deletes both the delegated Connectivity and the GatewayHTTPAPI
(client.IgnoreNotFound). Call it from the hard/persistent gates only:

- LedgerNotFound  (module removed)      -> teardown
- LedgerNotV3     (real downgrade)      -> teardown

Leave the transient gates untouched so a momentary blip does not flap the
workload:

- LedgerVersionUnresolved (resolution error, not a downgrade) -> keep
- LedgerNotReady          (v3 but momentarily not ready)      -> keep

Add unit tests covering both the teardown-on-not-v3 and keep-on-v3-not-ready
paths.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>