### PR TITLE
fix(ledger): resolve configured gRPC port in V3GRPCBackendRef

### DIFF
--- a/internal/resources/connectivities/init.go
+++ b/internal/resources/connectivities/init.go
@@ -211,8 +211,14 @@ func Reconcile(ctx Context, stack *v1beta1.Stack, connectivity *v1beta1.Connecti
 
 	// Reuse the single source of truth for the ledger v3 gRPC connection: same
 	// service, port and backend TLS material (self-signed CA secret + SNI) that
-	// the gateway uses to reach the ledger.
-	backend := ledgers.V3GRPCBackendRef(stack.Name)
+	// the gateway uses to reach the ledger. The port is resolved from the stack's
+	// LedgerConfiguration so a stack overriding spec.cluster.service.grpcPort
+	// stays reachable, consistently with the gateway backend.
+	backend, err := ledgers.V3GRPCBackendRef(ctx, stack.Name)
+	if err != nil {
+		setCondition(connectivity, metav1.ConditionFalse, "LedgerBackendResolveFailed", err.Error())
+		return err
+	}
 	ledgerAddress := fmt.Sprintf("%s:%d", backend.TLS.ServerName, backend.Port)
 
 	object := &unstructured.Unstructured{}

--- a/internal/resources/ledgers/exports.go
+++ b/internal/resources/ledgers/exports.go
@@ -18,6 +18,7 @@ package ledgers
 
 import (
 	"github.com/formancehq/operator/v3/api/formance.com/v1beta1"
+	"github.com/formancehq/operator/v3/internal/core"
 )
 
 // IsV3 reports whether the given ledger version resolves to a Ledger v3 (or
@@ -30,9 +31,15 @@ func IsV3(version string) bool {
 // V3GRPCBackendRef returns the connection details of the ledger v3 gRPC service
 // for the given stack: service name, port, and backend TLS material
 // (self-signed CA secret and SNI server name). It is the single source of
-// truth for how in-cluster clients reach the ledger v3 gRPC endpoint. The
-// default gRPC service port is assumed; stacks overriding the ledger Cluster
-// service port are not reachable through this helper.
-func V3GRPCBackendRef(stackName string) v1beta1.GatewayBackendRef {
-	return ledgerV3GRPCBackendRef(stackName, 0)
+// truth for how in-cluster clients reach the ledger v3 gRPC endpoint. The gRPC
+// service port is resolved from the stack's LedgerConfiguration
+// (spec.cluster.service.grpcPort) exactly as the gateway backend resolves it,
+// so stacks overriding the ledger Cluster service port stay reachable through
+// this helper; it falls back to the default gRPC port when unset.
+func V3GRPCBackendRef(ctx core.Context, stackName string) (v1beta1.GatewayBackendRef, error) {
+	baseSpec, err := ledgerV3BaseSpec(ctx, stackName)
+	if err != nil {
+		return v1beta1.GatewayBackendRef{}, err
+	}
+	return ledgerV3GRPCBackendRef(stackName, baseSpec.Service.GrpcPort), nil
 }

--- a/internal/resources/ledgers/exports_test.go
+++ b/internal/resources/ledgers/exports_test.go
@@ -1,0 +1,111 @@
+package ledgers
+
+import (
+	"context"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	ledgerv1alpha1 "github.com/formancehq/ledger/misc/operator/api/v1alpha1"
+
+	"github.com/formancehq/operator/v3/api/formance.com/v1beta1"
+)
+
+func newExportsContext(t *testing.T, objects ...client.Object) ledgerV3DiscoveryContext {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	if err := v1beta1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	kubernetesClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithIndex(&v1beta1.LedgerConfiguration{}, "stack", func(object client.Object) []string {
+			return object.(*v1beta1.LedgerConfiguration).GetStacks()
+		}).
+		WithObjects(objects...).
+		Build()
+	return ledgerV3DiscoveryContext{Context: context.Background(), client: kubernetesClient}
+}
+
+func ledgerConfiguration(name string, grpcPort int32, stacks ...string) *v1beta1.LedgerConfiguration {
+	return &v1beta1.LedgerConfiguration{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec: v1beta1.LedgerConfigurationSpec{
+			Stacks: stacks,
+			Cluster: ledgerv1alpha1.ClusterSpec{
+				Service: ledgerv1alpha1.ServiceSpec{GrpcPort: grpcPort},
+			},
+		},
+	}
+}
+
+// TestV3GRPCBackendRefHonoursConfiguredGrpcPort proves the connectivity-facing
+// export resolves the same gRPC port as the gateway backend
+// (LedgerConfiguration spec.cluster.service.grpcPort), rather than always
+// defaulting to the standard port.
+func TestV3GRPCBackendRefHonoursConfiguredGrpcPort(t *testing.T) {
+	t.Parallel()
+
+	const stackName = "stack0"
+	tests := []struct {
+		name     string
+		objects  []client.Object
+		wantPort int32
+	}{
+		{
+			name:     "defaults to the standard gRPC port without a configuration",
+			wantPort: ledgerV3GRPCPort,
+		},
+		{
+			name:     "defaults to the standard gRPC port when grpcPort is unset",
+			objects:  []client.Object{ledgerConfiguration("default", 0, stackName)},
+			wantPort: ledgerV3GRPCPort,
+		},
+		{
+			name:     "honours the stack LedgerConfiguration override",
+			objects:  []client.Object{ledgerConfiguration("default", 7777, stackName)},
+			wantPort: 7777,
+		},
+		{
+			name:     "honours a wildcard LedgerConfiguration override",
+			objects:  []client.Object{ledgerConfiguration("wildcard", 6666, "*")},
+			wantPort: 6666,
+		},
+		{
+			name: "stack-scoped configuration takes priority over the wildcard",
+			objects: []client.Object{
+				ledgerConfiguration("wildcard", 6666, "*"),
+				ledgerConfiguration("scoped", 7777, stackName),
+			},
+			wantPort: 7777,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := newExportsContext(t, tt.objects...)
+
+			backend, err := V3GRPCBackendRef(ctx, stackName)
+			if err != nil {
+				t.Fatalf("V3GRPCBackendRef() returned error: %v", err)
+			}
+			if backend.Port != tt.wantPort {
+				t.Fatalf("V3GRPCBackendRef() port = %d, want %d", backend.Port, tt.wantPort)
+			}
+			if wantName := "ledger-" + stackName; backend.Name != wantName {
+				t.Fatalf("V3GRPCBackendRef() name = %q, want %q", backend.Name, wantName)
+			}
+			if backend.TLS == nil {
+				t.Fatal("V3GRPCBackendRef() must carry backend TLS material")
+			}
+			if wantServerName := "ledger-" + stackName + "." + stackName + ".svc.cluster.local"; backend.TLS.ServerName != wantServerName {
+				t.Fatalf("V3GRPCBackendRef() server name = %q, want %q", backend.TLS.ServerName, wantServerName)
+			}
+		})
+	}
+}


### PR DESCRIPTION
V3GRPCBackendRef, the single source of truth consumed by the
connectivity module to build its ledgerAddress, always passed port 0 to
ledgerV3GRPCBackendRef and therefore assumed the default gRPC port. The
gateway backend (v3.go / v3_preview.go) instead resolves the port from
the stack LedgerConfiguration (spec.cluster.service.grpcPort), so a stack
overriding the ledger Cluster gRPC service port got a Connectivity
pointed at the wrong port while the gateway stayed correct.

Resolve the configured port from the LedgerConfiguration inside
V3GRPCBackendRef (via ledgerV3BaseSpec, the same base the gateway derives
its clusterSpec from) so both consumers honour the override and fall back
to the default port when unset. Thread the reconciler Context through the
export and its connectivity caller.

Add a table-driven unit test covering default, stack-scoped, wildcard,
and precedence cases.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>