### PR TITLE
chore(release): prepare v3.13.0

### DIFF
--- a/api/formance.com/v1beta1/reconciliation_types.go
+++ b/api/formance.com/v1beta1/reconciliation_types.go
@@ -21,7 +21,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-const ReconciliationV3Version = "v3.0.0-0"
+const ReconciliationV3Version = "v2.4.0"
 
 type ReconciliationSpec struct {
 	StackDependency  `json:",inline"`

--- a/api/formance.com/v1beta1/reconciliation_types_test.go
+++ b/api/formance.com/v1beta1/reconciliation_types_test.go
@@ -4,12 +4,13 @@ import "testing"
 
 func TestReconciliationPublishesEvents(t *testing.T) {
 	tests := map[string]bool{
-		"v2.3.1":         false,
-		"v3.0.0-0":       true,
-		"v3.0.0-alpha.1": true,
-		"v3.0.0-rc.1":    true,
-		"v3.0.0":         true,
-		"main":           true,
+		"v2.3.1":      false,
+		"v2.4.0-rc.1": false,
+		"v2.4.0":      true,
+		"v2.4.1":      true,
+		"v3.0.0-0":    true,
+		"v3.0.0":      true,
+		"main":        true,
 	}
 
 	reconciliation := Reconciliation{}

--- a/helm/crds/Chart.yaml
+++ b/helm/crds/Chart.yaml
@@ -13,9 +13,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: "3.12.1"
+version: "3.13.0"
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v3.12.1"
+appVersion: "v3.13.0"

--- a/helm/operator/Chart.lock
+++ b/helm/operator/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: operator-crds
   repository: file://../crds
-  version: 3.12.1
-digest: sha256:fc93d6068b4831109c346c284242e95a391a8617a0c3278efcd0f3225a6cc732
-generated: "2026-07-14T15:10:55.16729+02:00"
+  version: 3.13.0
+digest: sha256:cc6f37a5e0e02d1e16c67c6bb54af11f600011d70b18de175158261ac7740d8a
+generated: "2026-08-03T15:49:18.491532+02:00"

--- a/helm/operator/Chart.yaml
+++ b/helm/operator/Chart.yaml
@@ -13,12 +13,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: "3.12.1"
+version: "3.13.0"
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v3.12.1"
+appVersion: "v3.13.0"
 dependencies:
 - name: operator-crds
   version: "3.X"

--- a/internal/core/publisher_test.go
+++ b/internal/core/publisher_test.go
@@ -19,12 +19,16 @@ func TestListEventPublishersFiltersVersionedPublishers(t *testing.T) {
 		reconciliationVersion string
 		expectedServices      []string
 	}{
-		"v2 reconciliation is excluded": {
+		"v2.3 reconciliation is excluded": {
 			reconciliationVersion: "v2.3.1",
 			expectedServices:      []string{"Ledger", "Payments"},
 		},
-		"v3 prerelease reconciliation is included": {
-			reconciliationVersion: "v3.0.0-alpha.1",
+		"v2.4 prerelease reconciliation is excluded": {
+			reconciliationVersion: "v2.4.0-rc.1",
+			expectedServices:      []string{"Ledger", "Payments"},
+		},
+		"v2.4 reconciliation is included": {
+			reconciliationVersion: "v2.4.0",
 			expectedServices:      []string{"Ledger", "Payments", "Reconciliation"},
 		},
 		"main reconciliation is included": {

--- a/internal/resources/reconciliations/init_test.go
+++ b/internal/resources/reconciliations/init_test.go
@@ -10,14 +10,15 @@ import (
 
 func TestUsesV3Topology(t *testing.T) {
 	tests := map[string]bool{
-		"v2.3.1":         false,
-		"v2.3.1-rc.1":    false,
-		"v3.0.0-0":       true,
-		"v3.0.0-alpha.1": true,
-		"v3.0.0-rc.1":    true,
-		"v3.0.0":         true,
-		"v3.1.0":         true,
-		"main":           true,
+		"v2.3.1":      false,
+		"v2.3.1-rc.1": false,
+		"v2.4.0-rc.1": false,
+		"v2.4.0":      true,
+		"v2.4.1":      true,
+		"v3.0.0-0":    true,
+		"v3.0.0":      true,
+		"v3.1.0":      true,
+		"main":        true,
 	}
 	for version, expected := range tests {
 		t.Run(version, func(t *testing.T) {


### PR DESCRIPTION
## What changed

- bump the `operator` and `operator-crds` Helm charts to `3.13.0`
- set both chart app versions to `v3.13.0`
- regenerate the Operator chart dependency lock
- move the Reconciliation v3-topology and event-publisher threshold from `v3.0.0-0` to the released `v2.4.0`
- cover the `v2.4.0-rc.1`, `v2.4.0`, and later-version boundaries in unit and publisher-filter tests

## Why

The new Reconciliation topology was ultimately released as `v2.4.0`. Keeping the threshold at `v3.0.0-0` caused released `v2.4.x` versions to use the legacy topology and excluded Reconciliation from event publishers.

## Impact

Reconciliation `v2.4.0+` now uses the new API/worker topology and participates in event publishing. Prereleases below the final `v2.4.0` tag continue to use the legacy behavior.

The Helm artifacts are ready to be published by tagging the merged commit as `v3.13.0`.

## Validation

- `nix develop --impure --command just pre-commit`
- `nix develop --impure --command just tests` — 14 suites, 134 specs
- targeted tests for the API version gate, publisher filtering, and Reconciliation topology
- Helm lint and template generation through `just pre-commit`
- GitNexus impact and staged change detection — low risk
- `git diff --check`

## Note

`goreleaser check` recognizes the current configuration as valid but exits non-zero because the existing shared configuration still uses deprecated GoReleaser properties.