### PR TITLE
fix(connectivity): dial ledger v3 gRPC by Service name, not TLS SNI

### DIFF
--- a/internal/resources/connectivities/init.go
+++ b/internal/resources/connectivities/init.go
@@ -232,7 +232,7 @@ func Reconcile(ctx Context, stack *v1beta1.Stack, connectivity *v1beta1.Connecti
 		setCondition(connectivity, metav1.ConditionFalse, "LedgerBackendResolveFailed", err.Error())
 		return err
 	}
-	ledgerAddress := fmt.Sprintf("%s:%d", backend.TLS.ServerName, backend.Port)
+	ledgerAddress := ledgerV3GRPCAddress(backend)
 
 	object := &unstructured.Unstructured{}
 	object.SetGroupVersionKind(connectivityGVK)
@@ -384,6 +384,13 @@ func ledgerGateClosed(ctx Context, stack *v1beta1.Stack) bool {
 // connectivityAPIBackendRef points the gateway at the connectivity-api Service
 // the connectivity operator provisions for the delegated Connectivity. It is
 // named "<delegated-name>-api", i.e. "connectivity-api".
+// ledgerV3GRPCAddress dials the backend Service name (resolves in-namespace on
+// any cluster DNS domain), not backend.TLS.ServerName — the SNI FQDN, which is
+// kept for TLS verification only. Mirrors the gateway upstream.
+func ledgerV3GRPCAddress(backend v1beta1.GatewayBackendRef) string {
+	return fmt.Sprintf("%s:%d", backend.Name, backend.Port)
+}
+
 func connectivityAPIBackendRef() v1beta1.GatewayBackendRef {
 	return v1beta1.GatewayBackendRef{
 		Name: connectivityDelegatedName + "-api",

--- a/internal/resources/connectivities/init_test.go
+++ b/internal/resources/connectivities/init_test.go
@@ -942,6 +942,19 @@ func TestConnectivityReconcilePendingWhenLedgerCredentialsAPIUnavailable(t *test
 	}
 }
 
+// ledgerAddress must dial the backend Service name (resolves in-namespace on any
+// cluster DNS domain), not the TLS SNI FQDN which may not resolve off cluster.local.
+func TestLedgerV3GRPCAddressUsesServiceNameNotSNI(t *testing.T) {
+	backend := v1beta1.GatewayBackendRef{
+		Name: "ledger-stack0",
+		Port: 8888,
+		TLS:  &v1beta1.GatewayBackendTLS{ServerName: "ledger-stack0.stack0.svc.cluster.local"},
+	}
+	if got := ledgerV3GRPCAddress(backend); got != "ledger-stack0:8888" {
+		t.Fatalf("ledgerV3GRPCAddress = %q, want the in-namespace Service name ledger-stack0:8888 (not the SNI FQDN)", got)
+	}
+}
+
 // The connectivity-api Service is named after the (now fixed) delegated
 // resource name, so the gateway backend must point at "connectivity-api".
 func TestConnectivityAPIBackendRef(t *testing.T) {


### PR DESCRIPTION
ledgerAddress was built from backend.TLS.ServerName, the SNI/certificate FQDN
(ledger-<stack>.<stack>.svc.cluster.local). On clusters whose DNS domain is not
cluster.local that FQDN need not resolve, so connectivity-core could not reach
the ledger. Build the dial address from backend.Name — the Service name, which
resolves in the stack namespace on any DNS domain — and keep TLS.ServerName as
the SNI on spec.ledgerTLS for certificate verification, mirroring how the gateway
upstream dials its backend.

Addresses NumaryBot finding 52f0f4a930fa3d33.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>