### PR TITLE
fix(ci): make staging promotion atomic

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,9 @@ permissions:
   pull-requests: write
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  # A cancelled main run can leave a mutable Argo CD parameter override behind.
+  # Queue main deployments so each promotion either completes or rolls back.
+  cancel-in-progress: ${{ github.event_name != 'push' }}
 jobs:
   PR:
     if: github.event_name == 'pull_request'
@@ -60,6 +62,8 @@ jobs:
       - uses: "namespacelabs/nscloud-checkout-action@v9"
         with:
           fetch-depth: 0
+      - name: Test staging promotion rollback
+        run: scripts/deploy-staging_test.sh
       - name: Setup Env
         uses: ./.github/actions/default
         with:

--- a/Earthfile
+++ b/Earthfile
@@ -113,12 +113,15 @@ deploy-staging:
     ARG --required TAG
     ARG APPLICATION=staging-eu-west-1-hosting-operator
     LET SERVER=argocd.internal.formance.cloud
+    RUN apk add --no-cache jq
+    COPY scripts/deploy-staging.sh /usr/local/bin/deploy-staging
+    RUN chmod 555 /usr/local/bin/deploy-staging
     RUN --secret AUTH_TOKEN \
-        argocd app set $APPLICATION \ 
-        --parameter image.tag=$TAG \
-        --parameter operator.utils.tag=$TAG \
-        --auth-token=$AUTH_TOKEN --server=$SERVER --grpc-web
-    RUN --secret AUTH_TOKEN argocd --auth-token=$AUTH_TOKEN --server=$SERVER --grpc-web app sync $APPLICATION
+        AUTH_TOKEN=$AUTH_TOKEN \
+        APPLICATION=$APPLICATION \
+        SERVER=$SERVER \
+        TAG=$TAG \
+        deploy-staging
 
 ### Following targets are used by agent tests
 manifests:

