### PR TITLE
feat(webhooks): coordinate worker-safe upgrades

### DIFF
--- a/docs/04-Modules/10-Webhooks.md
+++ b/docs/04-Modules/10-Webhooks.md
@@ -8,6 +8,8 @@ Formance Webhooks requires:
 - **PostgreSQL**: See configuration guide [here](../05-Infrastructure%20services/01-PostgreSQL.md).
 - **Broker**: See configuration guide [here](../05-Infrastructure%20services/02-Message%20broker.md).
 
+Starting with Webhooks `v2.5.0-0`, the API and workers run in separate Deployments. During an update, the Operator stops all workers and waits for their termination before running database migrations. It then rolls out the new API version before recreating the workers.
+
 ## Webhooks Object
 
 :::info

--- a/docs/09-Configuration reference/settings.catalog.json
+++ b/docs/09-Configuration reference/settings.catalog.json
@@ -34,7 +34,7 @@
       "valueType": "uri",
       "sources": [
         "internal/resources/brokers/reconcile.go:24",
-        "internal/resources/webhooks/deployment.go:22"
+        "internal/resources/webhooks/deployment.go:25"
       ]
     },
     {

--- a/docs/09-Configuration reference/settings.catalog.json
+++ b/docs/09-Configuration reference/settings.catalog.json
@@ -34,7 +34,7 @@
       "valueType": "uri",
       "sources": [
         "internal/resources/brokers/reconcile.go:24",
-        "internal/resources/webhooks/deployment.go:26"
+        "internal/resources/webhooks/deployment.go:28"
       ]
     },
     {

--- a/docs/09-Configuration reference/settings.catalog.json
+++ b/docs/09-Configuration reference/settings.catalog.json
@@ -34,7 +34,7 @@
       "valueType": "uri",
       "sources": [
         "internal/resources/brokers/reconcile.go:24",
-        "internal/resources/webhooks/deployment.go:25"
+        "internal/resources/webhooks/deployment.go:26"
       ]
     },
     {

--- a/docs/09-Configuration reference/settings.catalog.json
+++ b/docs/09-Configuration reference/settings.catalog.json
@@ -34,7 +34,7 @@
       "valueType": "uri",
       "sources": [
         "internal/resources/brokers/reconcile.go:24",
-        "internal/resources/webhooks/deployment.go:28"
+        "internal/resources/webhooks/deployment.go:30"
       ]
     },
     {

--- a/internal/core/controllers.go
+++ b/internal/core/controllers.go
@@ -35,9 +35,7 @@ func ForObjectController[T v1beta1.Object](controller ObjectController[T]) Objec
 		err := controller(ctx, reconcilerOptions, object)
 		if err != nil {
 			setStatus(err)
-			if !IsApplicationError(err) {
-				reconcilerError = err
-			}
+			reconcilerError = err
 		} else {
 			for _, condition := range *object.GetConditions() {
 				if condition.ObservedGeneration != object.GetGeneration() {

--- a/internal/core/controllers_test.go
+++ b/internal/core/controllers_test.go
@@ -3,6 +3,7 @@ package core
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
@@ -27,6 +28,19 @@ func (t testContext) GetClient() client.Client    { return t.client }
 func (t testContext) GetScheme() *runtime.Scheme  { return t.scheme }
 func (t testContext) GetAPIReader() client.Reader { return t.apiReader }
 func (t testContext) GetPlatform() Platform       { return t.platform }
+
+func TestForObjectControllerPropagatesApplicationErrorRequeue(t *testing.T) {
+	delay := 5 * time.Second
+	search := &v1beta1.Search{}
+	controller := ForObjectController(func(_ Context, _ *ReconcilerOptions[*v1beta1.Search], _ *v1beta1.Search) error {
+		return NewPendingError().WithRequeueAfter(delay)
+	})
+
+	err := controller(testContext{Context: context.Background()}, &ReconcilerOptions[*v1beta1.Search]{}, search)
+	require.Error(t, err)
+	require.Equal(t, delay, ApplicationErrorRequeueAfter(err))
+	require.False(t, search.Status.Ready)
+}
 
 func TestForModulePassesRefreshedLicenceState(t *testing.T) {
 	scheme := runtime.NewScheme()

--- a/internal/core/errors.go
+++ b/internal/core/errors.go
@@ -2,12 +2,14 @@ package core
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/pkg/errors"
 )
 
 type ApplicationError struct {
-	message string
+	message      string
+	requeueAfter time.Duration
 }
 
 func (e *ApplicationError) Error() string {
@@ -21,6 +23,11 @@ func (e *ApplicationError) Is(err error) bool {
 
 func (e *ApplicationError) WithMessage(msg string, args ...any) *ApplicationError {
 	e.message = fmt.Sprintf(msg, args...)
+	return e
+}
+
+func (e *ApplicationError) WithRequeueAfter(delay time.Duration) *ApplicationError {
+	e.requeueAfter = delay
 	return e
 }
 
@@ -42,4 +49,12 @@ func NewMissingSettingsError(msg string) *ApplicationError {
 
 func IsApplicationError(err error) bool {
 	return errors.Is(err, &ApplicationError{})
+}
+
+func ApplicationErrorRequeueAfter(err error) time.Duration {
+	applicationError := &ApplicationError{}
+	if errors.As(err, &applicationError) {
+		return applicationError.requeueAfter
+	}
+	return 0
 }

--- a/internal/core/errors_test.go
+++ b/internal/core/errors_test.go
@@ -1,0 +1,19 @@
+package core
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+func TestApplicationErrorRequeueAfter(t *testing.T) {
+	delay := 5 * time.Second
+	err := fmt.Errorf("wrapped: %w", NewPendingError().WithRequeueAfter(delay))
+
+	if got := ApplicationErrorRequeueAfter(err); got != delay {
+		t.Fatalf("unexpected requeue delay: got %s, want %s", got, delay)
+	}
+	if got := ApplicationErrorRequeueAfter(fmt.Errorf("ordinary error")); got != 0 {
+		t.Fatalf("ordinary errors must not request a requeue, got %s", got)
+	}
+}

--- a/internal/core/reconciler.go
+++ b/internal/core/reconciler.go
@@ -331,11 +331,14 @@ func reconcileObject[T client.Object](mgr Manager, controller ObjectController[T
 		patch := client.MergeFrom(cp)
 
 		var reconcilerError error
+		var requeueAfter time.Duration
 		err := controller(reconcileContext, &reconcilerOptions, object)
 		if err != nil {
 			log.FromContext(ctx).Info(fmt.Sprintf("Terminated with error: %s", err))
 			if !IsApplicationError(err) {
 				reconcilerError = errors.Wrap(err, "reconciling resource")
+			} else {
+				requeueAfter = ApplicationErrorRequeueAfter(err)
 			}
 		}
 
@@ -353,7 +356,7 @@ func reconcileObject[T client.Object](mgr Manager, controller ObjectController[T
 			}, nil
 		}
 
-		return ctrl.Result{}, reconcilerError
+		return ctrl.Result{RequeueAfter: requeueAfter}, reconcilerError
 	}
 }
 

--- a/internal/resources/webhooks/deployment.go
+++ b/internal/resources/webhooks/deployment.go
@@ -4,6 +4,7 @@ import (
 	"github.com/pkg/errors"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -202,6 +203,12 @@ func stopWorkers(ctx core.Context, namespace string) error {
 }
 
 func deleteWorkerDeployment(ctx core.Context, namespace string) error {
+	if err := client.IgnoreNotFound(ctx.GetClient().Delete(ctx, &policyv1.PodDisruptionBudget{
+		ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: "webhooks-worker"},
+	})); err != nil {
+		return err
+	}
+
 	deployment := &appsv1.Deployment{}
 	err := ctx.GetClient().Get(ctx, types.NamespacedName{Namespace: namespace, Name: "webhooks-worker"}, deployment)
 	if apierrors.IsNotFound(err) {
@@ -264,5 +271,19 @@ func removeEmbeddedWorker(deployment *appsv1.Deployment) {
 			}
 		}
 		deployment.Spec.Template.Spec.Containers[containerIndex].Env = filtered
+	}
+}
+
+func clearWorkerDeploymentConditions(webhooks *v1beta1.Webhooks) {
+	conditions := webhooks.GetConditions()
+	for _, conditionType := range []string{
+		"DeploymentReady",
+		"PodDisruptionBudget",
+		"PodDisruptionBudgetConfigured",
+	} {
+		conditions.Delete(v1beta1.AndConditions(
+			v1beta1.ConditionTypeMatch(conditionType),
+			v1beta1.ConditionReasonMatch("WebhooksWorker"),
+		))
 	}
 }

--- a/internal/resources/webhooks/deployment.go
+++ b/internal/resources/webhooks/deployment.go
@@ -231,7 +231,7 @@ func deleteWorkerDeployment(ctx core.Context, namespace string) error {
 
 func waitForDeploymentRollout(ctx core.Context, namespace, name string) error {
 	deployment := &appsv1.Deployment{}
-	if err := ctx.GetClient().Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, deployment); err != nil {
+	if err := ctx.GetAPIReader().Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, deployment); err != nil {
 		return err
 	}
 	if !deploymentRolloutComplete(deployment) {

--- a/internal/resources/webhooks/deployment.go
+++ b/internal/resources/webhooks/deployment.go
@@ -4,7 +4,10 @@ import (
 	"github.com/pkg/errors"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/formancehq/operator/v3/api/formance.com/v1beta1"
 	"github.com/formancehq/operator/v3/internal/core"
@@ -123,4 +126,143 @@ func createAPIDeployment(ctx core.Context, stack *v1beta1.Stack, webhooks *v1bet
 
 func createSingleDeployment(ctx core.Context, stack *v1beta1.Stack, webhooks *v1beta1.Webhooks, database *v1beta1.Database, consumer *v1beta1.BrokerConsumer, version string) error {
 	return createAPIDeployment(ctx, stack, webhooks, database, consumer, version, true)
+}
+
+func createWorkerDeployment(ctx core.Context, stack *v1beta1.Stack, webhooks *v1beta1.Webhooks, database *v1beta1.Database, consumer *v1beta1.BrokerConsumer, version string) error {
+	imageConfiguration, err := registries.GetFormanceImage(ctx, stack, "webhooks", version)
+	if err != nil {
+		return err
+	}
+
+	env, err := deploymentEnvVars(ctx, stack, webhooks, database)
+	if err != nil {
+		return err
+	}
+	topics, err := brokers.GetTopicsEnvVars(ctx, stack, "KAFKA_TOPICS", consumer.Spec.Services...)
+	if err != nil {
+		return err
+	}
+	env = append(env, topics...)
+
+	serviceAccountName, err := settings.GetAWSServiceAccount(ctx, stack.Name)
+	if err != nil {
+		return err
+	}
+
+	return applications.
+		New(webhooks, &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "webhooks-worker",
+			},
+			Spec: appsv1.DeploymentSpec{
+				Template: v1.PodTemplateSpec{
+					Spec: v1.PodSpec{
+						ServiceAccountName: serviceAccountName,
+						ImagePullSecrets:   imageConfiguration.PullSecrets,
+						Containers: []v1.Container{{
+							Name:           "worker",
+							Env:            env,
+							Image:          imageConfiguration.GetFullImageName(),
+							Args:           []string{"worker"},
+							Ports:          []v1.ContainerPort{applications.StandardHTTPPort()},
+							LivenessProbe:  applications.DefaultLiveness("http"),
+							ReadinessProbe: applications.DefaultReadiness("http"),
+						}},
+					},
+				},
+			},
+		}).
+		IsEE().
+		Install(ctx)
+}
+
+func stopWorkers(ctx core.Context, namespace string) error {
+	if err := deleteWorkerDeployment(ctx, namespace); err != nil {
+		return err
+	}
+
+	deployment := &appsv1.Deployment{}
+	err := ctx.GetClient().Get(ctx, types.NamespacedName{Namespace: namespace, Name: "webhooks"}, deployment)
+	if apierrors.IsNotFound(err) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+
+	if deploymentHasEmbeddedWorker(deployment) {
+		removeEmbeddedWorker(deployment)
+		if err := ctx.GetClient().Update(ctx, deployment); err != nil {
+			return err
+		}
+		return core.NewPendingError().WithMessage("waiting for embedded webhooks workers to terminate")
+	}
+
+	return waitForDeploymentRollout(ctx, namespace, "webhooks")
+}
+
+func deleteWorkerDeployment(ctx core.Context, namespace string) error {
+	deployment := &appsv1.Deployment{}
+	err := ctx.GetClient().Get(ctx, types.NamespacedName{Namespace: namespace, Name: "webhooks-worker"}, deployment)
+	if apierrors.IsNotFound(err) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	if !deployment.DeletionTimestamp.IsZero() {
+		return core.NewPendingError().WithMessage("waiting for webhooks workers to terminate")
+	}
+
+	propagationPolicy := metav1.DeletePropagationForeground
+	core.LogDeletion(ctx, deployment, "webhooks.deleteWorkerDeployment")
+	if err := ctx.GetClient().Delete(ctx, deployment, &client.DeleteOptions{PropagationPolicy: &propagationPolicy}); err != nil {
+		return err
+	}
+	return core.NewPendingError().WithMessage("waiting for webhooks workers to terminate")
+}
+
+func waitForDeploymentRollout(ctx core.Context, namespace, name string) error {
+	deployment := &appsv1.Deployment{}
+	if err := ctx.GetClient().Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, deployment); err != nil {
+		return err
+	}
+	if !deploymentRolloutComplete(deployment) {
+		return core.NewPendingError().WithMessage("waiting for deployment %s rollout to complete", name)
+	}
+	return nil
+}
+
+func deploymentRolloutComplete(deployment *appsv1.Deployment) bool {
+	if deployment.Spec.Replicas == nil || deployment.Status.ObservedGeneration != deployment.Generation {
+		return false
+	}
+	desired := *deployment.Spec.Replicas
+	return deployment.Status.UpdatedReplicas >= desired &&
+		deployment.Status.Replicas == deployment.Status.UpdatedReplicas &&
+		deployment.Status.AvailableReplicas >= desired
+}
+
+func deploymentHasEmbeddedWorker(deployment *appsv1.Deployment) bool {
+	for _, container := range deployment.Spec.Template.Spec.Containers {
+		for _, env := range container.Env {
+			if env.Name == "WORKER" && env.Value == "true" {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func removeEmbeddedWorker(deployment *appsv1.Deployment) {
+	for containerIndex := range deployment.Spec.Template.Spec.Containers {
+		env := deployment.Spec.Template.Spec.Containers[containerIndex].Env
+		filtered := env[:0]
+		for _, variable := range env {
+			if variable.Name != "WORKER" {
+				filtered = append(filtered, variable)
+			}
+		}
+		deployment.Spec.Template.Spec.Containers[containerIndex].Env = filtered
+	}
 }

--- a/internal/resources/webhooks/deployment.go
+++ b/internal/resources/webhooks/deployment.go
@@ -1,6 +1,8 @@
 package webhooks
 
 import (
+	"time"
+
 	"github.com/pkg/errors"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
@@ -232,7 +234,9 @@ func waitForEmbeddedWorkerPodsTermination(ctx core.Context, deployment *appsv1.D
 
 	for index := range pods.Items {
 		if podHasActiveEmbeddedWorker(&pods.Items[index]) {
-			return core.NewPendingError().WithMessage("waiting for embedded webhooks worker pods to terminate")
+			return core.NewPendingError().
+				WithMessage("waiting for embedded webhooks worker pods to terminate").
+				WithRequeueAfter(time.Second)
 		}
 	}
 	return nil

--- a/internal/resources/webhooks/deployment.go
+++ b/internal/resources/webhooks/deployment.go
@@ -221,7 +221,7 @@ func deleteWorkerDeployment(ctx core.Context, namespace string) error {
 	}
 
 	deployment := &appsv1.Deployment{}
-	err := ctx.GetClient().Get(ctx, types.NamespacedName{Namespace: namespace, Name: "webhooks-worker"}, deployment)
+	err := ctx.GetAPIReader().Get(ctx, types.NamespacedName{Namespace: namespace, Name: "webhooks-worker"}, deployment)
 	if apierrors.IsNotFound(err) {
 		return nil
 	}

--- a/internal/resources/webhooks/deployment.go
+++ b/internal/resources/webhooks/deployment.go
@@ -21,6 +21,8 @@ import (
 	"github.com/formancehq/operator/v3/internal/resources/settings"
 )
 
+const workerDrainAnnotation = "formance.com/webhooks-workers-draining"
+
 func deploymentEnvVars(ctx core.Context, stack *v1beta1.Stack, webhooks *v1beta1.Webhooks, database *v1beta1.Database) ([]v1.EnvVar, error) {
 
 	brokerURI, err := settings.RequireURL(ctx, stack.Name, "broker", "dsn")
@@ -183,7 +185,7 @@ func stopWorkers(ctx core.Context, namespace string) error {
 	}
 
 	deployment := &appsv1.Deployment{}
-	err := ctx.GetClient().Get(ctx, types.NamespacedName{Namespace: namespace, Name: "webhooks"}, deployment)
+	err := ctx.GetAPIReader().Get(ctx, types.NamespacedName{Namespace: namespace, Name: "webhooks"}, deployment)
 	if apierrors.IsNotFound(err) {
 		return nil
 	}
@@ -193,13 +195,22 @@ func stopWorkers(ctx core.Context, namespace string) error {
 
 	if deploymentHasEmbeddedWorker(deployment) {
 		removeEmbeddedWorker(deployment)
+		markWorkerDrain(deployment)
 		if err := ctx.GetClient().Update(ctx, deployment); err != nil {
 			return err
 		}
 		return core.NewPendingError().WithMessage("waiting for embedded webhooks workers to terminate")
 	}
 
-	return waitForDeploymentRollout(ctx, namespace, "webhooks")
+	if !workerDrainPending(deployment) {
+		return nil
+	}
+	deployment, err = getDeploymentAfterRollout(ctx, namespace, "webhooks")
+	if err != nil {
+		return err
+	}
+	clearWorkerDrain(deployment)
+	return ctx.GetClient().Update(ctx, deployment)
 }
 
 func deleteWorkerDeployment(ctx core.Context, namespace string) error {
@@ -230,14 +241,19 @@ func deleteWorkerDeployment(ctx core.Context, namespace string) error {
 }
 
 func waitForDeploymentRollout(ctx core.Context, namespace, name string) error {
+	_, err := getDeploymentAfterRollout(ctx, namespace, name)
+	return err
+}
+
+func getDeploymentAfterRollout(ctx core.Context, namespace, name string) (*appsv1.Deployment, error) {
 	deployment := &appsv1.Deployment{}
 	if err := ctx.GetAPIReader().Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, deployment); err != nil {
-		return err
+		return nil, err
 	}
 	if !deploymentRolloutComplete(deployment) {
-		return core.NewPendingError().WithMessage("waiting for deployment %s rollout to complete", name)
+		return nil, core.NewPendingError().WithMessage("waiting for deployment %s rollout to complete", name)
 	}
-	return nil
+	return deployment, nil
 }
 
 func deploymentRolloutComplete(deployment *appsv1.Deployment) bool {
@@ -286,4 +302,19 @@ func clearWorkerDeploymentConditions(webhooks *v1beta1.Webhooks) {
 			v1beta1.ConditionReasonMatch("WebhooksWorker"),
 		))
 	}
+}
+
+func markWorkerDrain(deployment *appsv1.Deployment) {
+	if deployment.Annotations == nil {
+		deployment.Annotations = map[string]string{}
+	}
+	deployment.Annotations[workerDrainAnnotation] = "true"
+}
+
+func workerDrainPending(deployment *appsv1.Deployment) bool {
+	return deployment.Annotations[workerDrainAnnotation] == "true"
+}
+
+func clearWorkerDrain(deployment *appsv1.Deployment) {
+	delete(deployment.Annotations, workerDrainAnnotation)
 }

--- a/internal/resources/webhooks/deployment.go
+++ b/internal/resources/webhooks/deployment.go
@@ -209,8 +209,47 @@ func stopWorkers(ctx core.Context, namespace string) error {
 	if err != nil {
 		return err
 	}
+	if err := waitForEmbeddedWorkerPodsTermination(ctx, deployment); err != nil {
+		return err
+	}
 	clearWorkerDrain(deployment)
 	return ctx.GetClient().Update(ctx, deployment)
+}
+
+func waitForEmbeddedWorkerPodsTermination(ctx core.Context, deployment *appsv1.Deployment) error {
+	selector, err := metav1.LabelSelectorAsSelector(deployment.Spec.Selector)
+	if err != nil {
+		return err
+	}
+
+	pods := &v1.PodList{}
+	if err := ctx.GetAPIReader().List(ctx, pods,
+		client.InNamespace(deployment.Namespace),
+		client.MatchingLabelsSelector{Selector: selector},
+	); err != nil {
+		return err
+	}
+
+	for index := range pods.Items {
+		if podHasActiveEmbeddedWorker(&pods.Items[index]) {
+			return core.NewPendingError().WithMessage("waiting for embedded webhooks worker pods to terminate")
+		}
+	}
+	return nil
+}
+
+func podHasActiveEmbeddedWorker(pod *v1.Pod) bool {
+	if pod.Status.Phase == v1.PodSucceeded || pod.Status.Phase == v1.PodFailed {
+		return false
+	}
+	for _, container := range pod.Spec.Containers {
+		for _, env := range container.Env {
+			if env.Name == "WORKER" && env.Value == "true" {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func deleteWorkerDeployment(ctx core.Context, namespace string) error {

--- a/internal/resources/webhooks/deployment_test.go
+++ b/internal/resources/webhooks/deployment_test.go
@@ -1,0 +1,107 @@
+package webhooks
+
+import (
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+)
+
+func TestUsesSeparateWorkerDeployment(t *testing.T) {
+	tests := map[string]bool{
+		"v2.4.9":         false,
+		"2.4.9":          false,
+		"v2.5.0-0":       true,
+		"2.5.0-0":        true,
+		"v2.5.0-alpha.1": true,
+		"v2.5.0":         true,
+		"v3.0.0":         true,
+		"main":           true,
+	}
+
+	for version, expected := range tests {
+		t.Run(version, func(t *testing.T) {
+			if got := usesSeparateWorkerDeployment(version); got != expected {
+				t.Fatalf("usesSeparateWorkerDeployment(%q) = %v, want %v", version, got, expected)
+			}
+		})
+	}
+}
+
+func TestDeploymentRolloutComplete(t *testing.T) {
+	ready := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Generation: 2},
+		Spec:       appsv1.DeploymentSpec{Replicas: ptr.To[int32](2)},
+		Status: appsv1.DeploymentStatus{
+			ObservedGeneration: 2,
+			Replicas:           2,
+			UpdatedReplicas:    2,
+			AvailableReplicas:  2,
+		},
+	}
+	if !deploymentRolloutComplete(ready) {
+		t.Fatal("expected completed rollout")
+	}
+
+	oldWorkerRemaining := ready.DeepCopy()
+	oldWorkerRemaining.Status.Replicas = 3
+	if deploymentRolloutComplete(oldWorkerRemaining) {
+		t.Fatal("rollout must wait until every old worker pod has terminated")
+	}
+
+	unobserved := ready.DeepCopy()
+	unobserved.Status.ObservedGeneration = 1
+	if deploymentRolloutComplete(unobserved) {
+		t.Fatal("rollout must wait for the current generation")
+	}
+}
+
+func TestDeploymentHasEmbeddedWorker(t *testing.T) {
+	deployment := &appsv1.Deployment{
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Env: []corev1.EnvVar{{Name: "WORKER", Value: "true"}},
+					}},
+				},
+			},
+		},
+	}
+	if !deploymentHasEmbeddedWorker(deployment) {
+		t.Fatal("expected embedded worker to be detected")
+	}
+
+	deployment.Spec.Template.Spec.Containers[0].Env[0].Value = "false"
+	if deploymentHasEmbeddedWorker(deployment) {
+		t.Fatal("disabled worker must not be detected as embedded")
+	}
+}
+
+func TestRemoveEmbeddedWorker(t *testing.T) {
+	deployment := &appsv1.Deployment{
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Env: []corev1.EnvVar{
+							{Name: "BEFORE", Value: "before"},
+							{Name: "WORKER", Value: "true"},
+							{Name: "AFTER", Value: "after"},
+						},
+					}},
+				},
+			},
+		},
+	}
+
+	removeEmbeddedWorker(deployment)
+
+	got := deployment.Spec.Template.Spec.Containers[0].Env
+	want := []corev1.EnvVar{{Name: "BEFORE", Value: "before"}, {Name: "AFTER", Value: "after"}}
+	if len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
+		t.Fatalf("unexpected environment after disabling worker: %#v", got)
+	}
+}

--- a/internal/resources/webhooks/deployment_test.go
+++ b/internal/resources/webhooks/deployment_test.go
@@ -7,6 +7,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
+
+	"github.com/formancehq/operator/v3/api/formance.com/v1beta1"
 )
 
 func TestUsesSeparateWorkerDeployment(t *testing.T) {
@@ -103,5 +105,25 @@ func TestRemoveEmbeddedWorker(t *testing.T) {
 	want := []corev1.EnvVar{{Name: "BEFORE", Value: "before"}, {Name: "AFTER", Value: "after"}}
 	if len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
 		t.Fatalf("unexpected environment after disabling worker: %#v", got)
+	}
+}
+
+func TestClearWorkerDeploymentConditions(t *testing.T) {
+	webhooks := &v1beta1.Webhooks{}
+	webhooks.Status.Conditions = v1beta1.Conditions{
+		{Type: "DeploymentReady", Reason: "Webhooks", Status: metav1.ConditionTrue},
+		{Type: "DeploymentReady", Reason: "WebhooksWorker", Status: metav1.ConditionFalse},
+		{Type: "PodDisruptionBudget", Reason: "WebhooksWorker", Status: metav1.ConditionTrue},
+		{Type: "PodDisruptionBudgetConfigured", Reason: "WebhooksWorker", Status: metav1.ConditionFalse},
+	}
+
+	clearWorkerDeploymentConditions(webhooks)
+
+	if len(webhooks.Status.Conditions) != 1 {
+		t.Fatalf("expected only API conditions to remain, got %#v", webhooks.Status.Conditions)
+	}
+	remaining := webhooks.Status.Conditions[0]
+	if remaining.Type != "DeploymentReady" || remaining.Reason != "Webhooks" {
+		t.Fatalf("unexpected remaining condition: %#v", remaining)
 	}
 }

--- a/internal/resources/webhooks/deployment_test.go
+++ b/internal/resources/webhooks/deployment_test.go
@@ -108,6 +108,36 @@ func TestRemoveEmbeddedWorker(t *testing.T) {
 	}
 }
 
+func TestPodHasActiveEmbeddedWorker(t *testing.T) {
+	pod := &corev1.Pod{
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{
+				Env: []corev1.EnvVar{{Name: "WORKER", Value: "true"}},
+			}},
+		},
+		Status: corev1.PodStatus{Phase: corev1.PodRunning},
+	}
+	if !podHasActiveEmbeddedWorker(pod) {
+		t.Fatal("expected running embedded worker pod to be active")
+	}
+
+	pod.DeletionTimestamp = &metav1.Time{Time: metav1.Now().Time}
+	if !podHasActiveEmbeddedWorker(pod) {
+		t.Fatal("terminating embedded worker pod must remain active until it reaches a terminal phase")
+	}
+
+	pod.Status.Phase = corev1.PodSucceeded
+	if podHasActiveEmbeddedWorker(pod) {
+		t.Fatal("completed embedded worker pod must not block migrations")
+	}
+
+	pod.Status.Phase = corev1.PodRunning
+	pod.Spec.Containers[0].Env[0].Value = "false"
+	if podHasActiveEmbeddedWorker(pod) {
+		t.Fatal("API-only pod must not be detected as an embedded worker")
+	}
+}
+
 func TestClearWorkerDeploymentConditions(t *testing.T) {
 	webhooks := &v1beta1.Webhooks{}
 	webhooks.Status.Conditions = v1beta1.Conditions{

--- a/internal/resources/webhooks/deployment_test.go
+++ b/internal/resources/webhooks/deployment_test.go
@@ -127,3 +127,17 @@ func TestClearWorkerDeploymentConditions(t *testing.T) {
 		t.Fatalf("unexpected remaining condition: %#v", remaining)
 	}
 }
+
+func TestWorkerDrainAnnotation(t *testing.T) {
+	deployment := &appsv1.Deployment{}
+
+	markWorkerDrain(deployment)
+	if !workerDrainPending(deployment) {
+		t.Fatal("expected worker drain annotation")
+	}
+
+	clearWorkerDrain(deployment)
+	if workerDrainPending(deployment) {
+		t.Fatal("worker drain annotation must be removable after the rollout completes")
+	}
+}

--- a/internal/resources/webhooks/init.go
+++ b/internal/resources/webhooks/init.go
@@ -101,6 +101,7 @@ func Reconcile(ctx Context, stack *v1beta1.Stack, webhooks *v1beta1.Webhooks, ve
 			if err := deleteWorkerDeployment(ctx, stack.Name); err != nil {
 				return err
 			}
+			clearWorkerDeploymentConditions(webhooks)
 			if err := createSingleDeployment(ctx, stack, webhooks, database, consumer, version); err != nil {
 				return err
 			}

--- a/internal/resources/webhooks/init.go
+++ b/internal/resources/webhooks/init.go
@@ -86,25 +86,26 @@ func Reconcile(ctx Context, stack *v1beta1.Stack, webhooks *v1beta1.Webhooks, ve
 		}
 	}
 
-	if consumer.Status.Ready {
-		if separateWorkerDeployment {
-			if err := createAPIDeployment(ctx, stack, webhooks, database, consumer, version, false); err != nil {
-				return err
-			}
-			if err := waitForDeploymentRollout(ctx, stack.Name, "webhooks"); err != nil {
-				return err
-			}
-			if err := createWorkerDeployment(ctx, stack, webhooks, database, consumer, version); err != nil {
-				return err
-			}
-		} else {
-			if err := deleteWorkerDeployment(ctx, stack.Name); err != nil {
-				return err
-			}
-			clearWorkerDeploymentConditions(webhooks)
-			if err := createSingleDeployment(ctx, stack, webhooks, database, consumer, version); err != nil {
-				return err
-			}
+	if separateWorkerDeployment {
+		if err := createAPIDeployment(ctx, stack, webhooks, database, consumer, version, false); err != nil {
+			return err
+		}
+		if err := waitForDeploymentRollout(ctx, stack.Name, "webhooks"); err != nil {
+			return err
+		}
+		if !consumer.Status.Ready {
+			return NewPendingError().WithMessage("broker consumer not ready")
+		}
+		if err := createWorkerDeployment(ctx, stack, webhooks, database, consumer, version); err != nil {
+			return err
+		}
+	} else if consumer.Status.Ready {
+		if err := deleteWorkerDeployment(ctx, stack.Name); err != nil {
+			return err
+		}
+		clearWorkerDeploymentConditions(webhooks)
+		if err := createSingleDeployment(ctx, stack, webhooks, database, consumer, version); err != nil {
+			return err
 		}
 	}
 

--- a/internal/resources/webhooks/init.go
+++ b/internal/resources/webhooks/init.go
@@ -17,7 +17,10 @@ limitations under the License.
 package webhooks
 
 import (
+	"strings"
+
 	"github.com/pkg/errors"
+	"golang.org/x/mod/semver"
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 
@@ -35,6 +38,8 @@ import (
 //+kubebuilder:rbac:groups=formance.com,resources=webhooks/finalizers,verbs=update
 
 func Reconcile(ctx Context, stack *v1beta1.Stack, webhooks *v1beta1.Webhooks, version string) error {
+	separateWorkerDeployment := usesSeparateWorkerDeployment(version)
+
 	database, err := databases.Create(ctx, stack, webhooks)
 	if err != nil {
 		return err
@@ -58,7 +63,15 @@ func Reconcile(ctx Context, stack *v1beta1.Stack, webhooks *v1beta1.Webhooks, ve
 		return errors.Wrap(err, "resolving image")
 	}
 
-	if databases.GetSavedModuleVersion(database) != version {
+	savedVersion := databases.GetSavedModuleVersion(database)
+	if savedVersion != version {
+		updateRequiresStoppedWorkers := separateWorkerDeployment ||
+			(savedVersion != "" && usesSeparateWorkerDeployment(savedVersion))
+		if updateRequiresStoppedWorkers {
+			if err := stopWorkers(ctx, stack.Name); err != nil {
+				return err
+			}
+		}
 
 		if err := databases.Migrate(ctx, stack, webhooks, image, database); err != nil {
 			return err
@@ -67,15 +80,42 @@ func Reconcile(ctx Context, stack *v1beta1.Stack, webhooks *v1beta1.Webhooks, ve
 		if err := databases.SaveModuleVersion(ctx, database, version); err != nil {
 			return errors.Wrap(err, "saving module version in database object")
 		}
+
+		if separateWorkerDeployment {
+			return NewPendingError().WithMessage("database migrated, waiting to deploy webhooks API")
+		}
 	}
 
 	if consumer.Status.Ready {
-		if err := createSingleDeployment(ctx, stack, webhooks, database, consumer, version); err != nil {
-			return err
+		if separateWorkerDeployment {
+			if err := createAPIDeployment(ctx, stack, webhooks, database, consumer, version, false); err != nil {
+				return err
+			}
+			if err := waitForDeploymentRollout(ctx, stack.Name, "webhooks"); err != nil {
+				return err
+			}
+			if err := createWorkerDeployment(ctx, stack, webhooks, database, consumer, version); err != nil {
+				return err
+			}
+		} else {
+			if err := deleteWorkerDeployment(ctx, stack.Name); err != nil {
+				return err
+			}
+			if err := createSingleDeployment(ctx, stack, webhooks, database, consumer, version); err != nil {
+				return err
+			}
 		}
 	}
 
 	return nil
+}
+
+func usesSeparateWorkerDeployment(version string) bool {
+	normalizedVersion := version
+	if !strings.HasPrefix(normalizedVersion, "v") && semver.IsValid("v"+normalizedVersion) {
+		normalizedVersion = "v" + normalizedVersion
+	}
+	return !semver.IsValid(normalizedVersion) || semver.Compare(normalizedVersion, "v2.5.0-0") >= 0
 }
 
 func init() {

--- a/tests/e2e/chainsaw/18-webhooks-module/chainsaw-test.yaml
+++ b/tests/e2e/chainsaw/18-webhooks-module/chainsaw-test.yaml
@@ -50,13 +50,16 @@ spec:
               }
               kubectl wait --for=jsonpath='{.status.ready}'=true brokerconsumer/webhooks-webhooks --timeout=5m
               kubectl wait --for=create deployment/webhooks -n chainsaw-webhooks --timeout=2m
+              kubectl wait --for=create deployment/webhooks-worker -n chainsaw-webhooks --timeout=2m
               kubectl wait --for=create service/webhooks -n chainsaw-webhooks --timeout=2m
               kubectl wait --for=create pdb/webhooks -n chainsaw-webhooks --timeout=2m
               kubectl wait --for=jsonpath='{.spec.template.spec.containers[0].image}'=ghcr.io/formancehq/webhooks:v3.0.0 deployment/webhooks -n chainsaw-webhooks --timeout=2m
+              kubectl wait --for=jsonpath='{.spec.template.spec.containers[0].image}'=ghcr.io/formancehq/webhooks:v3.0.0 deployment/webhooks-worker -n chainsaw-webhooks --timeout=2m
               kubectl wait --for=jsonpath='{.status.ready}'=true gatewayhttpapi/chainsaw-webhooks-webhooks --timeout=2m
               kubectl wait --for=jsonpath='{.spec.ports[0].port}'=8080 service/webhooks -n chainsaw-webhooks --timeout=2m
               assert_jsonpath deployment/webhooks '{.spec.replicas}' '2'
               assert_jsonpath deployment/webhooks '{.spec.template.spec.containers[0].args[0]}' 'serve'
+              assert_jsonpath deployment/webhooks-worker '{.spec.template.spec.containers[0].args[0]}' 'worker'
               assert_jsonpath deployment/webhooks '{.spec.template.spec.containers[0].resources.requests.cpu}' '20m'
               assert_jsonpath deployment/webhooks '{.spec.template.spec.containers[0].resources.limits.memory}' '160Mi'
               assert_jsonpath deployment/webhooks '{.spec.template.metadata.annotations.chainsaw\.formance\.com/template}' 'webhooks'
@@ -75,9 +78,15 @@ spec:
               grep -Fx 'PUBLISHER_NATS_URL=nats.chainsaw-webhooks.svc.cluster.local:4222' /tmp/chainsaw-webhooks-env
               grep -Fx 'PUBLISHER_NATS_CLIENT_ID=chainsaw-webhooks-webhooks' /tmp/chainsaw-webhooks-env
               grep -Fx 'PUBLISHER_NATS_AUTO_PROVISION=false' /tmp/chainsaw-webhooks-env
-              grep -Fx 'WORKER=true' /tmp/chainsaw-webhooks-env
+              if grep -q '^WORKER=' /tmp/chainsaw-webhooks-env; then
+                echo 'webhooks API must not run an embedded worker' >&2
+                exit 1
+              fi
               grep -Fx 'OTEL_TRACES=true' /tmp/chainsaw-webhooks-env
               grep -Fx 'OTEL_SERVICE_NAME=webhooks' /tmp/chainsaw-webhooks-env
+              kubectl get deployment webhooks-worker -n chainsaw-webhooks -o jsonpath='{range .spec.template.spec.containers[0].env[*]}{.name}={.value}{"\n"}{end}' > /tmp/chainsaw-webhooks-worker-env
+              grep -E '^KAFKA_TOPICS=' /tmp/chainsaw-webhooks-worker-env
+              grep -Fx 'STORAGE_POSTGRES_CONN_STRING=$(POSTGRES_URI)' /tmp/chainsaw-webhooks-worker-env
               kubectl get deployment webhooks -n chainsaw-webhooks -o jsonpath='{range .spec.template.spec.containers[0].env[*]}{.name}={.valueFrom.secretKeyRef.name}/{.valueFrom.secretKeyRef.key}{"\n"}{end}' > /tmp/chainsaw-webhooks-secret-env
               grep -Fx 'POSTGRES_USERNAME=postgres/username' /tmp/chainsaw-webhooks-secret-env
               grep -Fx 'POSTGRES_PASSWORD=postgres/password' /tmp/chainsaw-webhooks-secret-env

--- a/tests/e2e/chainsaw/18-webhooks-module/chainsaw-test.yaml
+++ b/tests/e2e/chainsaw/18-webhooks-module/chainsaw-test.yaml
@@ -53,8 +53,8 @@ spec:
               kubectl wait --for=create deployment/webhooks-worker -n chainsaw-webhooks --timeout=2m
               kubectl wait --for=create service/webhooks -n chainsaw-webhooks --timeout=2m
               kubectl wait --for=create pdb/webhooks -n chainsaw-webhooks --timeout=2m
-              kubectl wait --for=jsonpath='{.spec.template.spec.containers[0].image}'=ghcr.io/formancehq/webhooks:v3.0.0 deployment/webhooks -n chainsaw-webhooks --timeout=2m
-              kubectl wait --for=jsonpath='{.spec.template.spec.containers[0].image}'=ghcr.io/formancehq/webhooks:v3.0.0 deployment/webhooks-worker -n chainsaw-webhooks --timeout=2m
+              kubectl wait --for=jsonpath='{.spec.template.spec.containers[0].image}'=ghcr.io/formancehq/webhooks:v2.5.0 deployment/webhooks -n chainsaw-webhooks --timeout=2m
+              kubectl wait --for=jsonpath='{.spec.template.spec.containers[0].image}'=ghcr.io/formancehq/webhooks:v2.5.0 deployment/webhooks-worker -n chainsaw-webhooks --timeout=2m
               kubectl wait --for=jsonpath='{.status.ready}'=true gatewayhttpapi/chainsaw-webhooks-webhooks --timeout=2m
               kubectl wait --for=jsonpath='{.spec.ports[0].port}'=8080 service/webhooks -n chainsaw-webhooks --timeout=2m
               assert_jsonpath deployment/webhooks '{.spec.replicas}' '2'

--- a/tests/e2e/chainsaw/18-webhooks-module/chainsaw-test.yaml
+++ b/tests/e2e/chainsaw/18-webhooks-module/chainsaw-test.yaml
@@ -77,7 +77,6 @@ spec:
               grep -Fx 'PUBLISHER_NATS_ENABLED=true' /tmp/chainsaw-webhooks-env
               grep -Fx 'PUBLISHER_NATS_URL=nats.chainsaw-webhooks.svc.cluster.local:4222' /tmp/chainsaw-webhooks-env
               grep -Fx 'PUBLISHER_NATS_CLIENT_ID=chainsaw-webhooks-webhooks' /tmp/chainsaw-webhooks-env
-              grep -Fx 'PUBLISHER_NATS_AUTO_PROVISION=false' /tmp/chainsaw-webhooks-env
               if grep -q '^WORKER=' /tmp/chainsaw-webhooks-env; then
                 echo 'webhooks API must not run an embedded worker' >&2
                 exit 1
@@ -86,6 +85,7 @@ spec:
               grep -Fx 'OTEL_SERVICE_NAME=webhooks' /tmp/chainsaw-webhooks-env
               kubectl get deployment webhooks-worker -n chainsaw-webhooks -o jsonpath='{range .spec.template.spec.containers[0].env[*]}{.name}={.value}{"\n"}{end}' > /tmp/chainsaw-webhooks-worker-env
               grep -E '^KAFKA_TOPICS=' /tmp/chainsaw-webhooks-worker-env
+              grep -Fx 'PUBLISHER_NATS_AUTO_PROVISION=false' /tmp/chainsaw-webhooks-worker-env
               grep -Fx 'STORAGE_POSTGRES_CONN_STRING=$(POSTGRES_URI)' /tmp/chainsaw-webhooks-worker-env
               kubectl get deployment webhooks -n chainsaw-webhooks -o jsonpath='{range .spec.template.spec.containers[0].env[*]}{.name}={.valueFrom.secretKeyRef.name}/{.valueFrom.secretKeyRef.key}{"\n"}{end}' > /tmp/chainsaw-webhooks-secret-env
               grep -Fx 'POSTGRES_USERNAME=postgres/username' /tmp/chainsaw-webhooks-secret-env

--- a/tests/e2e/chainsaw/18-webhooks-module/resources/database.yaml
+++ b/tests/e2e/chainsaw/18-webhooks-module/resources/database.yaml
@@ -3,7 +3,7 @@ kind: Database
 metadata:
   name: chainsaw-webhooks-webhooks
   annotations:
-    formance.com/module-version: v3.0.0
+    formance.com/module-version: v2.5.0
 spec:
   stack: chainsaw-webhooks
   service: webhooks

--- a/tests/e2e/chainsaw/18-webhooks-module/resources/stack.yaml
+++ b/tests/e2e/chainsaw/18-webhooks-module/resources/stack.yaml
@@ -3,5 +3,5 @@ kind: Stack
 metadata:
   name: chainsaw-webhooks
 spec:
-  version: v3.0.0
+  version: v2.5.0
   dev: true


### PR DESCRIPTION
## Summary

- split the Webhooks API and worker deployments starting with v2.5.0-0
- stop and fully drain legacy embedded or dedicated workers before database migrations
- roll out the new API version before recreating workers
- preserve the monolithic deployment behavior for older Webhooks versions
- cover prerelease, stable, non-v-prefixed, and development versions

## Upgrade sequence

1. Stop existing workers.
2. Wait for their complete termination.
3. Run database migrations.
4. Roll out the new API version and wait for completion.
5. Recreate the worker deployment.

## Validation

- `just tests` (15 suites passed)
- `just pre-commit`
- targeted Webhooks tests
- targeted `golangci-lint`

## Risk

The API/worker topology changes only for Webhooks v2.5.0-0 and newer. Older versions retain the existing embedded-worker deployment.