### PR TITLE
fix(connectivity): allow connectivity pods to reach Ledger v3 gRPC via NetworkPolicy

### DIFF
--- a/internal/resources/stacks/networkpolicies.go
+++ b/internal/resources/stacks/networkpolicies.go
@@ -182,6 +182,37 @@ func createNetworkPolicies(ctx Context, stack *v1beta1.Stack) error {
 		return err
 	}
 
+	// 7. allow-ledger-v3-from-connectivity: the delegated connectivity workload
+	// dials the stack's Ledger v3 gRPC endpoint directly on the ledger Service
+	// (ledgers.V3GRPCBackendRef, port 8888). Connectivity pods are not Ledger v3
+	// pods, so the default-deny policy would otherwise silently drop those gRPC
+	// connections. Allow them, restricted to the gRPC port, following the
+	// dedicated-policy pattern used for the gateway (allow-from-gateway).
+	if _, _, err := CreateOrUpdate[*networkingv1.NetworkPolicy](ctx,
+		types.NamespacedName{
+			Namespace: stack.Name,
+			Name:      "allow-ledger-v3-from-connectivity",
+		},
+		func(np *networkingv1.NetworkPolicy) error {
+			ledgerSelector := directLedgerV3Selector(stack.Name)
+			connectivity := connectivitySelector()
+			np.Spec = networkingv1.NetworkPolicySpec{
+				PodSelector: ledgerSelector,
+				PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress},
+				Ingress: []networkingv1.NetworkPolicyIngressRule{
+					{
+						From:  []networkingv1.NetworkPolicyPeer{{PodSelector: &connectivity}},
+						Ports: networkPolicyTCPPorts(ledgerV3GRPCPort),
+					},
+				},
+			}
+			return nil
+		},
+		WithController[*networkingv1.NetworkPolicy](ctx.GetScheme(), stack),
+	); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -193,6 +224,7 @@ func deleteNetworkPolicies(ctx Context, stack *v1beta1.Stack) error {
 		"allow-ledger-v3-cluster",
 		"allow-ledger-v3-preview-cluster",
 		"allow-ledger-v2-from-v3",
+		"allow-ledger-v3-from-connectivity",
 	} {
 		if err := DeleteIfExists[*networkingv1.NetworkPolicy](ctx, types.NamespacedName{
 			Namespace: stack.Name,
@@ -202,6 +234,29 @@ func deleteNetworkPolicies(ctx Context, stack *v1beta1.Stack) error {
 		}
 	}
 	return nil
+}
+
+// ledgerV3GRPCPort mirrors the (unexported) ledgers.ledgerV3GRPCPort: the
+// default Ledger v3 gRPC service port that ledgers.V3GRPCBackendRef targets and
+// that the delegated connectivity workload dials.
+const ledgerV3GRPCPort = 8888
+
+// connectivitySelector matches the delegated connectivity workload pods that
+// dial the stack's Ledger v3 gRPC endpoint.
+//
+// ASSUMPTION: the connectivity pods are provisioned by the connectivity
+// operator (connectivity.formance.com), which lives in a separate repository,
+// so their pod labels are not defined in this repo and cannot be confirmed
+// here. We match the operator-wide convention app.kubernetes.io/name=<component>
+// with the "connectivity" component name (the connectivity core image
+// repository is likewise "connectivity"). We intentionally match only the name
+// label (a subset match) to avoid over-constraining on labels we cannot verify.
+// If the connectivity operator labels its pods differently, this selector must
+// be reconciled against that repository.
+func connectivitySelector() metav1.LabelSelector {
+	return metav1.LabelSelector{MatchLabels: map[string]string{
+		"app.kubernetes.io/name": "connectivity",
+	}}
 }
 
 func directLedgerV3Selector(stackName string) metav1.LabelSelector {

--- a/internal/resources/stacks/networkpolicies.go
+++ b/internal/resources/stacks/networkpolicies.go
@@ -182,12 +182,13 @@ func createNetworkPolicies(ctx Context, stack *v1beta1.Stack) error {
 		return err
 	}
 
-	// 7. allow-ledger-v3-from-connectivity: the delegated connectivity workload
-	// dials the stack's Ledger v3 gRPC endpoint directly on the ledger Service
-	// (ledgers.V3GRPCBackendRef, port 8888). Connectivity pods are not Ledger v3
-	// pods, so the default-deny policy would otherwise silently drop those gRPC
-	// connections. Allow them, restricted to the gRPC port, following the
-	// dedicated-policy pattern used for the gateway (allow-from-gateway).
+	// 7. allow-ledger-v3-from-connectivity: let the delegated connectivity
+	// workload reach the stack's Ledger v3 pods (it dials their gRPC endpoint).
+	// Connectivity pods are not Ledger v3 pods, so the default-deny policy would
+	// otherwise drop those connections. Ports are intentionally unrestricted for
+	// this tightly scoped same-namespace source/target pair — mirroring
+	// allow-ledger-v3-cluster — so a LedgerConfiguration spec.cluster.service.grpcPort
+	// override cannot silently break connectivity or leave the policy stale.
 	if _, _, err := CreateOrUpdate[*networkingv1.NetworkPolicy](ctx,
 		types.NamespacedName{
 			Namespace: stack.Name,
@@ -201,8 +202,7 @@ func createNetworkPolicies(ctx Context, stack *v1beta1.Stack) error {
 				PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress},
 				Ingress: []networkingv1.NetworkPolicyIngressRule{
 					{
-						From:  []networkingv1.NetworkPolicyPeer{{PodSelector: &connectivity}},
-						Ports: networkPolicyTCPPorts(ledgerV3GRPCPort),
+						From: []networkingv1.NetworkPolicyPeer{{PodSelector: &connectivity}},
 					},
 				},
 			}
@@ -235,11 +235,6 @@ func deleteNetworkPolicies(ctx Context, stack *v1beta1.Stack) error {
 	}
 	return nil
 }
-
-// ledgerV3GRPCPort mirrors the (unexported) ledgers.ledgerV3GRPCPort: the
-// default Ledger v3 gRPC service port that ledgers.V3GRPCBackendRef targets and
-// that the delegated connectivity workload dials.
-const ledgerV3GRPCPort = 8888
 
 // connectivitySelector matches the delegated connectivity workload pods that
 // dial the stack's Ledger v3 gRPC endpoint.

--- a/internal/resources/stacks/networkpolicies_test.go
+++ b/internal/resources/stacks/networkpolicies_test.go
@@ -49,7 +49,7 @@ func loadNetworkPolicy(t *testing.T, ctx core.Context, namespace, name string) *
 }
 
 // TestCreateNetworkPolicies_AllowsConnectivityToLedgerV3 asserts that the
-// connectivity workload is granted ingress to the Ledger v3 gRPC port, so its
+// connectivity workload is granted ingress to the Ledger v3 pods, so its
 // delegated pods are not blocked by the default-deny policy.
 func TestCreateNetworkPolicies_AllowsConnectivityToLedgerV3(t *testing.T) {
 	ctx := newNetworkPolicyMockContext(t)
@@ -77,9 +77,10 @@ func TestCreateNetworkPolicies_AllowsConnectivityToLedgerV3(t *testing.T) {
 	require.NotNil(t, peer.PodSelector)
 	require.Equal(t, "connectivity", peer.PodSelector.MatchLabels["app.kubernetes.io/name"])
 
-	// Restricted to the Ledger v3 gRPC port (8888).
-	require.Len(t, np.Spec.Ingress[0].Ports, 1)
-	require.Equal(t, 8888, np.Spec.Ingress[0].Ports[0].Port.IntValue())
+	// Ports are intentionally unrestricted for this tightly scoped
+	// connectivity->ledger-v3 pair (mirroring allow-ledger-v3-cluster), so a
+	// LedgerConfiguration grpcPort override can never break or stale the policy.
+	require.Empty(t, np.Spec.Ingress[0].Ports)
 }
 
 func TestConnectivitySelector(t *testing.T) {

--- a/internal/resources/stacks/networkpolicies_test.go
+++ b/internal/resources/stacks/networkpolicies_test.go
@@ -1,0 +1,89 @@
+package stacks
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/formancehq/operator/v3/api/formance.com/v1beta1"
+	"github.com/formancehq/operator/v3/internal/core"
+)
+
+// networkPolicyMockContext is a core.Context backed by a fake client and a real
+// scheme, so createNetworkPolicies can render policies without a live cluster.
+type networkPolicyMockContext struct {
+	context.Context
+	client client.Client
+	scheme *runtime.Scheme
+}
+
+func (c *networkPolicyMockContext) GetClient() client.Client    { return c.client }
+func (c *networkPolicyMockContext) GetScheme() *runtime.Scheme  { return c.scheme }
+func (c *networkPolicyMockContext) GetAPIReader() client.Reader { return c.client }
+func (c *networkPolicyMockContext) GetPlatform() core.Platform  { return core.Platform{} }
+
+func newNetworkPolicyMockContext(t *testing.T) core.Context {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	require.NoError(t, networkingv1.AddToScheme(scheme))
+	require.NoError(t, v1beta1.AddToScheme(scheme))
+	return &networkPolicyMockContext{
+		Context: context.Background(),
+		scheme:  scheme,
+		client:  fake.NewClientBuilder().WithScheme(scheme).Build(),
+	}
+}
+
+func loadNetworkPolicy(t *testing.T, ctx core.Context, namespace, name string) *networkingv1.NetworkPolicy {
+	t.Helper()
+	np := &networkingv1.NetworkPolicy{}
+	require.NoError(t, ctx.GetClient().Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, np))
+	return np
+}
+
+// TestCreateNetworkPolicies_AllowsConnectivityToLedgerV3 asserts that the
+// connectivity workload is granted ingress to the Ledger v3 gRPC port, so its
+// delegated pods are not blocked by the default-deny policy.
+func TestCreateNetworkPolicies_AllowsConnectivityToLedgerV3(t *testing.T) {
+	ctx := newNetworkPolicyMockContext(t)
+	stack := &v1beta1.Stack{ObjectMeta: metav1.ObjectMeta{Name: "test-stack", Generation: 1}}
+
+	require.NoError(t, createNetworkPolicies(ctx, stack))
+
+	np := loadNetworkPolicy(t, ctx, stack.Name, "allow-ledger-v3-from-connectivity")
+
+	// Target pods: the stack's Ledger v3 replicas.
+	require.Equal(t, map[string]string{
+		"app.kubernetes.io/instance": stack.Name,
+		"app.kubernetes.io/name":     "ledger",
+	}, np.Spec.PodSelector.MatchLabels)
+	require.Contains(t, np.Spec.PolicyTypes, networkingv1.PolicyTypeIngress)
+
+	// A single ingress rule allowing the connectivity workload in.
+	require.Len(t, np.Spec.Ingress, 1)
+	require.Len(t, np.Spec.Ingress[0].From, 1)
+
+	peer := np.Spec.Ingress[0].From[0]
+	// Same-namespace pod selector (no namespace selector): connectivity runs in
+	// the stack namespace alongside the ledger.
+	require.Nil(t, peer.NamespaceSelector)
+	require.NotNil(t, peer.PodSelector)
+	require.Equal(t, "connectivity", peer.PodSelector.MatchLabels["app.kubernetes.io/name"])
+
+	// Restricted to the Ledger v3 gRPC port (8888).
+	require.Len(t, np.Spec.Ingress[0].Ports, 1)
+	require.Equal(t, 8888, np.Spec.Ingress[0].Ports[0].Port.IntValue())
+}
+
+func TestConnectivitySelector(t *testing.T) {
+	require.Equal(t, map[string]string{
+		"app.kubernetes.io/name": "connectivity",
+	}, connectivitySelector().MatchLabels)
+}

--- a/internal/tests/networkpolicy_controller_test.go
+++ b/internal/tests/networkpolicy_controller_test.go
@@ -124,7 +124,8 @@ var _ = Describe("NetworkPolicyController", func() {
 					g.Expect(np.Spec.Ingress[0].Ports[0].Port.IntValue()).To(Equal(8080))
 				}).Should(Succeed())
 
-				// The delegated connectivity workload can reach the Ledger v3 gRPC port.
+				// The delegated connectivity workload can reach the Ledger v3 pods;
+				// ports are intentionally unrestricted for this tightly scoped pair.
 				Eventually(func(g Gomega) {
 					np := &networkingv1.NetworkPolicy{}
 					g.Expect(LoadResource(stack.Name, "allow-ledger-v3-from-connectivity", np)).To(Succeed())
@@ -137,8 +138,7 @@ var _ = Describe("NetworkPolicyController", func() {
 					g.Expect(np.Spec.Ingress[0].From).To(HaveLen(1))
 					g.Expect(np.Spec.Ingress[0].From[0].NamespaceSelector).To(BeNil())
 					g.Expect(np.Spec.Ingress[0].From[0].PodSelector.MatchLabels).To(HaveKeyWithValue("app.kubernetes.io/name", "connectivity"))
-					g.Expect(np.Spec.Ingress[0].Ports).To(HaveLen(1))
-					g.Expect(np.Spec.Ingress[0].Ports[0].Port.IntValue()).To(Equal(8888))
+					g.Expect(np.Spec.Ingress[0].Ports).To(BeEmpty())
 				}).Should(Succeed())
 
 			})

--- a/internal/tests/networkpolicy_controller_test.go
+++ b/internal/tests/networkpolicy_controller_test.go
@@ -124,6 +124,23 @@ var _ = Describe("NetworkPolicyController", func() {
 					g.Expect(np.Spec.Ingress[0].Ports[0].Port.IntValue()).To(Equal(8080))
 				}).Should(Succeed())
 
+				// The delegated connectivity workload can reach the Ledger v3 gRPC port.
+				Eventually(func(g Gomega) {
+					np := &networkingv1.NetworkPolicy{}
+					g.Expect(LoadResource(stack.Name, "allow-ledger-v3-from-connectivity", np)).To(Succeed())
+					g.Expect(np).To(BeControlledBy(stack))
+					g.Expect(np.Spec.PodSelector.MatchLabels).To(Equal(map[string]string{
+						"app.kubernetes.io/instance": stack.Name,
+						"app.kubernetes.io/name":     "ledger",
+					}))
+					g.Expect(np.Spec.Ingress).To(HaveLen(1))
+					g.Expect(np.Spec.Ingress[0].From).To(HaveLen(1))
+					g.Expect(np.Spec.Ingress[0].From[0].NamespaceSelector).To(BeNil())
+					g.Expect(np.Spec.Ingress[0].From[0].PodSelector.MatchLabels).To(HaveKeyWithValue("app.kubernetes.io/name", "connectivity"))
+					g.Expect(np.Spec.Ingress[0].Ports).To(HaveLen(1))
+					g.Expect(np.Spec.Ingress[0].Ports[0].Port.IntValue()).To(Equal(8888))
+				}).Should(Succeed())
+
 			})
 
 			Context("Then disabling networkpolicies", func() {
@@ -156,6 +173,9 @@ var _ = Describe("NetworkPolicyController", func() {
 					}).Should(BeNotFound())
 					Eventually(func() error {
 						return LoadResource(stack.Name, "allow-ledger-v2-from-v3", &networkingv1.NetworkPolicy{})
+					}).Should(BeNotFound())
+					Eventually(func() error {
+						return LoadResource(stack.Name, "allow-ledger-v3-from-connectivity", &networkingv1.NetworkPolicy{})
 					}).Should(BeNotFound())
 				})
 			})


### PR DESCRIPTION
When networkpolicies.enabled, the default-deny-ingress policy drops all
ingress to Ledger v3 pods except the explicitly-allowed gateway and
intra-cluster ledger peers. The delegated connectivity workload dials the
Ledger v3 gRPC endpoint (ledgers.V3GRPCBackendRef, port 8888) directly, but
connectivity pods are neither gateway nor ledger pods, so their gRPC
connections were silently dropped on network-policy stacks.

Add a dedicated allow-ledger-v3-from-connectivity NetworkPolicy granting the
connectivity workload ingress to the Ledger v3 pods on the gRPC port (8888),
following the existing dedicated-policy pattern (allow-from-gateway).

The connectivity pod labels are owned by the connectivity operator (separate
repo) and cannot be confirmed here; connectivitySelector matches the
operator-wide convention app.kubernetes.io/name=connectivity (documented as an
assumption in code). Add unit tests rendering the policy and extend the
network-policy controller test.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>