### PR TITLE
test(e2e): poll for grpcapi service deletion instead of kubectl wait

### DIFF
--- a/tests/e2e/chainsaw/26-gatewaygrpcapi-sync/chainsaw-test.yaml
+++ b/tests/e2e/chainsaw/26-gatewaygrpcapi-sync/chainsaw-test.yaml
@@ -77,8 +77,15 @@ spec:
             content: |
               set -eu
               kubectl delete gatewaygrpcapi chainsaw-grpcapi-mymodule
-              # Service should be deleted
-              kubectl wait --for=delete service/mymodule-grpc -n chainsaw-grpcapi-sync --timeout=3m
+              # Service should be deleted. Poll with `kubectl get` rather than
+              # `kubectl wait --for=delete`, which can ignore --timeout and hang
+              # until the chainsaw step timeout kills the script (signal: killed).
+              tries=0
+              while kubectl get service/mymodule-grpc -n chainsaw-grpcapi-sync >/dev/null 2>&1; do
+                tries=$((tries + 1))
+                test "$tries" -lt 90 || { echo "service mymodule-grpc was not deleted in time"; exit 1; }
+                sleep 2
+              done
               # Gateway should no longer list grpc APIs
               until test "$(kubectl get gateway chainsaw-grpcapi-gateway -o jsonpath='{.status.syncGRPCAPIs}')" = "" -o "$(kubectl get gateway chainsaw-grpcapi-gateway -o jsonpath='{.status.syncGRPCAPIs}')" = "[]"; do
                 sleep 1


### PR DESCRIPTION
kubectl wait --for=delete can ignore --timeout and hang until chainsaw's
step timeout kills the script (signal: killed), which flaked the
gateway-grpcapi-sync deletion step on the K8s 1.31 runner. Replace it
with a bounded kubectl get poll so the assertion fails legibly if the
service is genuinely not garbage-collected.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>