--- a/scripts/deploy-staging.sh
+++ b/scripts/deploy-staging.sh
@@ -1,0 +1,73 @@
+#!/bin/sh
+
+set -eu
+
+: "${APPLICATION:?APPLICATION is required}"
+: "${AUTH_TOKEN:?AUTH_TOKEN is required}"
+: "${SERVER:?SERVER is required}"
+: "${TAG:?TAG is required}"
+
+argocd_cli() {
+	argocd --auth-token="$AUTH_TOKEN" --server="$SERVER" --grpc-web "$@"
+}
+
+parameter_value() {
+	argocd_cli app get "$APPLICATION" --output json |
+		jq -r --arg name "$1" \
+		'.spec.source.helm.parameters // [] | map(select(.name == $name)) | last | .value // empty'
+}
+
+restore_parameter() {
+	name=$1
+	value=$2
+	if [ -n "$value" ]; then
+		argocd_cli app set "$APPLICATION" --parameter "$name=$value"
+	else
+		argocd_cli app unset "$APPLICATION" --parameter "$name"
+	fi
+}
+
+mutated=false
+previous_image_tag=""
+previous_utils_tag=""
+
+rollback() {
+	status=$?
+	trap - EXIT INT TERM
+	if [ "$status" -ne 0 ] && [ "$mutated" = true ]; then
+		echo "Staging promotion failed; restoring previous Argo CD parameters" >&2
+		restore_parameter image.tag "$previous_image_tag" || true
+		restore_parameter operator.utils.tag "$previous_utils_tag" || true
+		argocd_cli app sync "$APPLICATION" --timeout 600 || true
+		argocd_cli app wait "$APPLICATION" --operation --sync --health --timeout 600 || true
+	fi
+	exit "$status"
+}
+
+trap rollback EXIT INT TERM
+
+# Never mutate parameters while another sync can still consume them.
+argocd_cli app wait "$APPLICATION" --operation --timeout 600
+
+previous_image_tag=$(parameter_value image.tag)
+previous_utils_tag=$(parameter_value operator.utils.tag)
+
+argocd_cli app set "$APPLICATION" \
+	--parameter "image.tag=$TAG" \
+	--parameter "operator.utils.tag=$TAG"
+mutated=true
+
+argocd_cli app sync "$APPLICATION" --timeout 600
+argocd_cli app wait "$APPLICATION" --operation --sync --health --timeout 600
+
+application=$(argocd_cli app get "$APPLICATION" --refresh --output json)
+echo "$application" | jq -e --arg tag "$TAG" '
+  (.spec.source.helm.parameters // [] | any(.name == "image.tag" and .value == $tag)) and
+  (.spec.source.helm.parameters // [] | any(.name == "operator.utils.tag" and .value == $tag)) and
+  (.status.sync.status == "Synced") and
+  (.status.health.status == "Healthy") and
+  (.status.summary.images // [] | any(endswith("/operator:" + $tag)))
+' >/dev/null
+
+mutated=false
+trap - EXIT INT TERM

--- a/scripts/deploy-staging.sh
+++ b/scripts/deploy-staging.sh
@@ -11,46 +11,52 @@ argocd_cli() {
 	argocd --auth-token="$AUTH_TOKEN" --server="$SERVER" --grpc-web "$@"
 }
 
-parameter_value() {
-	argocd_cli app get "$APPLICATION" --output json |
-		jq -r --arg name "$1" \
-		'.spec.source.helm.parameters // [] | map(select(.name == $name)) | last | .value // empty'
-}
-
-restore_parameter() {
-	name=$1
-	value=$2
-	if [ -n "$value" ]; then
-		argocd_cli app set "$APPLICATION" --parameter "$name=$value"
-	else
-		argocd_cli app unset "$APPLICATION" --parameter "$name"
-	fi
-}
-
 mutated=false
-previous_image_tag=""
-previous_utils_tag=""
+previous_parameters='[]'
+
+wait_for_operation() {
+	if argocd_cli app wait "$APPLICATION" --operation --timeout 600; then
+		return 0
+	fi
+
+	echo "Argo CD operation did not finish; terminating it before rollback" >&2
+	argocd_cli app terminate-op "$APPLICATION"
+	argocd_cli app wait "$APPLICATION" --operation --timeout 60
+}
 
 rollback() {
-	status=$?
-	trap - EXIT INT TERM
-	if [ "$status" -ne 0 ] && [ "$mutated" = true ]; then
+	status=$1
+	trap - EXIT
+	trap '' INT TERM
+
+	if [ "$mutated" = true ]; then
 		echo "Staging promotion failed; restoring previous Argo CD parameters" >&2
-		restore_parameter image.tag "$previous_image_tag" || true
-		restore_parameter operator.utils.tag "$previous_utils_tag" || true
-		argocd_cli app sync "$APPLICATION" --timeout 600 || true
-		argocd_cli app wait "$APPLICATION" --operation --sync --health --timeout 600 || true
+		if wait_for_operation; then
+			patch=$(jq -cn --argjson parameters "$previous_parameters" \
+				'{spec:{source:{helm:{parameters:$parameters}}}}')
+			if argocd_cli app patch "$APPLICATION" --type merge --patch "$patch"; then
+				argocd_cli app sync "$APPLICATION" --timeout 600 || true
+				argocd_cli app wait "$APPLICATION" --operation --sync --health --timeout 600 || true
+			else
+				echo "Unable to restore the previous Argo CD parameters" >&2
+			fi
+		else
+			echo "Unable to stop the active Argo CD operation; parameters were not changed during rollback" >&2
+		fi
 	fi
+
 	exit "$status"
 }
 
-trap rollback EXIT INT TERM
+trap 'rollback $?' EXIT
+trap 'rollback 130' INT
+trap 'rollback 143' TERM
 
 # Never mutate parameters while another sync can still consume them.
 argocd_cli app wait "$APPLICATION" --operation --timeout 600
 
-previous_image_tag=$(parameter_value image.tag)
-previous_utils_tag=$(parameter_value operator.utils.tag)
+baseline=$(argocd_cli app get "$APPLICATION" --output json)
+previous_parameters=$(printf '%s\n' "$baseline" | jq -c '.spec.source.helm.parameters // []')
 
 argocd_cli app set "$APPLICATION" \
 	--parameter "image.tag=$TAG" \
@@ -61,7 +67,7 @@ argocd_cli app sync "$APPLICATION" --timeout 600
 argocd_cli app wait "$APPLICATION" --operation --sync --health --timeout 600
 
 application=$(argocd_cli app get "$APPLICATION" --refresh --output json)
-echo "$application" | jq -e --arg tag "$TAG" '
+printf '%s\n' "$application" | jq -e --arg tag "$TAG" '
   (.spec.source.helm.parameters // [] | any(.name == "image.tag" and .value == $tag)) and
   (.spec.source.helm.parameters // [] | any(.name == "operator.utils.tag" and .value == $tag)) and
   (.status.sync.status == "Synced") and

--- a/scripts/deploy-staging.sh
+++ b/scripts/deploy-staging.sh
@@ -58,10 +58,10 @@ argocd_cli app wait "$APPLICATION" --operation --timeout 600
 baseline=$(argocd_cli app get "$APPLICATION" --output json)
 previous_parameters=$(printf '%s\n' "$baseline" | jq -c '.spec.source.helm.parameters // []')
 
+mutated=true
 argocd_cli app set "$APPLICATION" \
 	--parameter "image.tag=$TAG" \
 	--parameter "operator.utils.tag=$TAG"
-mutated=true
 
 argocd_cli app sync "$APPLICATION" --timeout 600
 argocd_cli app wait "$APPLICATION" --operation --sync --health --timeout 600

--- a/scripts/deploy-staging_test.sh
+++ b/scripts/deploy-staging_test.sh
@@ -1,0 +1,80 @@
+#!/bin/sh
+
+set -eu
+
+script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+subject="$script_dir/deploy-staging.sh"
+test_dir=$(mktemp -d)
+trap 'rm -rf "$test_dir"' EXIT INT TERM
+
+cat >"$test_dir/argocd" <<'EOF'
+#!/bin/sh
+set -eu
+
+while [ "$#" -gt 0 ]; do
+	case "$1" in
+		--auth-token | --server)
+			shift 2
+			;;
+		--auth-token=* | --server=* | --grpc-web)
+			shift
+			;;
+		*)
+			break
+			;;
+	esac
+done
+
+printf '%s\n' "$*" >>"$FAKE_ARGOCD_LOG"
+
+case "$1 $2" in
+	"app get")
+		tag=$(cat "$FAKE_ARGOCD_STATE")
+		printf '{"spec":{"source":{"helm":{"parameters":[{"name":"image.tag","value":"%s"},{"name":"operator.utils.tag","value":"%s"}]}}},"status":{"sync":{"status":"Synced"},"health":{"status":"Healthy"},"summary":{"images":["ghcr.io/formancehq/operator:%s"]}}}\n' "$tag" "$tag" "$tag"
+		;;
+	"app set")
+		for argument in "$@"; do
+			case "$argument" in
+				image.tag=*) printf '%s' "${argument#image.tag=}" >"$FAKE_ARGOCD_STATE" ;;
+			esac
+		done
+		;;
+	"app sync")
+		if [ -f "$FAKE_ARGOCD_FAIL_ONCE" ]; then
+			rm "$FAKE_ARGOCD_FAIL_ONCE"
+			exit 20
+		fi
+		;;
+esac
+EOF
+chmod +x "$test_dir/argocd"
+
+run_subject() {
+	PATH="$test_dir:$PATH" \
+		APPLICATION=staging-operator \
+		AUTH_TOKEN=test-token \
+		SERVER=argocd.example.test \
+		TAG=new-sha \
+		FAKE_ARGOCD_LOG="$test_dir/log" \
+		FAKE_ARGOCD_STATE="$test_dir/state" \
+		FAKE_ARGOCD_FAIL_ONCE="$test_dir/fail-once" \
+		sh "$subject"
+}
+
+printf 'old-sha' >"$test_dir/state"
+: >"$test_dir/log"
+run_subject
+test "$(cat "$test_dir/state")" = new-sha
+test "$(sed -n '1p' "$test_dir/log")" = "app wait staging-operator --operation --timeout 600"
+
+printf 'old-sha' >"$test_dir/state"
+: >"$test_dir/log"
+: >"$test_dir/fail-once"
+if run_subject; then
+	echo "expected failed synchronization" >&2
+	exit 1
+fi
+test "$(cat "$test_dir/state")" = old-sha
+grep -q 'app set staging-operator --parameter image.tag=old-sha' "$test_dir/log"
+
+echo "deploy-staging tests passed"

