### PR TITLE
refactor(connectivity): name the delegated resource "connectivity"

### DIFF
--- a/internal/resources/connectivities/init.go
+++ b/internal/resources/connectivities/init.go
@@ -49,6 +49,11 @@ import (
 
 const (
 	connectivityReadyCondition = "ConnectivityClusterReady"
+	// connectivityDelegatedName is the fixed name of the delegated
+	// connectivity.formance.com/Connectivity resource. It is namespaced (one per
+	// stack namespace), so a constant name stays unique per stack; the connectivity
+	// operator derives its API Service name from it ("connectivity-api").
+	connectivityDelegatedName = "connectivity"
 	// connectivityAPIPort is the port the connectivity-api HTTP server (and its
 	// Service, provisioned by the connectivity operator) listens on.
 	connectivityAPIPort = int32(8080)
@@ -224,7 +229,7 @@ func Reconcile(ctx Context, stack *v1beta1.Stack, connectivity *v1beta1.Connecti
 	object := &unstructured.Unstructured{}
 	object.SetGroupVersionKind(connectivityGVK)
 	object.SetNamespace(stack.Name)
-	object.SetName(stack.Name)
+	object.SetName(connectivityDelegatedName)
 	if _, err := controllerutil.CreateOrUpdate(ctx, ctx.GetClient(), object, func() error {
 		if err := controllerutil.SetControllerReference(connectivity, object, ctx.GetScheme()); err != nil {
 			return err
@@ -280,10 +285,10 @@ func Reconcile(ctx Context, stack *v1beta1.Stack, connectivity *v1beta1.Connecti
 	}
 
 	// Expose the connectivity-api through the stack gateway: routes
-	// /api/connectivity to the connectivity-api Service (named "<stack>-api")
+	// /api/connectivity to the connectivity-api Service (named "connectivity-api")
 	// the connectivity operator provisions for the delegated Connectivity.
 	if err := gatewayhttpapis.Create(ctx, connectivity,
-		gatewayhttpapis.WithRules(gatewayhttpapis.RuleSecuredWithBackend("", connectivityAPIBackendRef(stack.Name))),
+		gatewayhttpapis.WithRules(gatewayhttpapis.RuleSecuredWithBackend("", connectivityAPIBackendRef())),
 	); err != nil {
 		setCondition(connectivity, metav1.ConditionFalse, "GatewayReconcileFailed", err.Error())
 		return err
@@ -317,7 +322,7 @@ func teardownDelegated(ctx Context, stack *v1beta1.Stack, connectivity *v1beta1.
 	delegated := &unstructured.Unstructured{}
 	delegated.SetGroupVersionKind(connectivityGVK)
 	delegated.SetNamespace(stack.Name)
-	delegated.SetName(stack.Name)
+	delegated.SetName(connectivityDelegatedName)
 
 	httpAPI := &v1beta1.GatewayHTTPAPI{}
 	httpAPI.SetName(GetObjectName(connectivity.GetStack(), LowerCaseKind(ctx, connectivity)))
@@ -369,12 +374,11 @@ func ledgerGateClosed(ctx Context, stack *v1beta1.Stack) bool {
 }
 
 // connectivityAPIBackendRef points the gateway at the connectivity-api Service
-// the connectivity operator provisions for the delegated Connectivity, which is
-// named "<connectivity-name>-api" (the delegated resource is named after the
-// stack).
-func connectivityAPIBackendRef(stackName string) v1beta1.GatewayBackendRef {
+// the connectivity operator provisions for the delegated Connectivity. It is
+// named "<delegated-name>-api", i.e. "connectivity-api".
+func connectivityAPIBackendRef() v1beta1.GatewayBackendRef {
 	return v1beta1.GatewayBackendRef{
-		Name: stackName + "-api",
+		Name: connectivityDelegatedName + "-api",
 		Port: connectivityAPIPort,
 	}
 }

--- a/internal/resources/connectivities/init_test.go
+++ b/internal/resources/connectivities/init_test.go
@@ -613,12 +613,13 @@ func newReconcileTestContext(t *testing.T, objs ...client.Object) credsTestConte
 }
 
 // newDelegatedConnectivity returns the delegated Connectivity resource as it is
-// provisioned by Reconcile: namespaced, with name == namespace == stack name.
+// provisioned by Reconcile: namespaced in the stack namespace, with the fixed
+// name "connectivity".
 func newDelegatedConnectivity(stackName string) *unstructured.Unstructured {
 	object := &unstructured.Unstructured{}
 	object.SetGroupVersionKind(connectivityGVK)
 	object.SetNamespace(stackName)
-	object.SetName(stackName)
+	object.SetName(connectivityDelegatedName)
 	return object
 }
 
@@ -628,7 +629,7 @@ func delegatedConnectivityExists(t *testing.T, ctx credsTestContext, stackName s
 	t.Helper()
 	got := &unstructured.Unstructured{}
 	got.SetGroupVersionKind(connectivityGVK)
-	err := ctx.GetClient().Get(ctx, client.ObjectKey{Namespace: stackName, Name: stackName}, got)
+	err := ctx.GetClient().Get(ctx, client.ObjectKey{Namespace: stackName, Name: connectivityDelegatedName}, got)
 	return err == nil
 }
 
@@ -884,5 +885,17 @@ func TestTeardownDelegatedAttemptsEveryDeletion(t *testing.T) {
 	}
 	if credentialsExist(t, ctx, "stack0") {
 		t.Error("god-mode Credentials must still be torn down when the delegated Connectivity delete fails")
+	}
+}
+
+// The connectivity-api Service is named after the (now fixed) delegated
+// resource name, so the gateway backend must point at "connectivity-api".
+func TestConnectivityAPIBackendRef(t *testing.T) {
+	ref := connectivityAPIBackendRef()
+	if ref.Name != "connectivity-api" {
+		t.Fatalf("connectivityAPIBackendRef().Name = %q, want %q", ref.Name, "connectivity-api")
+	}
+	if ref.Port != connectivityAPIPort {
+		t.Fatalf("connectivityAPIBackendRef().Port = %d, want %d", ref.Port, connectivityAPIPort)
 	}
 }


### PR DESCRIPTION
The delegated connectivity.formance.com/Connectivity is namespaced (one
per stack namespace), so it no longer needs a stack-scoped name. Give it
the fixed name "connectivity"; the connectivity operator derives the API
Service from it, so it becomes "connectivity-api" instead of "<stack>-api".

Credentials (connectivity-<stack>) and the GatewayHTTPAPI
(<stack>-connectivity) stay stack-scoped — they are cluster-scoped and need
the stack for uniqueness. No migration: the module is not yet released.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>