### PR TITLE
chore(release): prepare v3.13.1

### DIFF
--- a/helm/crds/Chart.yaml
+++ b/helm/crds/Chart.yaml
@@ -13,9 +13,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: "3.13.0"
+version: "3.13.1"
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v3.13.0"
+appVersion: "v3.13.1"

--- a/helm/operator/Chart.lock
+++ b/helm/operator/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: operator-crds
   repository: file://../crds
-  version: 3.13.0
-digest: sha256:cc6f37a5e0e02d1e16c67c6bb54af11f600011d70b18de175158261ac7740d8a
-generated: "2026-08-03T15:49:18.491532+02:00"
+  version: 3.13.1
+digest: sha256:2cc449fa32074bb9142e2e4015a38592545b8518a4c43699a18b5901ffc4d383
+generated: "2026-08-05T12:40:22.122714+02:00"

--- a/helm/operator/Chart.yaml
+++ b/helm/operator/Chart.yaml
@@ -13,12 +13,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: "3.13.0"
+version: "3.13.1"
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v3.13.0"
+appVersion: "v3.13.1"
 dependencies:
 - name: operator-crds
   version: "3.X"


### PR DESCRIPTION
## Summary

- bump the Operator and CRD Helm charts to 3.13.1
- set the packaged application version to v3.13.1
- regenerate the Operator chart dependency lock

## Validation

- `nix develop --impure --command just pre-commit`
- `nix develop --impure --command just tests`
- `helm lint helm/crds`
- `helm lint helm/operator`
- `helm template operator helm/operator`

## Risk

Low. This release-only change updates chart metadata and the generated dependency lock.