--- a/scripts/deploy-staging_test.sh
+++ b/scripts/deploy-staging_test.sh
@@ -27,23 +27,69 @@ done
 
 printf '%s\n' "$*" >>"$FAKE_ARGOCD_LOG"
 
+read_state() {
+	name=$1
+	if [ -f "$FAKE_ARGOCD_STATE.$name" ]; then
+		cat "$FAKE_ARGOCD_STATE.$name"
+	fi
+}
+
+write_state() {
+	name=$1
+	value=$2
+	if [ -n "$value" ]; then
+		printf '%s' "$value" >"$FAKE_ARGOCD_STATE.$name"
+	else
+		rm -f "$FAKE_ARGOCD_STATE.$name"
+	fi
+}
+
 case "$1 $2" in
 	"app get")
-		tag=$(cat "$FAKE_ARGOCD_STATE")
-		printf '{"spec":{"source":{"helm":{"parameters":[{"name":"image.tag","value":"%s"},{"name":"operator.utils.tag","value":"%s"}]}}},"status":{"sync":{"status":"Synced"},"health":{"status":"Healthy"},"summary":{"images":["ghcr.io/formancehq/operator:%s"]}}}\n' "$tag" "$tag" "$tag"
+		image=$(read_state image)
+		utils=$(read_state utils)
+		jq -cn --arg image "$image" --arg utils "$utils" '
+		  [
+		    (if $image == "" then empty else {name:"image.tag",value:$image} end),
+		    (if $utils == "" then empty else {name:"operator.utils.tag",value:$utils} end)
+		  ] as $parameters |
+		  {spec:{source:{helm:{parameters:$parameters}}},status:{sync:{status:"Synced"},health:{status:"Healthy"},summary:{images:["ghcr.io/formancehq/operator:" + $image]}}}
+		'
 		;;
 	"app set")
 		for argument in "$@"; do
 			case "$argument" in
-				image.tag=*) printf '%s' "${argument#image.tag=}" >"$FAKE_ARGOCD_STATE" ;;
+				image.tag=*) write_state image "${argument#image.tag=}" ;;
+				operator.utils.tag=*) write_state utils "${argument#operator.utils.tag=}" ;;
 			esac
 		done
+		;;
+	"app patch")
+		patch=""
+		while [ "$#" -gt 0 ]; do
+			if [ "$1" = --patch ]; then
+				patch=$2
+				break
+			fi
+			shift
+		done
+		write_state image "$(printf '%s' "$patch" | jq -r '.spec.source.helm.parameters[]? | select(.name == "image.tag") | .value')"
+		write_state utils "$(printf '%s' "$patch" | jq -r '.spec.source.helm.parameters[]? | select(.name == "operator.utils.tag") | .value')"
 		;;
 	"app sync")
 		if [ -f "$FAKE_ARGOCD_FAIL_ONCE" ]; then
 			rm "$FAKE_ARGOCD_FAIL_ONCE"
+			: >"$FAKE_ARGOCD_OPERATION"
 			exit 20
 		fi
+		;;
+	"app wait")
+		if [ -f "$FAKE_ARGOCD_OPERATION" ]; then
+			exit 1
+		fi
+		;;
+	"app terminate-op")
+		rm -f "$FAKE_ARGOCD_OPERATION"
 		;;
 esac
 EOF
@@ -58,23 +104,43 @@ run_subject() {
 		FAKE_ARGOCD_LOG="$test_dir/log" \
 		FAKE_ARGOCD_STATE="$test_dir/state" \
 		FAKE_ARGOCD_FAIL_ONCE="$test_dir/fail-once" \
+		FAKE_ARGOCD_OPERATION="$test_dir/operation" \
 		sh "$subject"
 }
 
-printf 'old-sha' >"$test_dir/state"
-: >"$test_dir/log"
+reset_test() {
+	rm -f "$test_dir"/state.* "$test_dir/fail-once" "$test_dir/operation"
+	: >"$test_dir/log"
+}
+
+reset_test
+printf 'old-image' >"$test_dir/state.image"
+printf 'old-utils' >"$test_dir/state.utils"
 run_subject
-test "$(cat "$test_dir/state")" = new-sha
+test "$(cat "$test_dir/state.image")" = new-sha
+test "$(cat "$test_dir/state.utils")" = new-sha
 test "$(sed -n '1p' "$test_dir/log")" = "app wait staging-operator --operation --timeout 600"
 
-printf 'old-sha' >"$test_dir/state"
-: >"$test_dir/log"
+reset_test
+printf 'old-image' >"$test_dir/state.image"
+printf 'old-utils' >"$test_dir/state.utils"
 : >"$test_dir/fail-once"
 if run_subject; then
 	echo "expected failed synchronization" >&2
 	exit 1
 fi
-test "$(cat "$test_dir/state")" = old-sha
-grep -q 'app set staging-operator --parameter image.tag=old-sha' "$test_dir/log"
+test "$(cat "$test_dir/state.image")" = old-image
+test "$(cat "$test_dir/state.utils")" = old-utils
+grep -q 'app terminate-op staging-operator' "$test_dir/log"
+grep -q 'app patch staging-operator --type merge --patch' "$test_dir/log"
+
+reset_test
+: >"$test_dir/fail-once"
+if run_subject; then
+	echo "expected failed synchronization with absent baseline parameters" >&2
+	exit 1
+fi
+test ! -e "$test_dir/state.image"
+test ! -e "$test_dir/state.utils"
 
 echo "deploy-staging tests passed"

--- a/scripts/deploy-staging_test.sh
+++ b/scripts/deploy-staging_test.sh
@@ -63,6 +63,10 @@ case "$1 $2" in
 				operator.utils.tag=*) write_state utils "${argument#operator.utils.tag=}" ;;
 			esac
 		done
+		if [ -f "$FAKE_ARGOCD_SIGNAL_ON_SET" ]; then
+			rm "$FAKE_ARGOCD_SIGNAL_ON_SET"
+			kill -TERM "$PPID"
+		fi
 		;;
 	"app patch")
 		patch=""
@@ -105,11 +109,12 @@ run_subject() {
 		FAKE_ARGOCD_STATE="$test_dir/state" \
 		FAKE_ARGOCD_FAIL_ONCE="$test_dir/fail-once" \
 		FAKE_ARGOCD_OPERATION="$test_dir/operation" \
+		FAKE_ARGOCD_SIGNAL_ON_SET="$test_dir/signal-on-set" \
 		sh "$subject"
 }
 
 reset_test() {
-	rm -f "$test_dir"/state.* "$test_dir/fail-once" "$test_dir/operation"
+	rm -f "$test_dir"/state.* "$test_dir/fail-once" "$test_dir/operation" "$test_dir/signal-on-set"
 	: >"$test_dir/log"
 }
 
@@ -142,5 +147,16 @@ if run_subject; then
 fi
 test ! -e "$test_dir/state.image"
 test ! -e "$test_dir/state.utils"
+
+reset_test
+printf 'old-image' >"$test_dir/state.image"
+printf 'old-utils' >"$test_dir/state.utils"
+: >"$test_dir/signal-on-set"
+if run_subject; then
+	echo "expected interrupted promotion" >&2
+	exit 1
+fi
+test "$(cat "$test_dir/state.image")" = old-image
+test "$(cat "$test_dir/state.utils")" = old-utils
 
 echo "deploy-staging tests passed"


### PR DESCRIPTION
## Summary

- queue `main` workflow runs instead of cancelling an in-flight staging promotion
- wait for any existing Argo CD operation before mutating image parameters
- roll back both image overrides when synchronization or verification fails
- verify the application is synced, healthy, and running the requested Operator tag
- cover successful promotion and rollback paths with a hermetic shell test

## Root cause

The staging deployment updated persistent Argo CD Helm parameters before starting the sync. If the sync failed or the workflow was cancelled, the parameter mutation survived and could later be applied independently. This left staging on `33bc2957` even though the chart metadata had advanced to `v3.13.1`.

## Validation

- `scripts/deploy-staging_test.sh`
- `nix --extra-experimental-features "nix-command flakes" develop --impure --command just pre-commit`
- `git diff --check`